### PR TITLE
notifications facelift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,14 +128,7 @@ The daemon can optionally connect outbound to a control-plane peer that speaks t
 
 ## 🤖 AGENT EXECUTION RULES
 
-1. **Validation commands** (run from repo root via `make …` or the equivalent `bun run …` alias):
-   - `make build` — builds the daemon (Makefile orchestrates web UI build → embed → go build).
-   - `make test` — `make test` across the workspace (per-package `go test` / `vitest`). Excludes Playwright; use `make test-e2e` after a real build for browser tests.
-   - `make check` — Go vet/lint via `scripts/check-go.sh` plus TS/Svelte checks. Slow lint (svelte-check, eslint) is cached at root `.cache/*.stamp`; `make clean` or branch switches invalidate.
-   - `make generate` — regenerates AsyncAPI Go types, common API types, and `apps/runwisp/openapi.json`. Run after editing `packages/asyncapi/asyncapi.yaml` *before* committing — downstream Go types must compile.
-    - **Before finalizing Go changes**: `make build && make test`.
-    - **Before finalizing TS/Svelte changes**: `make check && make test`.
-    - **After finalizing changes (or before wrapping up a session)**: `make ci`. This runs generate → format → check → test → test-e2e, the full CI pipeline.
+1. **Validation**: `make ci` is the **only** validation command you must run — it chains generate → format → check → test → test-e2e (build is covered via `test-e2e`'s binary dependency). Run it from repo root before wrapping up any session that touched code. Don't bother with `make build` / `make test` / `make check` / `make generate` individually unless you're iterating on a single stage — `make ci` supersedes them.
 2. **TOML schema changes require**: docs (`apps/docs/src/content/docs/configuration/`), OpenAPI (`apps/runwisp/openapi.json` via `bun run generate`), `CHANGELOG.md`, and the README config reference if user-visible.
 3. **AsyncAPI changes**: edit `packages/asyncapi/asyncapi.yaml` first, then `bun run generate`, then consume the regenerated types in `internal/generated/protocol/`. Never the other way round.
 4. **User-facing changes** require a `CHANGELOG.md` entry. The changelog is marketing-facing — tell users what they can do, not how it was implemented. Concise but informative.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`[daemon] external_url` for notification deep-links.** Set `external_url = "https://your-host.example.com"` (or the LAN address you actually reach the dashboard on) and Slack / Telegram messages now include a direct link to the run inside the embedded Web UI. Leaving it unset omits the link line entirely — no broken URLs.
+
 ### Changed
 
+- **Telegram and Slack notifications got a major facelift.** Same data, human shape: a one-line headline with an emoji and a verb, a sentence describing what happened (exit code + duration for failures, elapsed for timeouts, etc.), the trigger and timestamp on the next line, the **last 3 lines of captured output** for `run.failed` / `run.timeout` (capped at 300 bytes), a deep-link to the run in the dashboard when [`[daemon] external_url`](https://docs.runwisp.com/configuration/daemon/#external_url) is set, and a small italic footer identifying the daemon by its fingerprint. The previous flat single-paragraph form is gone.
 - **OpenAPI now exposes `EndReason` as a named schema.** The set of end-reason values (`success`, `failed`, `timeout`, …) is now a single `components/schemas/EndReason` enum referenced from every place a run's `end_reason` appears, instead of an inline enum repeated at each call site. Generated clients pick this up as one shared type/constant — no behavior or wire-format change.
 - **System resources panel shows live memory bytes inline.** The Memory sparkline header now displays `used / total` (e.g. `1.2 GB / 8.0 GB`) next to the percentage, replacing the separate Cores / RAM / Samples grid and the footer clock line that previously sat below the sparklines.
 

--- a/apps/docs/src/content/docs/configuration/daemon.mdx
+++ b/apps/docs/src/content/docs/configuration/daemon.mdx
@@ -22,11 +22,13 @@ think of them together.
 ```toml
 [daemon]
 shutdown_timeout = "10s"
+external_url     = "https://runwisp.example.com"
 ```
 
-| Key                | Default | What it does                                                                                                                                                   |
-| ------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `shutdown_timeout` | `"10s"` | Whole-daemon shutdown budget. After `SIGTERM`, the daemon SIGKILLs any in-flight runs that haven't exited within this window so the process can actually exit. |
+| Key                | Default | What it does                                                                                                                                                          |
+| ------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shutdown_timeout` | `"10s"` | Whole-daemon shutdown budget. After `SIGTERM`, the daemon SIGKILLs any in-flight runs that haven't exited within this window so the process can actually exit.        |
+| `external_url`     | _unset_ | Public base URL of this daemon's Web UI. When set, notification messages (Slack, Telegram) include a deep-link back to the run; when unset, the link line is omitted. |
 
 ### `shutdown_timeout`
 
@@ -39,6 +41,24 @@ will SIGKILL the survivor before its per-task grace window completes.
 Either raise `shutdown_timeout`, lower the per-task `graceful_stop`, or
 accept that the task's cleanup hook may be interrupted on daemon
 shutdown.
+
+### `external_url`
+
+`external_url` is the **public** base URL at which an operator (or a
+notification recipient) reaches this daemon's Web UI — e.g.
+`https://runwisp.example.com` behind a reverse proxy, or
+`http://192.168.1.50:9477` on a LAN. Trailing slashes are stripped; the
+scheme must be `http` or `https`.
+
+The daemon never opens an outbound connection to this URL. Its only
+purpose is rendering: when a Slack or Telegram notification fires, the
+template appends a "View run" link of the form
+`<external_url>/tasks/<task>?runId=<id>` that drops the operator directly
+into the run-detail panel of the embedded dashboard.
+
+Leaving `external_url` unset is the supported default. Notifications
+still render fully — they just omit the link line rather than emitting
+a broken URL.
 
 ## CLI flags: data directory & listen address
 

--- a/apps/docs/src/content/docs/notifications/providers/slack.mdx
+++ b/apps/docs/src/content/docs/notifications/providers/slack.mdx
@@ -11,7 +11,7 @@ The Slack driver posts via Slack's [Incoming Webhooks][iw]. One
 webhook URL maps to one default channel. An optional `channel`
 override lets a single webhook target several destinations.
 
-[iw]: https://api.slack.com/messaging/webhooks
+[iw]: https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/
 
 ## Fields
 
@@ -170,44 +170,33 @@ row in the Web UI's bell. If only the bell shows a row, Slack
 delivery failed — open the bell and look for a
 `notify.delivery_failed` event with the underlying reason.
 
+## What a message looks like
+
+The default Slack template renders one message per event as Block Kit
+JSON — a header block with the task name and verb, a section with the
+event sentence and trigger, a code-block tail (failures and timeouts
+only), an action button linking to the run (when
+[`[daemon] external_url`](/configuration/daemon/#external_url) is set),
+and a context footer with the daemon's fingerprint. The same shape is
+used for every event kind — only the emoji, verb, and sentence change.
+
+Without `external_url` the action-button block is omitted; without a
+log file the code-block tail is omitted. Both omissions are silent.
+
+The helpers `statusEmoji`, `statusVerb`, `humanTime`, `humanDuration`,
+`runDuration`, `triggerPhrase`, `eventSentence`, `eventTrigger`,
+`linkLabel`, `runURL`, `taskURL`, `outputTail`, and `fingerprint` are
+available to custom templates if you point `template_path` at a
+Go-template file of your own.
+
 ## Customising the message
 
 Point `template_path` at a Go-template file to override the embedded
-message format. The default template is JSON for Slack's Block Kit:
-
-```json
-{
-  "blocks": [
-    {
-      "type": "header",
-      "text": {
-        "type": "plain_text",
-        "text": "{{ emoji .Severity }} {{ .TaskName }} — {{ .Kind }}"
-      }
-    },
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "*Reason:* {{ jsonStr .Reason }}\n*Severity:* `{{ .Severity }}`"
-      }
-    }{{- if .Run }},
-    {
-      "type": "context",
-      "elements": [
-        {
-          "type": "mrkdwn",
-          "text": "Run `{{ .Run.ID }}` triggered by `{{ .Run.TriggeredBy }}` at {{ timeRFC .Timestamp }}"
-        }
-      ]
-    }{{- end }}
-  ]
-}
-```
-
-Copy this as your starting point and modify what you need. The
-template receives the full event struct — task name, run id, exit
-code, end reason, captured tail.
+message format. Copy
+[`slack.tmpl.json`](https://github.com/runwisp/runwisp/blob/main/apps/runwisp/internal/notify/render/defaults/slack.tmpl.json)
+as your starting point — it has the full per-kind sentence table and
+the Block Kit JSON shape. The template receives the full event struct:
+task name, run id, exit code, end reason, timestamp, captured tail.
 
 ## What the loader rejects
 

--- a/apps/docs/src/content/docs/notifications/providers/telegram.mdx
+++ b/apps/docs/src/content/docs/notifications/providers/telegram.mdx
@@ -177,6 +177,46 @@ Telegram messages usually arrive in 1–2 seconds. If yours doesn't:
   `curl https://api.telegram.org/bot<TOKEN>/getMe` — returns the
   bot's profile if the token is valid.
 
+## What a message looks like
+
+The default Telegram template renders one message per event in a single
+shape — only the emoji, headline verb, and sentence change between
+kinds. A failure looks like:
+
+```
+❌ backup-postgres failed
+
+Exited with code 1 after 0.3s.
+Manually triggered via API · 14 May, 17:11.
+
+> Error: connection refused
+> dial tcp 127.0.0.1:5432: connect:
+> connection refused
+
+🔗 View full run
+
+from runwisp · bright-falcon
+```
+
+- The **captured-output tail** (the `<blockquote>` block) appears on
+  `run.failed` and `run.timeout` only, capped at three lines / 300
+  bytes. A missing log file collapses the block silently.
+- The **View run** link points at
+  `<external_url>/tasks/<task>?runId=<id>`, taking from
+  [`[daemon] external_url`](/configuration/daemon/#external_url). When
+  `external_url` is unset the link line is omitted — no broken anchors.
+- The **fingerprint footer** (`from runwisp · bright-falcon`) names the
+  specific daemon that emitted the event. Single-daemon operators can
+  ignore it; multi-daemon operators finally know which box screamed.
+
+`template_path` overrides the embedded template if you need a different
+layout. Copy
+[`telegram.tmpl.html`](https://github.com/runwisp/runwisp/blob/main/apps/runwisp/internal/notify/render/defaults/telegram.tmpl.html)
+as your starting point. The helpers `statusEmoji`, `statusVerb`,
+`humanTime`, `humanDuration`, `runDuration`, `triggerPhrase`,
+`eventSentence`, `eventTrigger`, `linkLabel`, `runURL`, `taskURL`,
+`outputTail`, and `fingerprint` are available inside it.
+
 ## What the loader rejects
 
 - Two of `bot_token`, `bot_token_env`, `bot_token_file` set at the

--- a/apps/runwisp/cmd/runwisp/daemon_notify.go
+++ b/apps/runwisp/cmd/runwisp/daemon_notify.go
@@ -43,7 +43,12 @@ func initNotify(
 		return notifyBundle{}, nil
 	}
 
-	resolved, err := configload.Resolve(notifyCfg, flags.DataDir)
+	renderCtx := render.TemplateContext{
+		ExternalURL: cfg.Config.Daemon.ExternalURL,
+		Fingerprint: cfg.Fingerprint,
+		OutputTail:  render.NewOutputTail(),
+	}
+	resolved, err := configload.Resolve(notifyCfg, flags.DataDir, renderCtx)
 	if err != nil {
 		return notifyBundle{}, fmt.Errorf("resolve notify config: %w", err)
 	}

--- a/apps/runwisp/internal/config/config_test.go
+++ b/apps/runwisp/internal/config/config_test.go
@@ -818,6 +818,42 @@ run = "echo hi"
 		assert.Equal(t, 20*time.Second, cfg.Daemon.ShutdownTimeout)
 	})
 
+	t.Run("daemon external_url parses and strips trailing slash", func(t *testing.T) {
+		path := writeTOML(t, `
+[daemon]
+external_url = "https://runwisp.example.com/"
+
+[tasks.t]
+run = "echo hi"
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+		assert.Equal(t, "https://runwisp.example.com", cfg.Daemon.ExternalURL)
+	})
+
+	t.Run("daemon external_url rejects non-http schemes", func(t *testing.T) {
+		path := writeTOML(t, `
+[daemon]
+external_url = "ftp://nope"
+
+[tasks.t]
+run = "echo hi"
+`)
+		_, err := Load(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "daemon.external_url")
+	})
+
+	t.Run("daemon external_url omitted is empty", func(t *testing.T) {
+		path := writeTOML(t, `
+[tasks.t]
+run = "echo hi"
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+		assert.Equal(t, "", cfg.Daemon.ExternalURL)
+	})
+
 	t.Run("legacy parallelism key is rejected with a migration hint", func(t *testing.T) {
 		path := writeTOML(t, `
 [tasks.t]

--- a/apps/runwisp/internal/config/parse.go
+++ b/apps/runwisp/internal/config/parse.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -84,6 +85,29 @@ func parseScopedByteSize(scope, raw string) (int64, error) {
 		return 0, fmt.Errorf("invalid %s: %w", scope, err)
 	}
 	return n, nil
+}
+
+// parseExternalURL normalises [daemon] external_url: trims surrounding
+// whitespace and trailing slashes, and rejects anything that doesn't parse
+// as an absolute http(s) URL. Empty is the supported default — no link line
+// is rendered in notifications when unset.
+func parseExternalURL(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil
+	}
+	trimmed = strings.TrimRight(trimmed, "/")
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid daemon.external_url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid daemon.external_url: must start with http:// or https://")
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid daemon.external_url: missing host")
+	}
+	return trimmed, nil
 }
 
 // reservedKeyword reports whether the given string is one of the legacy

--- a/apps/runwisp/internal/config/schema.go
+++ b/apps/runwisp/internal/config/schema.go
@@ -99,9 +99,15 @@ type NotificationRoute struct {
 // ShutdownTimeout caps how long the daemon waits for in-flight tasks to drain
 // after SIGTERM before forcing exit. The default matches Docker's 10-second
 // stop-grace so a containerised daemon never leaves orphans.
+//
+// ExternalURL is the operator-supplied public base URL of the embedded Web UI
+// (e.g. "https://runwisp.example.com"). When set, notification renderers
+// build deep-links into the dashboard; when empty, link lines are omitted
+// from outbound messages rather than rendered as broken URLs.
 type Daemon struct {
 	AllowCloudDispatch bool          `toml:"-"`
 	ShutdownTimeout    time.Duration `toml:"-"`
+	ExternalURL        string        `toml:"-"`
 }
 
 // Defaults provides fallback values applied to every task.
@@ -241,6 +247,7 @@ type tomlConfig struct {
 type daemonWire struct {
 	AllowCloudDispatch bool   `toml:"allow_cloud_dispatch,omitempty"`
 	ShutdownTimeout    string `toml:"shutdown_timeout,omitempty"`
+	ExternalURL        string `toml:"external_url,omitempty"`
 }
 
 // schedulerWire mirrors [scheduler] before parsing.
@@ -442,9 +449,14 @@ func (w *daemonWire) toDaemon() (Daemon, error) {
 	if err != nil {
 		return Daemon{}, fmt.Errorf("invalid daemon.shutdown_timeout: %w", err)
 	}
+	externalURL, err := parseExternalURL(w.ExternalURL)
+	if err != nil {
+		return Daemon{}, err
+	}
 	return Daemon{
 		AllowCloudDispatch: w.AllowCloudDispatch,
 		ShutdownTimeout:    shutdown,
+		ExternalURL:        externalURL,
 	}, nil
 }
 

--- a/apps/runwisp/internal/notify/channel/factory.go
+++ b/apps/runwisp/internal/notify/channel/factory.go
@@ -31,6 +31,11 @@ type NotifierSpec struct {
 	// Transport overrides the channel's HTTP transport. Nil means use defaults.
 	// Daemon-level glue uses this to apply a global backoff override.
 	Transport *notify.HTTPProvider
+	// RenderContext binds per-daemon values (external URL, fingerprint, tail
+	// reader) into the template's func map. Zero values produce safe defaults:
+	// missing external URL collapses link blocks, missing fingerprint shortens
+	// the footer, missing tail reader collapses the output-tail blocks.
+	RenderContext render.TemplateContext
 }
 
 // Build turns a NotifierSpec into a notify.Channel. Inapp is built separately
@@ -42,7 +47,7 @@ func Build(spec NotifierSpec) (notify.Channel, error) {
 		if err != nil {
 			return nil, err
 		}
-		r, err := render.NewTemplateRenderer("slack:"+spec.ID, body, "application/json", render.DefaultTitle)
+		r, err := render.NewTemplateRendererWithContext("slack:"+spec.ID, body, "application/json", render.DefaultTitle, spec.RenderContext)
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +63,7 @@ func Build(spec NotifierSpec) (notify.Channel, error) {
 		if err != nil {
 			return nil, err
 		}
-		r, err := render.NewTemplateRenderer("telegram:"+spec.ID, body, "text/html", render.DefaultTitle)
+		r, err := render.NewTemplateRendererWithContext("telegram:"+spec.ID, body, "text/html", render.DefaultTitle, spec.RenderContext)
 		if err != nil {
 			return nil, err
 		}

--- a/apps/runwisp/internal/notify/channel/telegram/telegram_test.go
+++ b/apps/runwisp/internal/notify/channel/telegram/telegram_test.go
@@ -87,6 +87,30 @@ func TestTelegram_HonorsBodyRetryAfter(t *testing.T) {
 	assert.EqualValues(t, 2, hits.Load())
 }
 
+func TestTelegram_SendsRenderedBody(t *testing.T) {
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		seen = r.Form.Get("text")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ch, err := New(Config{
+		ID: "oncall", BotToken: "abc:xyz", ChatID: "-1001",
+		Renderer: newTestRenderer(t), APIBase: srv.URL,
+		Transport: newFastTransport(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ch.Execute(context.Background(), &notify.Event{
+		Kind: notify.KindRunFailed, Severity: notify.SevError,
+		TaskName: "backup-db", Reason: "exit 1",
+		Timestamp: time.Now().UTC(),
+	}))
+	assert.Contains(t, seen, "<b>backup-db</b> failed", "rendered body should carry the headline")
+	assert.Contains(t, seen, "<i>from runwisp</i>", "footer is always present, fingerprint omitted when blank")
+}
+
 func TestTelegram_RedactsTokenInError(t *testing.T) {
 	ch, err := New(Config{
 		ID: "oncall", BotToken: "TOPSECRET:Z", ChatID: "-1001",

--- a/apps/runwisp/internal/notify/configload/configload.go
+++ b/apps/runwisp/internal/notify/configload/configload.go
@@ -16,6 +16,7 @@ import (
 	"github.com/runwisp/runwisp/internal/config"
 	"github.com/runwisp/runwisp/internal/notify"
 	"github.com/runwisp/runwisp/internal/notify/channel"
+	"github.com/runwisp/runwisp/internal/notify/render"
 )
 
 // ResolvedNotify carries everything the daemon needs to construct a
@@ -27,17 +28,20 @@ type ResolvedNotify struct {
 
 // Resolve takes the post-parse config and the daemon's data dir, reads any
 // file-backed secrets relative to the data dir, and produces a ready-to-use
-// ResolvedNotify. Returns an error when a secret source is missing or when
-// a route refers to an unknown notifier.
-func Resolve(cfg config.NotifyConfig, dataDir string) (ResolvedNotify, error) {
+// ResolvedNotify. The renderCtx carries per-daemon values (external URL,
+// fingerprint, output-tail reader) that bind into each channel's template
+// func map. Returns an error when a secret source is missing or when a
+// route refers to an unknown notifier.
+func Resolve(cfg config.NotifyConfig, dataDir string, renderCtx render.TemplateContext) (ResolvedNotify, error) {
 	specs := make([]channel.NotifierSpec, 0, len(cfg.Notifiers))
 	for _, n := range cfg.Notifiers {
 		spec := channel.NotifierSpec{
-			ID:           n.ID,
-			Type:         n.Type,
-			ParseMode:    n.ParseMode,
-			ChatID:       n.ChatID,
-			TemplatePath: n.TemplatePath,
+			ID:            n.ID,
+			Type:          n.Type,
+			ParseMode:     n.ParseMode,
+			ChatID:        n.ChatID,
+			TemplatePath:  n.TemplatePath,
+			RenderContext: renderCtx,
 		}
 		switch n.Type {
 		case "slack":

--- a/apps/runwisp/internal/notify/configload/configload_test.go
+++ b/apps/runwisp/internal/notify/configload/configload_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/runwisp/runwisp/internal/config"
 	"github.com/runwisp/runwisp/internal/notify"
+	"github.com/runwisp/runwisp/internal/notify/render"
 )
 
 func TestResolve_InlineSecretWins(t *testing.T) {
@@ -23,7 +24,7 @@ func TestResolve_InlineSecretWins(t *testing.T) {
 			WebhookURL: "https://hooks.slack.test/T/B/Z",
 		}},
 	}
-	got, err := Resolve(cfg, t.TempDir())
+	got, err := Resolve(cfg, t.TempDir(), render.TemplateContext{})
 	require.NoError(t, err)
 	require.Len(t, got.Notifiers, 1)
 	assert.Equal(t, "https://hooks.slack.test/T/B/Z", got.Notifiers[0].WebhookURL)
@@ -38,7 +39,7 @@ func TestResolve_EnvSecret(t *testing.T) {
 			WebhookURLEnv: "RUNWISP_TEST_SLACK_URL",
 		}},
 	}
-	got, err := Resolve(cfg, t.TempDir())
+	got, err := Resolve(cfg, t.TempDir(), render.TemplateContext{})
 	require.NoError(t, err)
 	require.Len(t, got.Notifiers, 1)
 	assert.Equal(t, "https://hooks.slack.test/from-env", got.Notifiers[0].WebhookURL)
@@ -54,7 +55,7 @@ func TestResolve_EnvSecretMissing(t *testing.T) {
 			WebhookURLEnv: "RUNWISP_TEST_MISSING_URL",
 		}},
 	}
-	_, err := Resolve(cfg, t.TempDir())
+	_, err := Resolve(cfg, t.TempDir(), render.TemplateContext{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "RUNWISP_TEST_MISSING_URL")
 	assert.Contains(t, err.Error(), `notifier "ops"`)
@@ -71,7 +72,7 @@ func TestResolve_FileSecretRelativeToDataDir(t *testing.T) {
 			WebhookURLFile: "slack.url",
 		}},
 	}
-	got, err := Resolve(cfg, dir)
+	got, err := Resolve(cfg, dir, render.TemplateContext{})
 	require.NoError(t, err)
 	require.Len(t, got.Notifiers, 1)
 	assert.Equal(t, "https://hooks.slack.test/from-file", got.Notifiers[0].WebhookURL)
@@ -90,7 +91,7 @@ func TestResolve_FileSecretAbsolutePath(t *testing.T) {
 			ChatID:       "-100123",
 		}},
 	}
-	got, err := Resolve(cfg, t.TempDir())
+	got, err := Resolve(cfg, t.TempDir(), render.TemplateContext{})
 	require.NoError(t, err)
 	require.Len(t, got.Notifiers, 1)
 	assert.Equal(t, "absolute-token", got.Notifiers[0].BotToken)
@@ -110,7 +111,7 @@ func TestResolve_CompiledRulePredicates(t *testing.T) {
 			NotifierID: []string{"ops"},
 		}},
 	}
-	got, err := Resolve(cfg, t.TempDir())
+	got, err := Resolve(cfg, t.TempDir(), render.TemplateContext{})
 	require.NoError(t, err)
 	require.Len(t, got.Rules, 1)
 	require.Equal(t, []string{"ops"}, got.Rules[0].ActionIDs)

--- a/apps/runwisp/internal/notify/render/defaults/slack.tmpl.json
+++ b/apps/runwisp/internal/notify/render/defaults/slack.tmpl.json
@@ -1,27 +1,52 @@
+{{- /* Slack notification — Block Kit. */ -}}
+{{- $tail := "" -}}{{- if or (eq .Kind "run.failed") (eq .Kind "run.timeout") -}}{{- $tail = outputTail .Run -}}{{- end -}}
+{{- $url := "" -}}{{- if eq .Kind "log.disk_pressure" -}}{{- $url = taskURL .TaskName -}}{{- else -}}{{- $url = runURL .Run -}}{{- end -}}
+{{- $footer := "from runwisp" -}}{{- with fingerprint -}}{{- $footer = printf "from runwisp · %s" . -}}{{- end -}}
 {
   "blocks": [
     {
       "type": "header",
       "text": {
         "type": "plain_text",
-        "text": "{{ emoji .Severity }} {{ .TaskName }} — {{ .Kind }}"
+        "text": "{{ jsonStr (printf "%s %s %s" (statusEmoji .Kind) .TaskName (statusVerb .Kind)) }}",
+        "emoji": true
       }
     },
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "*Reason:* {{ jsonStr .Reason }}\n*Severity:* `{{ .Severity }}`"
+        "text": "{{ jsonStr (printf "%s\n%s · %s." (eventSentence .) (eventTrigger .) (humanTime .Timestamp)) }}"
       }
-    }{{- if .Run }},
+    }{{ if $tail }},
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "{{ jsonStr (printf "```\n%s\n```" $tail) }}"
+      }
+    }{{ end }}{{ if $url }},
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "{{ jsonStr (linkLabel .Kind) }}"
+          },
+          "url": "{{ jsonStr $url }}"
+        }
+      ]
+    }{{ end }},
     {
       "type": "context",
       "elements": [
         {
           "type": "mrkdwn",
-          "text": "Run `{{ .Run.ID }}` triggered by `{{ .Run.TriggeredBy }}` at {{ timeRFC .Timestamp }}"
+          "text": "{{ jsonStr $footer }}"
         }
       ]
-    }{{- end }}
+    }
   ]
 }

--- a/apps/runwisp/internal/notify/render/defaults/telegram.tmpl.html
+++ b/apps/runwisp/internal/notify/render/defaults/telegram.tmpl.html
@@ -1,5 +1,17 @@
-<b>{{ tgEscape .TaskName }}</b> — <i>{{ tgEscape (printf "%s" .Kind) }}</i>
-{{ if .Reason }}<code>{{ tgEscape .Reason }}</code>{{ end }}
-{{- if .Run }}
-Run <code>{{ tgEscape .Run.ID }}</code> ({{ tgEscape (printf "%s" .Run.TriggeredBy) }}) at {{ timeRFC .Timestamp }}
+{{- /* Telegram notification — HTML parse mode. */ -}}
+{{ statusEmoji .Kind }} <b>{{ tgEscape .TaskName }}</b> {{ statusVerb .Kind }}
+
+{{ tgEscape (eventSentence .) }}
+{{ tgEscape (eventTrigger .) }} · {{ humanTime .Timestamp }}.
+{{- $tail := "" }}{{ if or (eq .Kind "run.failed") (eq .Kind "run.timeout") }}{{ $tail = outputTail .Run }}{{ end }}
+{{- if $tail }}
+
+<blockquote>{{ tgEscape $tail }}</blockquote>
 {{- end }}
+{{- $url := "" }}{{ if eq .Kind "log.disk_pressure" }}{{ $url = taskURL .TaskName }}{{ else }}{{ $url = runURL .Run }}{{ end }}
+{{- if $url }}
+
+🔗 <a href="{{ $url }}">{{ linkLabel .Kind }}</a>
+{{- end }}
+
+<i>from runwisp{{ with fingerprint }} · {{ tgEscape . }}{{ end }}</i>

--- a/apps/runwisp/internal/notify/render/render.go
+++ b/apps/runwisp/internal/notify/render/render.go
@@ -10,10 +10,12 @@ import (
 	"bytes"
 	"fmt"
 	"html"
+	"net/url"
 	"strings"
 	"text/template"
 	"time"
 
+	"github.com/runwisp/runwisp/internal/model"
 	"github.com/runwisp/runwisp/internal/notify"
 )
 
@@ -34,6 +36,21 @@ type Renderer interface {
 	Render(*notify.Event) (RenderedMessage, error)
 }
 
+// TemplateContext carries per-daemon values that need to bind into the
+// template's func map at construction time so individual channels don't
+// have to know about base URLs, fingerprints, or how to read log files.
+//
+// All fields are optional. Zero values produce safe defaults: empty
+// ExternalURL suppresses run-link rendering, empty Fingerprint omits the
+// footer token, nil Now falls back to time.Now, nil OutputTail returns the
+// empty string (the template branch that wraps it then collapses).
+type TemplateContext struct {
+	ExternalURL string
+	Fingerprint string
+	Now         func() time.Time
+	OutputTail  func(run *model.Run, maxLines, maxBytes int) string
+}
+
 // TemplateRenderer is the workhorse: a parsed text/template plus a content
 // type label. Most providers wrap one of these.
 type TemplateRenderer struct {
@@ -44,9 +61,18 @@ type TemplateRenderer struct {
 
 // NewTemplateRenderer parses src under name and returns a Renderer using the
 // shared FuncMap. titleFn produces the notification title (used by inapp and
-// surfaced as Telegram preview / Slack header in defaults).
+// surfaced as Telegram preview / Slack header in defaults). The in-app
+// renderer uses this form — it needs no external URL, fingerprint, or tail
+// reader.
 func NewTemplateRenderer(name, src, contentType string, titleFn func(*notify.Event) string) (*TemplateRenderer, error) {
-	t, err := template.New(name).Funcs(funcMap()).Parse(src)
+	return NewTemplateRendererWithContext(name, src, contentType, titleFn, TemplateContext{})
+}
+
+// NewTemplateRendererWithContext is like NewTemplateRenderer but binds the
+// given TemplateContext into the funcMap closures, exposing per-daemon
+// helpers (runURL, taskURL, outputTail, fingerprint) to the template.
+func NewTemplateRendererWithContext(name, src, contentType string, titleFn func(*notify.Event) string, ctx TemplateContext) (*TemplateRenderer, error) {
+	t, err := template.New(name).Funcs(funcMap(ctx)).Parse(src)
 	if err != nil {
 		return nil, fmt.Errorf("parse template %q: %w", name, err)
 	}
@@ -70,16 +96,37 @@ func (r *TemplateRenderer) Render(ev *notify.Event) (RenderedMessage, error) {
 	}, nil
 }
 
-func funcMap() template.FuncMap {
+func funcMap(ctx TemplateContext) template.FuncMap {
+	if ctx.Now == nil {
+		ctx.Now = time.Now
+	}
 	return template.FuncMap{
-		"upper":    strings.ToUpper,
-		"lower":    strings.ToLower,
-		"trim":     strings.TrimSpace,
-		"htmlEsc":  html.EscapeString,
-		"jsonStr":  jsonEscape,
-		"tgEscape": tgEscape,
-		"timeRFC":  func(t time.Time) string { return t.Format(time.RFC3339) },
-		"emoji":    severityEmoji,
+		"upper":         strings.ToUpper,
+		"lower":         strings.ToLower,
+		"trim":          strings.TrimSpace,
+		"htmlEsc":       html.EscapeString,
+		"jsonStr":       jsonEscape,
+		"tgEscape":      tgEscape,
+		"timeRFC":       func(t time.Time) string { return t.Format(time.RFC3339) },
+		"emoji":         severityEmoji,
+		"statusEmoji":   statusEmoji,
+		"statusVerb":    statusVerb,
+		"humanTime":     humanTime,
+		"humanDuration": humanDuration,
+		"runDuration":   runDuration,
+		"triggerPhrase": triggerPhrase,
+		"eventSentence": eventSentence,
+		"eventTrigger":  eventTrigger,
+		"linkLabel":     linkLabel,
+		"runURL":        func(r *model.Run) string { return runURL(ctx.ExternalURL, r) },
+		"taskURL":       func(name string) string { return taskURL(ctx.ExternalURL, name) },
+		"outputTail": func(r *model.Run) string {
+			if ctx.OutputTail == nil {
+				return ""
+			}
+			return ctx.OutputTail(r, 3, 300)
+		},
+		"fingerprint": func() string { return ctx.Fingerprint },
 	}
 }
 
@@ -134,4 +181,218 @@ func severityEmoji(s notify.Severity) string {
 	default:
 		return ":information_source:"
 	}
+}
+
+// statusEmoji returns the per-kind emoji used in headlines.
+func statusEmoji(k notify.Kind) string {
+	switch k {
+	case notify.KindRunFailed:
+		return "❌"
+	case notify.KindRunSucceeded:
+		return "✅"
+	case notify.KindRunTimeout:
+		return "⏱️"
+	case notify.KindRunStopped:
+		return "⏹️"
+	case notify.KindRunCrashed:
+		return "💥"
+	case notify.KindRunStarted:
+		return "▶️"
+	case notify.KindLogDiskPressure:
+		return "💾"
+	case notify.KindNotifyDeliveryFailed:
+		return "⚠️"
+	default:
+		return ""
+	}
+}
+
+// statusVerb returns the past-tense verb that completes the headline
+// "<task> <verb>". Phrasing mirrors notify.Kind.Title.
+func statusVerb(k notify.Kind) string {
+	switch k {
+	case notify.KindRunFailed:
+		return "failed"
+	case notify.KindRunSucceeded:
+		return "succeeded"
+	case notify.KindRunTimeout:
+		return "timed out"
+	case notify.KindRunStopped:
+		return "was stopped"
+	case notify.KindRunCrashed:
+		return "crashed"
+	case notify.KindRunStarted:
+		return "started"
+	case notify.KindLogDiskPressure:
+		return "log output paused"
+	case notify.KindNotifyDeliveryFailed:
+		return "delivery failed"
+	default:
+		return string(k)
+	}
+}
+
+// humanTime renders a timestamp in the operator-facing "2 Jan, 15:04" shape.
+// Uses the time's own location, which is the daemon's scheduler TZ for
+// events emitted via the bridge.
+func humanTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("2 Jan, 15:04")
+}
+
+// humanDuration formats a duration the way an operator would read aloud:
+// "0.3s", "12s", "3m 4s", "1h 12m". Negative or zero durations yield "0s"
+// so the renderer never emits a bare "-0.0s" eyesore.
+func humanDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	if d < time.Second {
+		seconds := float64(d) / float64(time.Second)
+		return fmt.Sprintf("%.1fs", seconds)
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Round(time.Second)/time.Second))
+	}
+	if d < time.Hour {
+		m := int(d / time.Minute)
+		s := int((d - time.Duration(m)*time.Minute).Round(time.Second) / time.Second)
+		if s == 0 {
+			return fmt.Sprintf("%dm", m)
+		}
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	h := int(d / time.Hour)
+	m := int((d - time.Duration(h)*time.Hour) / time.Minute)
+	if m == 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh %dm", h, m)
+}
+
+// runDuration derives a humanized duration from run.EndAt - run.StartAt.
+// Returns the empty string when either endpoint is missing — the template
+// then omits the duration phrase entirely rather than printing "0s".
+func runDuration(r *model.Run) string {
+	if r == nil || r.StartAt == nil || r.EndAt == nil {
+		return ""
+	}
+	return humanDuration(r.EndAt.Sub(*r.StartAt))
+}
+
+// triggerPhrase maps a TriggeredBy to the operator-facing sentence prefix
+// used in notification bodies. Unknown values fall through to the literal
+// enum value so adding new triggers doesn't silently lose context.
+func triggerPhrase(t model.TriggeredBy) string {
+	switch t {
+	case model.TriggeredByCron:
+		return "Scheduled run"
+	case model.TriggeredByAPI:
+		return "Manually triggered via API"
+	case model.TriggeredByCloud:
+		return "Triggered from the control plane"
+	default:
+		if t == "" {
+			return "Run"
+		}
+		return string(t)
+	}
+}
+
+// eventSentence renders the per-kind body sentence ending in a period. It is
+// the single source of truth for the failure/success phrasing previously
+// duplicated inside the Telegram and Slack templates. Output is plain text;
+// callers apply the provider-specific escape (tgEscape, jsonStr).
+func eventSentence(e *notify.Event) string {
+	switch e.Kind {
+	case notify.KindRunFailed:
+		code := "?"
+		if e.Run != nil {
+			code = fmt.Sprintf("%d", e.Run.ExitCode)
+		}
+		if d := runDuration(e.Run); d != "" {
+			return fmt.Sprintf("Exited with code %s after %s.", code, d)
+		}
+		return fmt.Sprintf("Exited with code %s.", code)
+	case notify.KindRunSucceeded:
+		if d := runDuration(e.Run); d != "" {
+			return fmt.Sprintf("Completed in %s.", d)
+		}
+		return "Completed."
+	case notify.KindRunTimeout:
+		if d := runDuration(e.Run); d != "" {
+			return fmt.Sprintf("The task was killed after the configured timeout (%s elapsed).", d)
+		}
+		return "The task was killed after the configured timeout."
+	case notify.KindRunStopped:
+		if d := runDuration(e.Run); d != "" {
+			return fmt.Sprintf("Stopped manually after %s.", d)
+		}
+		return "Stopped manually."
+	case notify.KindRunCrashed:
+		if e.Reason != "" {
+			return fmt.Sprintf("The process couldn't start: %s.", e.Reason)
+		}
+		return "The process couldn't start."
+	case notify.KindRunStarted:
+		return "Run started."
+	case notify.KindLogDiskPressure:
+		return "Disk pressure is high; log capture is paused for this task until disk space is recovered."
+	case notify.KindNotifyDeliveryFailed:
+		if e.Reason != "" {
+			return fmt.Sprintf("A notification could not be delivered: %s.", e.Reason)
+		}
+		return "A notification could not be delivered."
+	default:
+		if e.Reason != "" {
+			return e.Reason
+		}
+		return statusVerb(e.Kind) + "."
+	}
+}
+
+// eventTrigger returns just the trigger phrase ("Scheduled run", "Manually
+// triggered via API", or "Event" fallback when the event carries no Run).
+// The template owns the separator, timestamp, and trailing period.
+func eventTrigger(e *notify.Event) string {
+	if e.Run == nil {
+		return "Event"
+	}
+	return triggerPhrase(e.Run.TriggeredBy)
+}
+
+// linkLabel returns the call-to-action label for the run/task link rendered
+// at the bottom of a notification.
+func linkLabel(k notify.Kind) string {
+	switch k {
+	case notify.KindRunFailed:
+		return "View full run"
+	case notify.KindLogDiskPressure:
+		return "Open task"
+	default:
+		return "View run"
+	}
+}
+
+// runURL builds the deep-link to a specific run in the embedded dashboard.
+// Returns "" when the operator hasn't configured external_url or when the
+// run/task name is missing — callers wrap the result in a template
+// conditional so the link line vanishes cleanly rather than rendering an
+// orphan anchor.
+func runURL(externalURL string, r *model.Run) string {
+	if externalURL == "" || r == nil || r.TaskName == "" || r.ID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/tasks/%s?runId=%s", externalURL, url.PathEscape(r.TaskName), url.QueryEscape(r.ID))
+}
+
+// taskURL is the link to a task's dashboard page, used by log.disk_pressure
+// where no run identifier exists.
+func taskURL(externalURL, taskName string) string {
+	if externalURL == "" || taskName == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/tasks/%s", externalURL, url.PathEscape(taskName))
 }

--- a/apps/runwisp/internal/notify/render/render_test.go
+++ b/apps/runwisp/internal/notify/render/render_test.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/notify"
+)
+
+func TestStatusEmojiAndVerbCoverAllKinds(t *testing.T) {
+	for _, k := range notify.AllKinds {
+		assert.NotEmpty(t, statusEmoji(k), "kind %s missing emoji", k)
+		assert.NotEmpty(t, statusVerb(k), "kind %s missing verb", k)
+	}
+}
+
+func TestHumanDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "0s"},
+		{-time.Second, "0s"},
+		{300 * time.Millisecond, "0.3s"},
+		{1500 * time.Millisecond, "2s"}, // rounds to nearest second
+		{12 * time.Second, "12s"},
+		{59 * time.Second, "59s"},
+		{61 * time.Second, "1m 1s"},
+		{2*time.Minute + 30*time.Second, "2m 30s"},
+		{5 * time.Minute, "5m"},
+		{time.Hour, "1h"},
+		{75 * time.Minute, "1h 15m"},
+	}
+	for _, c := range cases {
+		got := humanDuration(c.in)
+		assert.Equal(t, c.want, got, "humanDuration(%s)", c.in)
+	}
+}
+
+func TestHumanTime(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Bratislava")
+	if err != nil {
+		t.Skip("tz data unavailable")
+	}
+	got := humanTime(time.Date(2026, 5, 14, 17, 11, 0, 0, loc))
+	assert.Equal(t, "14 May, 17:11", got)
+	assert.Equal(t, "", humanTime(time.Time{}))
+}
+
+func TestTriggerPhrase(t *testing.T) {
+	assert.Equal(t, "Scheduled run", triggerPhrase(model.TriggeredByCron))
+	assert.Equal(t, "Manually triggered via API", triggerPhrase(model.TriggeredByAPI))
+	assert.Equal(t, "Triggered from the control plane", triggerPhrase(model.TriggeredByCloud))
+	assert.Equal(t, "Run", triggerPhrase(""))
+}
+
+func TestRunURL(t *testing.T) {
+	r := &model.Run{ID: "01KRK", TaskName: "nightly-backup"}
+	assert.Equal(t, "", runURL("", r))
+	assert.Equal(t, "", runURL("https://x", nil))
+	assert.Equal(t, "", runURL("https://x", &model.Run{ID: "01KRK"}))
+	assert.Equal(t, "", runURL("https://x", &model.Run{TaskName: "n"}))
+	assert.Equal(t, "https://x/tasks/nightly-backup?runId=01KRK", runURL("https://x", r))
+
+	// Path-escape the task name (spec disallows spaces but be defensive).
+	tricky := &model.Run{ID: "01", TaskName: "name with space"}
+	assert.Equal(t, "https://x/tasks/name%20with%20space?runId=01", runURL("https://x", tricky))
+}
+
+func TestTaskURL(t *testing.T) {
+	assert.Equal(t, "", taskURL("", "x"))
+	assert.Equal(t, "", taskURL("https://x", ""))
+	assert.Equal(t, "https://x/tasks/foo", taskURL("https://x", "foo"))
+}
+
+func TestRunDuration(t *testing.T) {
+	start := time.Date(2026, 5, 14, 17, 11, 0, 0, time.UTC)
+	end := start.Add(12*time.Second + 400*time.Millisecond)
+	r := &model.Run{StartAt: &start, EndAt: &end}
+	assert.Equal(t, "12s", runDuration(r))
+
+	assert.Equal(t, "", runDuration(nil))
+	assert.Equal(t, "", runDuration(&model.Run{StartAt: &start}))
+	assert.Equal(t, "", runDuration(&model.Run{EndAt: &end}))
+}
+
+func TestEventSentence(t *testing.T) {
+	start := time.Date(2026, 5, 14, 17, 11, 0, 0, time.UTC)
+	end := start.Add(300 * time.Millisecond)
+	withDur := &model.Run{StartAt: &start, EndAt: &end, ExitCode: 1}
+	noDur := &model.Run{ExitCode: 2}
+
+	cases := []struct {
+		name string
+		ev   *notify.Event
+		want string
+	}{
+		{"failed with run + duration", &notify.Event{Kind: notify.KindRunFailed, Run: withDur}, "Exited with code 1 after 0.3s."},
+		{"failed with run, no duration", &notify.Event{Kind: notify.KindRunFailed, Run: noDur}, "Exited with code 2."},
+		{"failed without run", &notify.Event{Kind: notify.KindRunFailed}, "Exited with code ?."},
+		{"succeeded with duration", &notify.Event{Kind: notify.KindRunSucceeded, Run: withDur}, "Completed in 0.3s."},
+		{"succeeded without duration", &notify.Event{Kind: notify.KindRunSucceeded}, "Completed."},
+		{"timeout with duration", &notify.Event{Kind: notify.KindRunTimeout, Run: withDur}, "The task was killed after the configured timeout (0.3s elapsed)."},
+		{"timeout without duration", &notify.Event{Kind: notify.KindRunTimeout}, "The task was killed after the configured timeout."},
+		{"stopped with duration", &notify.Event{Kind: notify.KindRunStopped, Run: withDur}, "Stopped manually after 0.3s."},
+		{"stopped without duration", &notify.Event{Kind: notify.KindRunStopped}, "Stopped manually."},
+		{"crashed with reason", &notify.Event{Kind: notify.KindRunCrashed, Reason: "exec format error"}, "The process couldn't start: exec format error."},
+		{"crashed without reason", &notify.Event{Kind: notify.KindRunCrashed}, "The process couldn't start."},
+		{"started", &notify.Event{Kind: notify.KindRunStarted}, "Run started."},
+		{"log disk pressure", &notify.Event{Kind: notify.KindLogDiskPressure}, "Disk pressure is high; log capture is paused for this task until disk space is recovered."},
+		{"delivery failed with reason", &notify.Event{Kind: notify.KindNotifyDeliveryFailed, Reason: "timeout"}, "A notification could not be delivered: timeout."},
+		{"delivery failed without reason", &notify.Event{Kind: notify.KindNotifyDeliveryFailed}, "A notification could not be delivered."},
+		{"unknown kind with reason", &notify.Event{Kind: notify.Kind("custom.kind"), Reason: "something"}, "something"},
+		{"unknown kind fallback", &notify.Event{Kind: notify.Kind("custom.kind")}, "custom.kind."},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, eventSentence(c.ev))
+		})
+	}
+}
+
+func TestEventTrigger(t *testing.T) {
+	assert.Equal(t, "Event", eventTrigger(&notify.Event{}))
+	assert.Equal(t, "Scheduled run", eventTrigger(&notify.Event{Run: &model.Run{TriggeredBy: model.TriggeredByCron}}))
+	assert.Equal(t, "Manually triggered via API", eventTrigger(&notify.Event{Run: &model.Run{TriggeredBy: model.TriggeredByAPI}}))
+	assert.Equal(t, "Triggered from the control plane", eventTrigger(&notify.Event{Run: &model.Run{TriggeredBy: model.TriggeredByCloud}}))
+	assert.Equal(t, "Run", eventTrigger(&notify.Event{Run: &model.Run{}}))
+}
+
+func TestLinkLabel(t *testing.T) {
+	cases := map[notify.Kind]string{
+		notify.KindRunFailed:            "View full run",
+		notify.KindLogDiskPressure:      "Open task",
+		notify.KindRunSucceeded:         "View run",
+		notify.KindRunTimeout:           "View run",
+		notify.KindRunStopped:           "View run",
+		notify.KindRunCrashed:           "View run",
+		notify.KindRunStarted:           "View run",
+		notify.KindNotifyDeliveryFailed: "View run",
+	}
+	for k, want := range cases {
+		assert.Equal(t, want, linkLabel(k), "kind %s", k)
+	}
+}

--- a/apps/runwisp/internal/notify/render/tail.go
+++ b/apps/runwisp/internal/notify/render/tail.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"strings"
+
+	"github.com/runwisp/runwisp/internal/logutil"
+	"github.com/runwisp/runwisp/internal/model"
+)
+
+// NewOutputTail returns the captured-output tail closure consumed by the
+// notify renderer. It reads the last maxLines from the run's log file and
+// caps the joined result at maxBytes. Empty/missing logs yield "" so the
+// template branch that wraps the tail in <blockquote> / Slack code-fence
+// collapses cleanly.
+//
+// Truncation rules:
+//   - empty/whitespace-only lines are skipped (they add no signal but eat
+//     budget),
+//   - bytes are counted across joined "\n"-separated lines,
+//   - when the budget is exceeded mid-line, the cut is taken from the front
+//     (keeping the tail of the tail) and prefixed with an ellipsis so the
+//     reader knows there's more.
+//
+// The closure does not HTML-escape its output — the consuming template
+// applies tgEscape / jsonEscape before placing the body inside a blockquote
+// or code block.
+func NewOutputTail() func(run *model.Run, maxLines, maxBytes int) string {
+	return func(run *model.Run, maxLines, maxBytes int) string {
+		if run == nil || run.LogPath == "" || maxLines <= 0 || maxBytes <= 0 {
+			return ""
+		}
+		lines, _, _, err := logutil.ReadLineRange(run.LogPath, -int64(maxLines), int64(maxLines))
+		if err != nil || len(lines) == 0 {
+			return ""
+		}
+		cleaned := make([]string, 0, len(lines))
+		for _, rec := range lines {
+			text := strings.TrimRight(rec.Text, " \t\r\n")
+			if text == "" {
+				continue
+			}
+			cleaned = append(cleaned, text)
+		}
+		if len(cleaned) == 0 {
+			return ""
+		}
+		joined := strings.Join(cleaned, "\n")
+		if len(joined) <= maxBytes {
+			return joined
+		}
+		// Keep the tail of the tail — the *last* maxBytes-1 bytes — and prefix
+		// with a single character ellipsis so the reader sees the truncation
+		// marker. maxBytes <= 1 collapses to "…" with nothing else, which is
+		// honest enough.
+		const ellipsis = "…"
+		budget := maxBytes - len(ellipsis)
+		if budget <= 0 {
+			return ellipsis
+		}
+		return ellipsis + joined[len(joined)-budget:]
+	}
+}

--- a/apps/runwisp/internal/notify/render/tail_test.go
+++ b/apps/runwisp/internal/notify/render/tail_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/runwisp/runwisp/internal/logutil"
+	"github.com/runwisp/runwisp/internal/model"
+)
+
+func writeLog(t *testing.T, lines ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "run.log")
+	var buf strings.Builder
+	for _, l := range lines {
+		buf.WriteString(logutil.FormatLine(l, logutil.StreamStdout))
+	}
+	require.NoError(t, os.WriteFile(path, []byte(buf.String()), 0o600))
+	return path
+}
+
+func TestOutputTail_NilOrMissing(t *testing.T) {
+	tail := NewOutputTail()
+	assert.Equal(t, "", tail(nil, 3, 300))
+	assert.Equal(t, "", tail(&model.Run{}, 3, 300))
+
+	// Non-existent file produces "" (not an error).
+	r := &model.Run{LogPath: filepath.Join(t.TempDir(), "missing.log")}
+	assert.Equal(t, "", tail(r, 3, 300))
+}
+
+func TestOutputTail_ShortOutputUnchanged(t *testing.T) {
+	path := writeLog(t, "first", "second", "third")
+	tail := NewOutputTail()
+	got := tail(&model.Run{LogPath: path}, 3, 300)
+	assert.Equal(t, "first\nsecond\nthird", got)
+}
+
+func TestOutputTail_LimitsToLastNLines(t *testing.T) {
+	path := writeLog(t, "a", "b", "c", "d", "e")
+	tail := NewOutputTail()
+	got := tail(&model.Run{LogPath: path}, 3, 300)
+	assert.Equal(t, "c\nd\ne", got)
+}
+
+func TestOutputTail_SkipsEmptyLines(t *testing.T) {
+	path := writeLog(t, "real", "", "    ", "tail")
+	tail := NewOutputTail()
+	got := tail(&model.Run{LogPath: path}, 4, 300)
+	assert.Equal(t, "real\ntail", got)
+}
+
+func TestOutputTail_TruncatesToMaxBytesWithEllipsis(t *testing.T) {
+	long := strings.Repeat("X", 200)
+	path := writeLog(t, long, long)
+	tail := NewOutputTail()
+	got := tail(&model.Run{LogPath: path}, 3, 50)
+	assert.True(t, strings.HasPrefix(got, "…"), "expected ellipsis prefix, got %q", got)
+	// budget is 50-len("…")=47 (since "…" is 3 bytes in UTF-8)
+	assert.Equal(t, 50, len(got))
+}

--- a/apps/runwisp/internal/notify/render/template_render_test.go
+++ b/apps/runwisp/internal/notify/render/template_render_test.go
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/runwisp/runwisp/internal/logutil"
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/notify"
+)
+
+func eventTime(t *testing.T) time.Time {
+	t.Helper()
+	loc, err := time.LoadLocation("Europe/Bratislava")
+	if err != nil {
+		t.Skip("tz data unavailable")
+	}
+	return time.Date(2026, 5, 14, 17, 11, 0, 0, loc)
+}
+
+func makeLogTail(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "run.log")
+	lines := []string{
+		"Error: connection refused",
+		"dial tcp 127.0.0.1:5432: connect:",
+		"connection refused",
+	}
+	var buf strings.Builder
+	for _, l := range lines {
+		buf.WriteString(logutil.FormatLine(l, logutil.StreamStdout))
+	}
+	require.NoError(t, os.WriteFile(path, []byte(buf.String()), 0o600))
+	return path
+}
+
+func renderTelegram(t *testing.T, ctx TemplateContext, ev *notify.Event) string {
+	t.Helper()
+	body, err := LoadDefaultTemplate("telegram")
+	require.NoError(t, err)
+	r, err := NewTemplateRendererWithContext("telegram:test", body, "text/html", DefaultTitle, ctx)
+	require.NoError(t, err)
+	out, err := r.Render(ev)
+	require.NoError(t, err)
+	return string(out.Body)
+}
+
+func renderSlack(t *testing.T, ctx TemplateContext, ev *notify.Event) string {
+	t.Helper()
+	body, err := LoadDefaultTemplate("slack")
+	require.NoError(t, err)
+	r, err := NewTemplateRendererWithContext("slack:test", body, "application/json", DefaultTitle, ctx)
+	require.NoError(t, err)
+	out, err := r.Render(ev)
+	require.NoError(t, err)
+	return string(out.Body)
+}
+
+func TestTelegram_RunFailed_WithURLAndTail(t *testing.T) {
+	logPath := makeLogTail(t)
+	start := eventTime(t)
+	end := start.Add(300 * time.Millisecond)
+	run := &model.Run{
+		ID:          "01KRK9SS7MKEWN4F49R30ZM74N",
+		TaskName:    "telegram-test-fail",
+		ExitCode:    1,
+		StartAt:     &start,
+		EndAt:       &end,
+		TriggeredBy: model.TriggeredByAPI,
+		LogPath:     logPath,
+	}
+	ev := &notify.Event{
+		Kind:      notify.KindRunFailed,
+		Severity:  notify.SevError,
+		Timestamp: start,
+		TaskName:  "telegram-test-fail",
+		Run:       run,
+	}
+	ctx := TemplateContext{
+		ExternalURL: "https://runwisp.example.com",
+		Fingerprint: "bright-falcon",
+		OutputTail:  NewOutputTail(),
+	}
+	got := renderTelegram(t, ctx, ev)
+	expected := "❌ <b>telegram-test-fail</b> failed\n" +
+		"\n" +
+		"Exited with code 1 after 0.3s.\n" +
+		"Manually triggered via API · 14 May, 17:11.\n" +
+		"\n" +
+		"<blockquote>Error: connection refused\ndial tcp 127.0.0.1:5432: connect:\nconnection refused</blockquote>\n" +
+		"\n" +
+		"🔗 <a href=\"https://runwisp.example.com/tasks/telegram-test-fail?runId=01KRK9SS7MKEWN4F49R30ZM74N\">View full run</a>\n" +
+		"\n" +
+		"<i>from runwisp · bright-falcon</i>\n"
+	assert.Equal(t, expected, got)
+}
+
+func TestTelegram_RunFailed_NoURL_NoTail(t *testing.T) {
+	start := eventTime(t)
+	end := start.Add(300 * time.Millisecond)
+	run := &model.Run{
+		ID:          "01KRK9SS7MKEWN4F49R30ZM74N",
+		TaskName:    "telegram-test-fail",
+		ExitCode:    1,
+		StartAt:     &start,
+		EndAt:       &end,
+		TriggeredBy: model.TriggeredByAPI,
+	}
+	ev := &notify.Event{
+		Kind:      notify.KindRunFailed,
+		Severity:  notify.SevError,
+		Timestamp: start,
+		TaskName:  "telegram-test-fail",
+		Run:       run,
+	}
+	ctx := TemplateContext{
+		Fingerprint: "bright-falcon",
+		OutputTail:  NewOutputTail(),
+	}
+	got := renderTelegram(t, ctx, ev)
+	assert.NotContains(t, got, "🔗", "link line must be omitted when external_url is unset")
+	assert.NotContains(t, got, "<blockquote>", "blockquote must be omitted when log tail is empty")
+	assert.Contains(t, got, "<b>telegram-test-fail</b> failed")
+	assert.Contains(t, got, "Exited with code 1 after 0.3s.")
+	assert.Contains(t, got, "<i>from runwisp · bright-falcon</i>")
+}
+
+func TestTelegram_RunSucceeded(t *testing.T) {
+	start := eventTime(t)
+	end := start.Add(12*time.Second + 400*time.Millisecond)
+	run := &model.Run{
+		ID:          "01KRK9",
+		TaskName:    "nightly-backup",
+		StartAt:     &start,
+		EndAt:       &end,
+		TriggeredBy: model.TriggeredByCron,
+	}
+	ev := &notify.Event{
+		Kind:      notify.KindRunSucceeded,
+		Severity:  notify.SevInfo,
+		Timestamp: start,
+		TaskName:  "nightly-backup",
+		Run:       run,
+	}
+	ctx := TemplateContext{
+		ExternalURL: "https://r.example.com",
+		Fingerprint: "bright-falcon",
+		OutputTail:  NewOutputTail(),
+	}
+	got := renderTelegram(t, ctx, ev)
+	assert.Contains(t, got, "✅ <b>nightly-backup</b> succeeded")
+	assert.Contains(t, got, "Completed in 12s.")
+	assert.Contains(t, got, "Scheduled run · 14 May, 17:11.")
+	assert.Contains(t, got, "View run</a>")
+	assert.NotContains(t, got, "<blockquote>", "no captured-output tail for successful runs")
+}
+
+func TestTelegram_RunTimeout_HasTail(t *testing.T) {
+	logPath := makeLogTail(t)
+	start := eventTime(t)
+	end := start.Add(5 * time.Minute)
+	run := &model.Run{
+		ID:          "01KT",
+		TaskName:    "long-task",
+		StartAt:     &start,
+		EndAt:       &end,
+		TriggeredBy: model.TriggeredByCron,
+		LogPath:     logPath,
+	}
+	ev := &notify.Event{
+		Kind:      notify.KindRunTimeout,
+		Severity:  notify.SevError,
+		Timestamp: start,
+		TaskName:  "long-task",
+		Run:       run,
+	}
+	ctx := TemplateContext{
+		ExternalURL: "https://r.example.com",
+		Fingerprint: "bright-falcon",
+		OutputTail:  NewOutputTail(),
+	}
+	got := renderTelegram(t, ctx, ev)
+	assert.Contains(t, got, "⏱️ <b>long-task</b> timed out")
+	assert.Contains(t, got, "The task was killed after the configured timeout (5m elapsed).")
+	assert.Contains(t, got, "<blockquote>")
+}
+
+func TestTelegram_RunCrashed_NoRun(t *testing.T) {
+	ev := &notify.Event{
+		Kind:      notify.KindRunCrashed,
+		Severity:  notify.SevError,
+		Timestamp: eventTime(t),
+		TaskName:  "doomed",
+		Reason:    "exec format error",
+	}
+	ctx := TemplateContext{
+		ExternalURL: "https://r.example.com",
+		Fingerprint: "bright-falcon",
+		OutputTail:  NewOutputTail(),
+	}
+	got := renderTelegram(t, ctx, ev)
+	assert.Contains(t, got, "💥 <b>doomed</b> crashed")
+	assert.Contains(t, got, "The process couldn't start: exec format error.")
+	assert.NotContains(t, got, "🔗", "no run link without a Run")
+	assert.Contains(t, got, "<i>from runwisp · bright-falcon</i>")
+}
+
+func TestTelegram_LogDiskPressure_TaskLink(t *testing.T) {
+	ev := &notify.Event{
+		Kind:      notify.KindLogDiskPressure,
+		Severity:  notify.SevWarn,
+		Timestamp: eventTime(t),
+		TaskName:  "noisy-task",
+	}
+	ctx := TemplateContext{
+		ExternalURL: "https://r.example.com",
+		Fingerprint: "bright-falcon",
+		OutputTail:  NewOutputTail(),
+	}
+	got := renderTelegram(t, ctx, ev)
+	assert.Contains(t, got, "💾 <b>noisy-task</b> log output paused")
+	assert.Contains(t, got, "Disk pressure is high")
+	assert.Contains(t, got, "🔗 <a href=\"https://r.example.com/tasks/noisy-task\">Open task</a>")
+}
+
+func TestTelegram_EscapesUntrustedFields(t *testing.T) {
+	ev := &notify.Event{
+		Kind:      notify.KindRunCrashed,
+		Severity:  notify.SevError,
+		Timestamp: eventTime(t),
+		TaskName:  "evil<script>",
+		Reason:    "boom & <b>bold</b>",
+	}
+	ctx := TemplateContext{Fingerprint: "fp&me"}
+	got := renderTelegram(t, ctx, ev)
+	assert.Contains(t, got, "&lt;script&gt;")
+	assert.Contains(t, got, "&amp;")
+	assert.Contains(t, got, "&lt;b&gt;bold&lt;/b&gt;")
+	assert.Contains(t, got, "fp&amp;me")
+}
+
+func TestSlack_RunFailed_WithURLAndTail(t *testing.T) {
+	logPath := makeLogTail(t)
+	start := eventTime(t)
+	end := start.Add(300 * time.Millisecond)
+	run := &model.Run{
+		ID:          "01KRK9",
+		TaskName:    "tg-fail",
+		ExitCode:    1,
+		StartAt:     &start,
+		EndAt:       &end,
+		TriggeredBy: model.TriggeredByAPI,
+		LogPath:     logPath,
+	}
+	ev := &notify.Event{
+		Kind:      notify.KindRunFailed,
+		Severity:  notify.SevError,
+		Timestamp: start,
+		TaskName:  "tg-fail",
+		Run:       run,
+	}
+	ctx := TemplateContext{
+		ExternalURL: "https://r.example.com",
+		Fingerprint: "bright-falcon",
+		OutputTail:  NewOutputTail(),
+	}
+	got := renderSlack(t, ctx, ev)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &parsed), "rendered slack body must be valid JSON:\n%s", got)
+	blocks, ok := parsed["blocks"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, blocks)
+
+	concatTexts := slackTexts(blocks)
+	assert.Contains(t, concatTexts, "❌ tg-fail failed")
+	assert.Contains(t, concatTexts, "Exited with code 1 after 0.3s.\nManually triggered via API · 14 May, 17:11.")
+	assert.Contains(t, concatTexts, "```\nError: connection refused\ndial tcp 127.0.0.1:5432: connect:\nconnection refused\n```")
+	assert.Contains(t, concatTexts, "View full run")
+	assert.Contains(t, concatTexts, "from runwisp · bright-falcon")
+
+	// Check the action block carries the expected URL.
+	foundButton := false
+	for _, b := range blocks {
+		obj, _ := b.(map[string]any)
+		if obj["type"] != "actions" {
+			continue
+		}
+		elems, _ := obj["elements"].([]any)
+		for _, e := range elems {
+			el, _ := e.(map[string]any)
+			if el["url"] == "https://r.example.com/tasks/tg-fail?runId=01KRK9" {
+				foundButton = true
+			}
+		}
+	}
+	assert.True(t, foundButton, "expected action button with run URL")
+}
+
+func TestSlack_RunFailed_NoURL(t *testing.T) {
+	start := eventTime(t)
+	end := start.Add(300 * time.Millisecond)
+	run := &model.Run{ID: "01KRK9", TaskName: "tg-fail", ExitCode: 1, StartAt: &start, EndAt: &end, TriggeredBy: model.TriggeredByAPI}
+	ev := &notify.Event{Kind: notify.KindRunFailed, Severity: notify.SevError, Timestamp: start, TaskName: "tg-fail", Run: run}
+	got := renderSlack(t, TemplateContext{Fingerprint: "fp"}, ev)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &parsed), got)
+	blocks := parsed["blocks"].([]any)
+	for _, b := range blocks {
+		obj, _ := b.(map[string]any)
+		assert.NotEqual(t, "actions", obj["type"], "no action block when external_url is unset")
+	}
+}
+
+func slackTexts(blocks []any) string {
+	var b strings.Builder
+	for _, blk := range blocks {
+		obj, _ := blk.(map[string]any)
+		if text, ok := obj["text"].(map[string]any); ok {
+			if s, ok := text["text"].(string); ok {
+				b.WriteString(s)
+				b.WriteString("\n")
+			}
+		}
+		if elems, ok := obj["elements"].([]any); ok {
+			for _, e := range elems {
+				el, _ := e.(map[string]any)
+				if text, ok := el["text"].(map[string]any); ok {
+					if s, ok := text["text"].(string); ok {
+						b.WriteString(s)
+						b.WriteString("\n")
+					}
+				}
+				if s, ok := el["text"].(string); ok {
+					b.WriteString(s)
+					b.WriteString("\n")
+				}
+			}
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
### Added

- **`[daemon] external_url` for notification deep-links.** Set `external_url = "https://your-host.example.com"` (or the LAN address you actually reach the dashboard on) and Slack / Telegram messages now include a direct link to the run inside the embedded Web UI. Leaving it unset omits the link line entirely — no broken URLs.

### Changed

- **Telegram and Slack notifications got a major facelift.** Same data, human shape: a one-line headline with an emoji and a verb, a sentence describing what happened (exit code + duration for failures, elapsed for timeouts, etc.), the trigger and timestamp on the next line, the **last 3 lines of captured output** for `run.failed` / `run.timeout` (capped at 300 bytes), a deep-link to the run in the dashboard when [`[daemon] external_url`](https://docs.runwisp.com/configuration/daemon/#external_url) is set, and a small italic footer identifying the daemon by its fingerprint. The previous flat single-paragraph form is gone.