### PR TITLE
Stop podman SMTP e2e tests from hanging CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+    # The podman SMTP e2e tests pull a container image over the network, which
+    # is non-hermetic and flaky in CI (and hung the ubuntu runner's `podman run`
+    # for the full test timeout). ubuntu-latest ships podman, so requirePodman
+    # would otherwise run them; skip them everywhere — the in-process SMTP fake
+    # covers the no-deps path. Run them locally with podman to exercise real TLS.
+    env:
+      RUNWISP_SKIP_PODMAN_TESTS: '1'
     steps:
       - uses: actions/checkout@v6
 

--- a/apps/runwisp/tests/e2e/notify_smtp_podman_test.go
+++ b/apps/runwisp/tests/e2e/notify_smtp_podman_test.go
@@ -268,7 +268,12 @@ func startMailpit(t *testing.T, opts mailpitOptions) *mailpitContainer {
 
 	args = append(args, "docker.io/axllent/mailpit:latest")
 
-	out, err := exec.Command("podman", args...).CombinedOutput()
+	// `podman run` pulls the image on first boot. Bound it so a slow or stalled
+	// registry fails this test fast instead of starving the whole go-test
+	// timeout (a hung pull once ate the full 10m CI budget).
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "podman", args...).CombinedOutput()
 	require.NoErrorf(t, err, "podman run failed: %s", string(out))
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## What

CI on `main` is red: the **Unit Tests (ubuntu-latest)** job hangs and fails after the 10-minute go-test timeout.

## Why

The Unit Tests job runs `bun run test` → `go test ./...`, which includes the podman-backed SMTP e2e tests in `tests/e2e/notify_smtp_podman_test.go`. Those tests gate on `requirePodman`, which skips when podman is absent — the author's assumption was that CI runners have no podman. But **GitHub's `ubuntu-latest` image ships podman**, so the gate passes and the tests run. `podman run` then pulls `docker.io/axllent/mailpit:latest` over the network; that pull stalled and consumed the entire 10m test budget. (macOS passed because it has no podman and skipped.)

These tests are inherently non-hermetic (they pull a container image over the network), which conflicts with the project's *hermetic e2e / no required network* invariant. The in-process SMTP fake in `notify_test.go` already covers the no-deps path.

## Fix

- Set `RUNWISP_SKIP_PODMAN_TESTS=1` on the Unit Tests job so the podman tests skip everywhere in CI. They remain runnable locally (with podman) to exercise real STARTTLS / implicit TLS / AUTH.
- Bound `podman run` with a 2-minute context timeout so a stalled image pull fails fast instead of starving the whole go-test timeout if these tests are ever run.

## Verification

- `go vet ./tests/e2e/` passes.
- `RUNWISP_SKIP_PODMAN_TESTS=1 go test ./tests/e2e/ -run TestSMTPPodman -v` → both tests SKIP, package passes.