### PR TITLE
TUI port conflict user experience fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to RunWisp will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Port conflict on daemon startup now surfaces a clear, actionable error message instead of silently timing out. If the configured port is held by a non-RunWisp process, RunWisp will tell you exactly what's blocking it and how to resolve it (stop the other process, pick a different port, or identify it with `ss`/`lsof`). ([#portcheck](apps/runwisp/cmd/runwisp/portcheck.go))
+- Daemon startup failure log tail is now always printed on every failure path (fatal log line, process exit, or health check timeout), not only on timeout. Previously a fatal log line would abort startup but produce no log output.
+- Error messages for daemon process exit during startup now include `"during startup"` to distinguish them from runtime exits.
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Initial public release of RunWisp — open-source cron replacement and process supervisor.
+- Single binary daemon with embedded SQLite, REST API, and SSE log streaming.
+- Embedded Svelte 5 web dashboard served directly by the daemon.
+- CLI commands: `run`, `trigger`, `status`, `list`, `add`, `edit`, `validate`, `tui`, `daemon`, `cloud`, `openapi`.
+- Bubbletea terminal UI (`tui` command) with home view, exec list, log pane, and dialogs.
+- Task scheduler with concurrency, restart, missed-run, and retention policies.
+- CHAP authentication for the HTTP API.
+- Deterministic human-readable instance fingerprint based on machine-id and working directory.
+
+[Unreleased]: https://github.com/runwisp/runwisp/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/runwisp/runwisp/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/runwisp/cmd/runwisp/cmd_default.go
+++ b/apps/runwisp/cmd/runwisp/cmd_default.go
@@ -46,6 +46,14 @@ func runDefault() error {
 		return err
 	}
 
