### PR TITLE
docs: surface the webhook provider page in navigation

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -98,6 +98,10 @@ export default defineConfig({
                                     label: "Email (SMTP)",
                                     slug: "notifications/providers/smtp",
                                 },
+                                {
+                                    label: "Webhook",
+                                    slug: "notifications/providers/webhook",
+                                },
                             ],
                         },
                         { label: "Per-task notifications", slug: "notifications/per-task" },

--- a/apps/docs/src/content/docs/notifications/providers/slack.mdx
+++ b/apps/docs/src/content/docs/notifications/providers/slack.mdx
@@ -235,6 +235,11 @@ task name, run id, exit code, end reason, timestamp, captured tail.
         description="Send failure alerts to any inbox via any SMTP server."
     />
     <LinkCard
+        title="Webhook"
+        href="/notifications/providers/webhook/"
+        description="POST structured JSON to any HTTP endpoint."
+    />
+    <LinkCard
         title="Notification rules"
         href="/notifications/routes/"
         description="One rule covering many tasks."

--- a/apps/docs/src/content/docs/notifications/providers/smtp.mdx
+++ b/apps/docs/src/content/docs/notifications/providers/smtp.mdx
@@ -343,6 +343,11 @@ as your starting point. The helpers `statusEmoji`, `statusVerb`,
         description="Same shape, on a different transport."
     />
     <LinkCard
+        title="Webhook"
+        href="/notifications/providers/webhook/"
+        description="POST structured JSON to any HTTP endpoint."
+    />
+    <LinkCard
         title="Notification rules"
         href="/notifications/routes/"
         description="One rule covering many tasks."

--- a/apps/docs/src/content/docs/notifications/providers/telegram.mdx
+++ b/apps/docs/src/content/docs/notifications/providers/telegram.mdx
@@ -236,6 +236,11 @@ as your starting point. The helpers `statusEmoji`, `statusVerb`,
         description="Send failure alerts to any inbox via any SMTP server."
     />
     <LinkCard
+        title="Webhook"
+        href="/notifications/providers/webhook/"
+        description="POST structured JSON to any HTTP endpoint."
+    />
+    <LinkCard
         title="Notification rules"
         href="/notifications/routes/"
         description="One rule covering many tasks."


### PR DESCRIPTION
The webhook notifier docs page shipped in #65 but was orphaned — not listed in the docs sidebar and not cross-linked from the other provider pages, so it was unreachable from navigation.

- Add **Webhook** to the Providers sidebar group in `astro.config.mjs`
- Add a Webhook `LinkCard` to the Slack, Telegram, and SMTP provider pages

No content changes to the webhook page itself.