### PR TITLE
Ticket length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fullscreen log streaming in the TUI.** Press `f` while viewing a task's logs to expand to fullscreen — the terminal cursor works normally (no hijacking), line numbers disappear, and you can select and copy text directly with your mouse. Press `f` or `esc` to return to the normal view.
 
+### Improved
+
+- **Launch tickets are shorter without losing security.** One-time launch-ticket URLs now use 43 base62 characters instead of 64 hex characters, keeping the same ~256 bits of entropy while producing a noticeably shorter URL.
+
 ### Fixed
 
 - **TUI sidebar navigation while viewing a run.** When an execution detail was open, pressing `←` to focus the sidebar and then `Enter` on a sidebar item (like "Home") could either snap back to the previous task detail or do nothing at all. Sidebar keyboard navigation now consistently takes you to the selected view.

--- a/apps/runwisp/internal/datadir/datadir.go
+++ b/apps/runwisp/internal/datadir/datadir.go
@@ -29,19 +29,25 @@ func GenerateJWTSecret() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(key), nil
 }
 
-// GeneratePassword returns a cryptographically random base62 password (128+ bits of entropy).
-func GeneratePassword() (string, error) {
+// RandBase62 returns a cryptographically random base62 string of n characters.
+// Each character contributes ~5.954 bits of entropy.
+func RandBase62(n int) (string, error) {
 	const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	max := big.NewInt(int64(len(alphabet)))
-	b := make([]byte, 22)
+	b := make([]byte, n)
 	for i := range b {
-		n, err := rand.Int(rand.Reader, max)
+		v, err := rand.Int(rand.Reader, max)
 		if err != nil {
-			return "", fmt.Errorf("failed to generate random password: %w", err)
+			return "", fmt.Errorf("failed to generate random base62 string: %w", err)
 		}
-		b[i] = alphabet[n.Int64()]
+		b[i] = alphabet[v.Int64()]
 	}
 	return string(b), nil
+}
+
+// GeneratePassword returns a cryptographically random base62 password (128+ bits of entropy).
+func GeneratePassword() (string, error) {
+	return RandBase62(22)
 }
 
 // ResolvePassword reads or generates the daemon password.

--- a/apps/runwisp/internal/server/auth_service.go
+++ b/apps/runwisp/internal/server/auth_service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/runwisp/runwisp/internal/datadir"
 	"log/slog"
 )
 
@@ -75,11 +76,12 @@ func newLaunchTicketStore() *launchTicketStore {
 }
 
 func (s *launchTicketStore) create() (string, error) {
-	buf := make([]byte, 32)
-	if _, err := rand.Read(buf); err != nil {
+	// 43 base62 chars ≈ 256 bits of entropy (matches the prior 32-byte hex ticket)
+	// while shrinking the URL-visible token from 64 to 43 characters.
+	ticket, err := datadir.RandBase62(43)
+	if err != nil {
 		return "", err
 	}
-	ticket := hex.EncodeToString(buf)
 	s.entries.Add(ticket, time.Now().Add(launchTicketTTL))
 	return ticket, nil
 }

--- a/apps/runwisp/internal/server/auth_service_test.go
+++ b/apps/runwisp/internal/server/auth_service_test.go
@@ -243,7 +243,7 @@ func TestLaunchTicketStore_CreateAndConsume(t *testing.T) {
 
 	ticket, err := store.create()
 	require.NoError(t, err)
-	assert.Len(t, ticket, 64) // 32 bytes hex-encoded
+	assert.Len(t, ticket, 43) // 43 base62 chars ≈ 256 bits of entropy
 
 	assert.True(t, store.consume(ticket))
 	// Single-use: second consume fails.
@@ -260,7 +260,7 @@ func TestAuthService_CreateLaunchTicket(t *testing.T) {
 
 	ticket, err := auth.CreateLaunchTicket()
 	require.NoError(t, err)
-	assert.Len(t, ticket, 64)
+	assert.Len(t, ticket, 43)
 
 	// Ticket should be consumable through the internal store.
 	assert.True(t, auth.launchTickets.consume(ticket))


### PR DESCRIPTION
**Launch tickets are shorter without losing security.** One-time launch-ticket URLs now use 43 base62 characters instead of 64 hex characters, keeping the same ~256 bits of entropy while producing a noticeably shorter URL.