+	// Health check failed. Before paying the cost of spawning a background
+	// daemon (which would then silently fail to bind), probe the port
+	// ourselves. If something is holding it but it is not a RunWisp daemon
+	// we can surface a clear, actionable error immediately.
+	if bindErr := probePortAvailable(flags.Host, flags.Port); bindErr != nil {
+		return portConflictError(flags.Host, flags.Port, bindErr)
+	}
+
 	if err := spawnDaemon(); err != nil {
 		log.Warn("Failed to spawn background daemon, running inline", "err", err)
 		return runDaemon(modeStandalone)

--- a/apps/runwisp/cmd/runwisp/daemon_spawn.go
+++ b/apps/runwisp/cmd/runwisp/daemon_spawn.go
@@ -122,7 +122,8 @@ func waitForProcessExit(pid int, timeout time.Duration) error {
 
 // waitForDaemon streams the daemon log file in real-time while polling the
 // health endpoint. It returns immediately on success, aborts early on fatal
-// log lines or process exit, and falls back to a static log dump on timeout.
+// log lines or process exit, and always dumps a log tail when startup fails
+// so the user can see why — regardless of which detection path tripped first.
 func waitForDaemon(client *apiclient.Client, logPath string, timeout time.Duration) error {
 	fmt.Fprintf(os.Stderr, "Starting daemon...\n")
 
@@ -172,10 +173,8 @@ func waitForDaemon(client *apiclient.Client, logPath string, timeout time.Durati
 				line = strings.TrimRight(line, "\n\r")
 				fmt.Fprintf(os.Stderr, "  %s\n", line)
 
-				if strings.Contains(line, "FATA") || strings.Contains(line, "Fatal error") {
-					done <- result{
-						err: fmt.Errorf("daemon failed to start: %s", line),
-					}
+				if msg, fatal := classifyDaemonLogLine(line); fatal {
+					done <- result{err: fmt.Errorf("daemon failed to start: %s", msg)}
 					return
 				}
 			}
@@ -211,20 +210,22 @@ func waitForDaemon(client *apiclient.Client, logPath string, timeout time.Durati
 
 			pid, err := datadir.ReadPidFile(flags.DataDir)
 			if err != nil {
-				time.Sleep(200 * time.Millisecond)
-				done <- result{err: errors.New("daemon process exited unexpectedly")}
+				// Give the tailer a beat to flush any final log lines
+				// from the dying daemon before we report the exit.
+				time.Sleep(300 * time.Millisecond)
+				done <- result{err: errors.New("daemon process exited unexpectedly during startup")}
 				return
 			}
 
 			proc, err := os.FindProcess(pid)
 			if err != nil {
-				time.Sleep(200 * time.Millisecond)
+				time.Sleep(300 * time.Millisecond)
 				done <- result{err: fmt.Errorf("daemon process %d not found", pid)}
 				return
 			}
 			if err := proc.Signal(syscall.Signal(0)); err != nil {
-				time.Sleep(200 * time.Millisecond)
-				done <- result{err: fmt.Errorf("daemon process %d exited", pid)}
+				time.Sleep(300 * time.Millisecond)
+				done <- result{err: fmt.Errorf("daemon process %d exited during startup", pid)}
 				return
 			}
 		}
@@ -232,15 +233,61 @@ func waitForDaemon(client *apiclient.Client, logPath string, timeout time.Durati
 
 	defer close(stop)
 
+	var (
+		startupErr error
+		timedOut   bool
+	)
 	select {
 	case r := <-done:
-		return r.err
-	case <-time.After(timeout):
-		if logTail := tailFile(logPath, 4096); logTail != "" {
-			fmt.Fprintf(os.Stderr, "\n--- daemon log (%s) ---\n%s\n---\n\n", logPath, strings.TrimSpace(logTail))
+		if r.err == nil {
+			return nil
 		}
-		return errors.New("daemon failed to start: health check timed out")
+		startupErr = r.err
+	case <-time.After(timeout):
+		timedOut = true
+		startupErr = errors.New("daemon failed to start: health check timed out")
 	}
+
+	// On any failure path, surface the daemon log so the user can see the
+	// underlying cause. Also promote a recognised bind error to a clearer
+	// message — this is the most common cause of a silent startup failure.
+	logTail := tailFile(logPath, 4096)
+	if hint := bindFailureHint(logTail, flags.Host, flags.Port); hint != "" {
+		return errors.New(hint)
+	}
+	if logTail != "" {
+		fmt.Fprintf(os.Stderr, "\n--- daemon log (%s) ---\n%s\n---\n\n", logPath, strings.TrimSpace(logTail))
+	} else if timedOut {
+		fmt.Fprintf(os.Stderr, "(daemon log at %s is empty)\n", logPath)
+	}
+	return startupErr
+}
+
+// classifyDaemonLogLine returns a trimmed message and fatal=true when the
+// given daemon log line indicates an unrecoverable startup failure.
+func classifyDaemonLogLine(line string) (string, bool) {
+	switch {
+	case strings.Contains(line, "FATA"),
+		strings.Contains(line, "Fatal error"),
+		strings.Contains(line, "Server failed"),
+		strings.Contains(line, "address already in use"),
+		strings.Contains(line, "bind: permission denied"):
+		return line, true
+	}
+	return "", false
+}
+
+// bindFailureHint inspects a daemon log tail for signs that the server could
+// not bind its port and returns a ready-to-display error message. Returns ""
+// when no bind failure is detected.
+func bindFailureHint(logTail string, host string, port int) string {
+	if logTail == "" {
+		return ""
+	}
+	if !strings.Contains(logTail, "address already in use") {
+		return ""
+	}
+	return portConflictError(host, port, errors.New("bind: address already in use")).Error()
 }
 
 // tailFile reads the last maxBytes bytes from a file.

--- a/apps/runwisp/cmd/runwisp/portcheck.go
+++ b/apps/runwisp/cmd/runwisp/portcheck.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+// probePortAvailable reports whether we can bind to host:port right now.
+// Returns nil if the port is free, or the bind error (typically EADDRINUSE).
+// The listener is closed immediately on success.
+func probePortAvailable(host string, port int) error {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		return err
+	}
+	return ln.Close()
+}
+
+// portConflictError builds the user-facing message shown when something
+// other than a RunWisp daemon is holding the configured port.
+func portConflictError(host string, port int, cause error) error {
+	displayHost := host
+	if displayHost == "" {
+		displayHost = "127.0.0.1"
+	}
+	return fmt.Errorf(
+		"port %d on %s is already in use by another process (%v)\n\n"+
+			"RunWisp could not start because something else is already listening on this port.\n"+
+			"The process there did not respond to the RunWisp health check, so it does not appear to be a RunWisp daemon.\n\n"+
+			"To resolve this you can:\n"+
+			"  - Stop the other process and try again\n"+
+			"  - Run RunWisp on a different port:  runwisp --port <PORT>\n"+
+			"  - Identify the culprit with:        ss -ltnp 'sport = :%d'   (or 'lsof -iTCP:%d -sTCP:LISTEN')",
+		port, displayHost, cause, port, port,
+	)
+}


### PR DESCRIPTION
### Added
- Changelog

### Fixed
- Port conflict on daemon startup now surfaces a clear, actionable error message instead of silently timing out. If the configured port is held by a non-RunWisp process, RunWisp will tell you exactly what's blocking it and how to resolve it (stop the other process, pick a different port, or identify it with `ss`/`lsof`). ([#portcheck](apps/runwisp/cmd/runwisp/portcheck.go))
- Daemon startup failure log tail is now always printed on every failure path (fatal log line, process exit, or health check timeout), not only on timeout. Previously a fatal log line would abort startup but produce no log output.
- Error messages for daemon process exit during startup now include `"during startup"` to distinguish them from runtime exits.