### PR TITLE
Add remote task triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Configurable control socket (`--socket` / `RUNWISP_SOCKET`).** Set the daemon's socket path explicitly so a bind-mounted `--data` can't break it and CLI commands can reach a daemon without restating `--data`. See [Daemon](https://docs.runwisp.com/configuration/daemon/#control-socket).
 - **Bundled tzdata.** IANA time zones now resolve on slim images (Alpine/distroless) without installing `tzdata`.
+- **`runwisp exec --url`.** Trigger a task on a remote daemon over the network: it logs in (CHAP), follows the live log stream, and exits with the task's exit code, caching the session token so repeated calls don't re-authenticate. Add `--detach` to fire-and-forget. See [Triggering a task remotely](https://docs.runwisp.com/recipes/remote-trigger/).
+- **`POST /api/tasks/{name}/run?wait=true`.** Block the trigger request until the run finishes and get the completed run (with `exit_code`) back in one call — no trigger-then-poll loop. Bound the hold with `wait_timeout` (seconds). See [Triggering a task remotely](https://docs.runwisp.com/recipes/remote-trigger/).
 
 ### Changed
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -127,6 +127,10 @@ export default defineConfig({
                         { label: "Nightly backup", slug: "recipes/backup" },
                         { label: "Health checks", slug: "recipes/healthcheck" },
                         { label: "Deploy hooks", slug: "recipes/deploy-hooks" },
+                        {
+                            label: "Trigger via API",
+                            slug: "recipes/remote-trigger",
+                        },
                         { label: "Docker patterns", slug: "recipes/docker" },
                         {
                             label: "Migrating from docker-compose",

--- a/apps/docs/src/content/docs/recipes/deploy-hooks.mdx
+++ b/apps/docs/src/content/docs/recipes/deploy-hooks.mdx
@@ -80,7 +80,8 @@ fires it until something explicitly asks for a run.
         `POST /api/tasks/deploy-app/run` — see [Triggering from CI](#triggering-from-ci) below for
         the full CHAP handshake plus trigger script. On the box itself, [`runwisp exec
         deploy-app`](/getting-started/quick-start/#3-run-the-example-task) is the same call wrapped
-        in a CLI.
+        in a CLI; from another machine, [`runwisp exec deploy-app --url
+        …`](/recipes/remote-trigger/) does it remotely.
     </TabItem>
 </Tabs>
 

--- a/apps/docs/src/content/docs/recipes/remote-trigger.mdx
+++ b/apps/docs/src/content/docs/recipes/remote-trigger.mdx
@@ -1,0 +1,183 @@
+---
+# SPDX-FileCopyrightText: PoppyCake, s.r.o.
+# SPDX-License-Identifier: Apache-2.0
+title: Triggering a task remotely
+description: Fire a single RunWisp task on a daemon you're not sitting at — from a deploy script, a cron job on another box, or CI — and get its live output and exit code back. One CLI command, or a dependency-free REST call.
+---
+
+import { Tabs, TabItem, CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+Sometimes the task lives on one machine and the thing that wants to
+run it lives on another — a deploy script on your laptop, a cron job
+on a jump host, a CI runner. You don't want to SSH in, remember the
+exact command, and lose the output to a scrollback buffer. You want
+to poke the daemon, watch what happens, and have your script stop if
+it fails.
+
+That's one command:
+
+```bash
+runwisp exec backup --url https://runwisp.example.com
+```
+
+It logs in, triggers the `backup` task, streams its stdout/stderr to
+your terminal live, and exits with the **task's** exit code — so
+`runwisp exec backup --url … && deploy.sh` does the right thing. Every
+trigger still lands as a browsable run in the daemon's history, with
+timestamps, exit code, and captured output, exactly like a scheduled
+run.
+
+## The two ways to do it
+
+<Tabs syncKey="surface">
+    <TabItem label="Remote CLI" icon="seti:shell">
+        Install the `runwisp` binary wherever your script runs (it's
+        a single static binary — no daemon, no data dir needed for
+        this), then point `exec` at the remote daemon:
+
+        ```bash
+        export RUNWISP_URL=https://runwisp.example.com
+        export RUNWISP_PASSWORD=…            # the daemon's password
+
+        runwisp exec backup                  # --url falls back to RUNWISP_URL
+        ```
+
+        RunWisp does the [CHAP handshake](/operations/auth/#network-clients-web-ui-remote-rest)
+        for you, **caches the resulting session token** under your
+        user cache dir (`$XDG_CACHE_HOME/runwisp/` on Linux,
+        `~/Library/Caches/runwisp/` on macOS), and reuses it on the
+        next call. That matters: the daemon rate-limits logins, so a
+        script that triggers a task every minute would get throttled
+        if it re-authenticated each time. With the cached token, only
+        the first call logs in; the rest just trigger.
+
+        The password can come from `--password` instead of the
+        environment, but `RUNWISP_PASSWORD` keeps it out of your shell
+        history and process list.
+
+        **Fire-and-forget.** If you only want to kick the task off and
+        not wait around, add `--detach` — it prints the run ID and
+        exits `0` immediately:
+
+        ```bash
+        runwisp exec backup --detach
+        # 01ARZ3NDEKTSV4RRFFQ69G5FAV
+        ```
+
+        You can quote that ULID back when you go looking for the run
+        in the Web UI or [`runwisp` history](/concepts/logs/).
+    </TabItem>
+    <TabItem label="REST API" icon="cloud-download">
+        Can't install the binary on the box that triggers the task?
+        It's all plain HTTP — the CLI is just a wrapper around these
+        calls. [Logging in](/operations/auth/#network-clients-web-ui-remote-rest)
+        is a two-step dance: GET a nonce, POST back
+        `sha256(password:nonce)`, and the daemon hands you a JWT.
+
+        ```bash
+        set -euo pipefail
+        BASE=https://runwisp.example.com
+
+        # 1. Log in (CHAP) → JWT.
+        NONCE=$(curl -sSf "$BASE/api/auth/challenge" | jq -r .nonce)
+        RESP=$(printf '%s:%s' "$RUNWISP_PASSWORD" "$NONCE" | sha256sum | cut -d' ' -f1)
+        TOKEN=$(curl -sSf -X POST "$BASE/api/auth" \
+          -H 'Content-Type: application/json' \
+          -d "$(jq -nc --arg n "$NONCE" --arg r "$RESP" '{nonce:$n, response:$r}')" \
+          | jq -r .token)
+
+        # 2. Trigger AND wait — one call returns the finished run.
+        curl -sSf -X POST "$BASE/api/tasks/backup/run?wait=true" \
+          -H "Authorization: Bearer $TOKEN" | jq .exit_code
+        ```
+
+        `wait=true` holds the request open until the run reaches a
+        terminal state and returns the completed run — same shape as
+        any other run object, so `.exit_code`, `.end_reason`, and
+        `.status` are all there. That's the whole result in a single
+        call: no trigger-then-poll loop to write.
+
+        Reuse that `$TOKEN` across calls — it's good for 24 hours.
+        Logging in on every trigger will eventually trip the daemon's
+        auth [rate limit](/operations/auth/#rate-limiting).
+
+        #### Long-running tasks: trigger, then poll
+
+        `wait=true` blocks for up to `wait_timeout` seconds (default
+        `300`); if the run hasn't finished by then the call returns it
+        still `running` rather than hanging forever. For tasks that
+        outlast a sensible HTTP timeout — yours or your reverse
+        proxy's — skip `wait`, take the run `id` the trigger returns,
+        and poll it on your own schedule:
+
+        ```bash
+        # 1. Trigger without waiting → returns the new run, including its id.
+        RUN_ID=$(curl -sSf -X POST "$BASE/api/tasks/backup/run" \
+          -H "Authorization: Bearer $TOKEN" | jq -r .id)
+
+        # 2. Poll until it ends, then read the exit code.
+        while :; do
+          RUN=$(curl -sSf "$BASE/api/tasks/backup/runs/$RUN_ID" \
+            -H "Authorization: Bearer $TOKEN")
+          [ "$(jq -r .status <<<"$RUN")" = "ended" ] && break
+          sleep 5
+        done
+        echo "exit code: $(jq -r .exit_code <<<"$RUN")"
+        ```
+
+        Want live output instead of polling? That same `id` feeds the
+        SSE stream at
+        `GET /api/tasks/backup/runs/$RUN_ID/log/stream`, which emits
+        `line` events and a final `done` event when the run ends —
+        that's exactly what the CLI follows under the hood.
+    </TabItem>
+
+</Tabs>
+
+## What the daemon needs
+
+Two things, and they're both about the daemon you're triggering — not
+the machine you're triggering from:
+
+1. **It has to be reachable over the network.** By default the daemon
+   binds to loopback only. Bind it wider with
+   `runwisp daemon --host 0.0.0.0` and — please — put it behind a
+   [TLS-terminating reverse proxy](/operations/auth/#reverse-proxies)
+   rather than exposing plain HTTP. CHAP keeps your password safe, but
+   not everything else: the session token and all the output ride over
+   plain HTTP in the clear, and anyone who can watch the traffic can
+   grab that token and reuse it. TLS is what closes that gap.
+2. **The task allows API triggering.** Tasks are triggerable over the
+   API by default (`api_trigger = true`). If you've set
+   `api_trigger = false` on a task to wall it off, the trigger comes
+   back `403` and so does `runwisp exec --url`. Drop the line to
+   re-enable it.
+
+That's the whole setup. The TOML on the daemon stays the single
+source of truth for _what_ runs; the remote trigger only ever says
+_when_.
+
+---
+
+<CardGrid>
+    <LinkCard
+        title="Operations: auth"
+        href="/operations/auth/"
+        description="The CHAP login and JWT session the remote trigger relies on."
+    />
+    <LinkCard
+        title="Deploy hooks"
+        href="/recipes/deploy-hooks/"
+        description="The sibling recipe — manual-only tasks triggered from CI."
+    />
+    <LinkCard
+        title="[tasks.*] ref"
+        href="/configuration/tasks/"
+        description="api_trigger and every other task key."
+    />
+    <LinkCard
+        title="Quick start"
+        href="/getting-started/quick-start/"
+        description="Get a daemon and a task running in the first place."
+    />
+</CardGrid>

--- a/apps/runwisp/cmd/runwisp/cli_errors.go
+++ b/apps/runwisp/cmd/runwisp/cli_errors.go
@@ -132,6 +132,60 @@ func tuiPasswordMismatchError(port int, explicit bool) error {
 	}
 }
 
+// remoteAuthRequiredError is returned when `runwisp exec --url` needs to run
+// the CHAP handshake (no cached session) but no password was supplied.
+func remoteAuthRequiredError(baseURL string) error {
+	return &userFacingError{
+		title: fmt.Sprintf("a password is required to authenticate with %s", baseURL),
+		details: "Provide the daemon's password so RunWisp can log in:\n" +
+			"  - Pass --password <PASSWORD>\n" +
+			"  - Or set RUNWISP_PASSWORD in the environment",
+	}
+}
+
+// remoteAuthFailedError is returned when the remote daemon rejects our login
+// (a 401), i.e. the password is wrong.
+func remoteAuthFailedError(baseURL string) error {
+	return &userFacingError{
+		title: fmt.Sprintf("authentication with %s failed", baseURL),
+		details: "The daemon rejected the password.\n" +
+			"  - Check --password / RUNWISP_PASSWORD matches the daemon's password",
+	}
+}
+
+// remoteRateLimitedError is returned when the remote daemon's auth rate
+// limiter rejects our login (a 429).
+func remoteRateLimitedError(baseURL string) error {
+	return &userFacingError{
+		title: fmt.Sprintf("too many authentication attempts against %s", baseURL),
+		details: "The daemon temporarily blocks further logins from your IP after repeated attempts.\n" +
+			"RunWisp caches the session token between calls, so this usually means the password is wrong.\n" +
+			"  - Wait a few minutes and try again\n" +
+			"  - Confirm --password / RUNWISP_PASSWORD is correct",
+	}
+}
+
+// remoteUnreachableError is returned when the remote daemon can't be dialed.
+func remoteUnreachableError(baseURL string, cause error) error {
+	return &userFacingError{
+		title: fmt.Sprintf("daemon at %s is not reachable (%v)", baseURL, cause),
+		details: "Check that:\n" +
+			"  - The URL is correct (scheme, host, and port)\n" +
+			"  - The daemon is bound beyond loopback (runwisp daemon --host 0.0.0.0) or reachable through your reverse proxy\n" +
+			"  - No firewall is blocking the connection",
+	}
+}
+
+// remoteAPITriggerDisabledError is returned when the task exists but has
+// api_trigger = false, so it can't be triggered over the API.
+func remoteAPITriggerDisabledError(taskName string) error {
+	return &userFacingError{
+		title: fmt.Sprintf("task %q cannot be triggered over the API", taskName),
+		details: "This task has api_trigger = false in runwisp.toml.\n" +
+			"  - Remove that line (api_trigger defaults to true) to allow remote triggering",
+	}
+}
+
 // authRateLimitedError is returned when the daemon's auth rate limiter
 // rejects our login attempt. The window and limit are exported constants in
 // the server package, but we avoid importing them here to keep this file

--- a/apps/runwisp/cmd/runwisp/cli_errors_test.go
+++ b/apps/runwisp/cmd/runwisp/cli_errors_test.go
@@ -103,6 +103,48 @@ func TestIsUserFacing_Nil(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestRemoteAuthRequiredError(t *testing.T) {
+	err := remoteAuthRequiredError("https://example.com")
+	var ufe *userFacingError
+	require.True(t, errors.As(err, &ufe))
+	assert.Contains(t, ufe.title, "https://example.com")
+	assert.Contains(t, ufe.details, "RUNWISP_PASSWORD")
+}
+
+func TestRemoteAuthFailedError(t *testing.T) {
+	err := remoteAuthFailedError("https://example.com")
+	var ufe *userFacingError
+	require.True(t, errors.As(err, &ufe))
+	assert.Contains(t, ufe.title, "authentication")
+	assert.Contains(t, ufe.title, "https://example.com")
+	assert.Contains(t, ufe.details, "rejected the password")
+}
+
+func TestRemoteRateLimitedError(t *testing.T) {
+	err := remoteRateLimitedError("https://example.com")
+	var ufe *userFacingError
+	require.True(t, errors.As(err, &ufe))
+	assert.Contains(t, ufe.title, "too many authentication attempts")
+	assert.Contains(t, ufe.details, "Wait a few minutes")
+}
+
+func TestRemoteUnreachableError(t *testing.T) {
+	err := remoteUnreachableError("https://example.com", errors.New("dial tcp: connection refused"))
+	var ufe *userFacingError
+	require.True(t, errors.As(err, &ufe))
+	assert.Contains(t, ufe.title, "not reachable")
+	assert.Contains(t, ufe.title, "connection refused")
+	assert.Contains(t, ufe.details, "URL is correct")
+}
+
+func TestRemoteAPITriggerDisabledError(t *testing.T) {
+	err := remoteAPITriggerDisabledError("backup")
+	var ufe *userFacingError
+	require.True(t, errors.As(err, &ufe))
+	assert.Contains(t, ufe.title, `"backup"`)
+	assert.Contains(t, ufe.details, "api_trigger = false")
+}
+
 func TestUnknownTaskError(t *testing.T) {
 	t.Run("suggests closest match and lists tasks", func(t *testing.T) {
 		err := unknownTaskError("backap", []string{"cleanup", "backup"})

--- a/apps/runwisp/cmd/runwisp/cmd_exec.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec.go
@@ -28,25 +28,36 @@ import (
 var execFlags struct {
 	Daemon     bool
 	Standalone bool
+	URL        string
+	Password   string
+	Detach     bool
 }
 
 // execCmd runs a task and streams its output to stdout/stderr. It auto-detects
 // whether a daemon owns this data dir: if one is running, the request is
 // dispatched over the REST API; otherwise the task runs in-process. The user
-// can pin the choice with --daemon or --standalone.
+// can pin the choice with --daemon or --standalone, or target a remote daemon
+// over the network with --url.
 var execCmd = &cobra.Command{
 	Use:   "exec <task-name>",
 	Short: "Run a task and stream its output",
 	Long: `Runs the named task and streams its log lines to stdout/stderr. Exits with
 the task's exit code.
 
-If a daemon is running against the same data dir, ` + "`runwisp exec`" + ` dispatches
-the run through its REST API and follows the live log stream. With no daemon
-running, the task is executed in this CLI process from runwisp.toml.
+With --url (or RUNWISP_URL) set, the run is dispatched to a remote daemon over
+the network: RunWisp logs in (CHAP), triggers the task, follows its live log
+stream, and exits with the task's exit code — ideal for automation scripts and
+CI. The password comes from --password or RUNWISP_PASSWORD, and the resulting
+session token is cached so repeated calls don't re-authenticate.
+
+Without --url, the run is local. If a daemon is running against the same data
+dir, ` + "`runwisp exec`" + ` dispatches the run through its REST API and follows the
+live log stream. With no daemon running, the task is executed in this CLI
+process from runwisp.toml.
 
 Use --daemon to require a running daemon (and fail fast if none is up), or
 --standalone to require in-process execution (and refuse if a daemon owns the
-data dir). Without either flag, the mode is auto-detected.`,
+data dir). Without either flag, the local mode is auto-detected.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if execFlags.Daemon && execFlags.Standalone {
@@ -66,9 +77,20 @@ data dir). Without either flag, the mode is auto-detected.`,
 func init() {
 	execCmd.Flags().BoolVar(&execFlags.Daemon, "daemon", false, "require a running daemon and dispatch through its API")
 	execCmd.Flags().BoolVar(&execFlags.Standalone, "standalone", false, "require no daemon and run the task in-process")
+	execCmd.Flags().StringVar(&execFlags.URL, "url", "", "trigger the task on a remote daemon at this base URL (env: RUNWISP_URL)")
+	execCmd.Flags().StringVar(&execFlags.Password, "password", "", "remote daemon password for --url (env: RUNWISP_PASSWORD)")
+	execCmd.Flags().BoolVar(&execFlags.Detach, "detach", false, "with --url, trigger and print the run ID without following the log stream")
 }
 
 func runExec(taskName string, f Flags) (int, error) {
+	if remoteURL := firstNonEmpty(execFlags.URL, os.Getenv("RUNWISP_URL")); remoteURL != "" {
+		if execFlags.Daemon || execFlags.Standalone {
+			return 0, errors.New("--url cannot be combined with --daemon or --standalone")
+		}
+		password := firstNonEmpty(execFlags.Password, os.Getenv("RUNWISP_PASSWORD"))
+		return runExecViaRemote(taskName, remoteURL, password, execFlags.Detach)
+	}
+
 	daemonUp := isDaemonRunning(f)
 
 	if execFlags.Daemon && !daemonUp {
@@ -114,24 +136,114 @@ func runExecViaDaemon(taskName string, f Flags) (int, error) {
 	}
 
 	slog.Info("Task triggered", "name", taskName, "run", run.ID)
+	return followRun(client, taskName, run.ID)
+}
 
+// runExecViaRemote dispatches the run to a remote daemon over the network. It
+// reuses a cached JWT when one is valid, falling back to a CHAP handshake, and
+// (unless detached) follows the SSE log stream to propagate the exit code.
+func runExecViaRemote(taskName, baseURL, password string, detach bool) (int, error) {
+	client := apiclient.New(baseURL, password)
+
+	// Health is a public endpoint — probe it before auth so an unreachable
+	// daemon reports as such rather than as a login failure.
+	if err := client.HealthCheck(); err != nil {
+		return 0, remoteUnreachableError(baseURL, err)
+	}
+
+	// Optimistically reuse a cached session; an expired token surfaces as a
+	// 401 on the trigger, which triggerRemote re-authenticates and retries.
+	if cached := loadCachedToken(baseURL); cached != "" {
+		client.SetToken(cached)
+	}
+	if !client.IsAuthenticated() {
+		if err := authenticateRemote(client, baseURL, password); err != nil {
+			return 0, err
+		}
+	}
+
+	run, err := triggerRemote(client, taskName, baseURL, password)
+	if err != nil {
+		return 0, err
+	}
+
+	slog.Info("Task triggered", "name", taskName, "run", run.ID, "url", baseURL)
+
+	if detach {
+		fmt.Println(run.ID)
+		return 0, nil
+	}
+	return followRun(client, taskName, run.ID)
+}
+
+// authenticateRemote runs the CHAP handshake and caches the resulting session
+// token. It maps auth failures to user-facing errors.
+func authenticateRemote(client *apiclient.Client, baseURL, password string) error {
+	if password == "" {
+		return remoteAuthRequiredError(baseURL)
+	}
+	if err := client.Authenticate(); err != nil {
+		switch {
+		case errors.Is(err, apiclient.ErrUnauthorized):
+			return remoteAuthFailedError(baseURL)
+		case errors.Is(err, apiclient.ErrRateLimited):
+			return remoteRateLimitedError(baseURL)
+		default:
+			return fmt.Errorf("authenticate with %s: %w", baseURL, err)
+		}
+	}
+	storeCachedToken(baseURL, client.Token())
+	return nil
+}
+
+// triggerRemote triggers the run, re-authenticating once if a cached token has
+// expired (401), and maps the daemon's error codes to user-facing messages.
+func triggerRemote(client *apiclient.Client, taskName, baseURL, password string) (*model.Run, error) {
+	run, err := client.TriggerRun(taskName)
+	if errors.Is(err, apiclient.ErrUnauthorized) {
+		if authErr := authenticateRemote(client, baseURL, password); authErr != nil {
+			return nil, authErr
+		}
+		run, err = client.TriggerRun(taskName)
+	}
+	if err != nil {
+		switch {
+		case apiclient.IsHTTPStatus(err, http.StatusNotFound):
+			return nil, unknownTaskError(taskName, daemonTaskNames(client))
+		case apiclient.IsHTTPStatus(err, http.StatusForbidden):
+			return nil, remoteAPITriggerDisabledError(taskName)
+		case errors.Is(err, apiclient.ErrUnauthorized):
+			return nil, remoteAuthFailedError(baseURL)
+		case errors.Is(err, apiclient.ErrRateLimited):
+			return nil, remoteRateLimitedError(baseURL)
+		default:
+			return nil, fmt.Errorf("trigger %q: %w", taskName, err)
+		}
+	}
+	return run, nil
+}
+
+// followRun follows a triggered run's SSE log stream, printing lines to
+// stdout/stderr and returning the run's exit code once it reaches a terminal
+// state. It is shared by the local-daemon and remote exec paths.
+func followRun(client *apiclient.Client, taskName, runID string) (int, error) {
 	ctx, cancel := newSignalCancelContext()
 	defer cancel()
 
 	// Line numbers are zero-indexed; the server reads from=0 as the default
 	// tail window and clamps to anchor 0 on a fresh run, so we see every line.
-	ch, err := client.StreamLogLines(ctx, taskName, run.ID, apiclient.StreamLogOpts{FromLine: 0})
+	ch, err := client.StreamLogLines(ctx, taskName, runID, apiclient.StreamLogOpts{FromLine: 0})
 	if err != nil {
 		return 0, fmt.Errorf("open log stream: %w", err)
 	}
 
-	if exitCode, done, err := streamRunLogs(ch, client, taskName, run.ID); done {
+	if exitCode, done, err := streamRunLogs(ch, client, taskName, runID); done {
 		return exitCode, err
 	}
 
 	// Stream closed without a Done event (ctx cancelled or transport ended);
 	// poll for the terminal state so we can propagate the exit code anyway.
-	final, err := client.GetRun(taskName, run.ID)
+	final, err := client.GetRun(taskName, runID)
 	if err != nil {
 		return 0, fmt.Errorf("fetch final run state: %w", err)
 	}

--- a/apps/runwisp/cmd/runwisp/cmd_exec_remote_errors_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec_remote_errors_test.go
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/runwisp/runwisp/internal/apiclient"
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// authStatusServer answers the CHAP challenge with a fixed status code, so a
+// test can drive authenticateRemote down each of its failure branches.
+func authStatusServer(t *testing.T, challengeStatus int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		case "/api/auth/challenge":
+			w.WriteHeader(challengeStatus)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestAuthenticateRemote_MissingPassword(t *testing.T) {
+	client := apiclient.New("https://example.com", "")
+	err := authenticateRemote(client, "https://example.com", "")
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok)
+	assert.Contains(t, ufe.Error(), "password is required")
+}
+
+func TestAuthenticateRemote_Unauthorized(t *testing.T) {
+	srv := authStatusServer(t, http.StatusUnauthorized)
+	defer srv.Close()
+
+	err := authenticateRemote(apiclient.New(srv.URL, "pw"), srv.URL, "pw")
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok)
+	assert.Contains(t, ufe.Error(), "authentication")
+	assert.Contains(t, ufe.Error(), "rejected the password")
+}
+
+func TestAuthenticateRemote_RateLimited(t *testing.T) {
+	srv := authStatusServer(t, http.StatusTooManyRequests)
+	defer srv.Close()
+
+	err := authenticateRemote(apiclient.New(srv.URL, "pw"), srv.URL, "pw")
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok)
+	assert.Contains(t, ufe.Error(), "too many authentication attempts")
+}
+
+func TestAuthenticateRemote_OtherError(t *testing.T) {
+	srv := authStatusServer(t, http.StatusInternalServerError)
+	defer srv.Close()
+
+	err := authenticateRemote(apiclient.New(srv.URL, "pw"), srv.URL, "pw")
+	require.Error(t, err)
+	_, ok := isUserFacing(err)
+	assert.False(t, ok, "a transport/5xx failure is a plain wrapped error, not user-facing")
+	assert.Contains(t, err.Error(), "authenticate with")
+}
+
+// triggerStatusServer answers POST .../run with a fixed status code and serves
+// an (empty) task list so daemonTaskNames stays best-effort.
+func triggerStatusServer(t *testing.T, runStatus int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/run") && r.Method == http.MethodPost:
+			w.WriteHeader(runStatus)
+		case r.URL.Path == "/api/tasks":
+			_ = json.NewEncoder(w).Encode([]model.Task{{Name: "other"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestTriggerRemote_NotFound(t *testing.T) {
+	srv := triggerStatusServer(t, http.StatusNotFound)
+	defer srv.Close()
+
+	client := apiclient.New(srv.URL, "pw")
+	client.SetToken("tok")
+	_, err := triggerRemote(client, "backup", srv.URL, "pw")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `task "backup" not found`)
+}
+
+func TestTriggerRemote_Forbidden(t *testing.T) {
+	srv := triggerStatusServer(t, http.StatusForbidden)
+	defer srv.Close()
+
+	client := apiclient.New(srv.URL, "pw")
+	client.SetToken("tok")
+	_, err := triggerRemote(client, "backup", srv.URL, "pw")
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok)
+	assert.Contains(t, ufe.Error(), "cannot be triggered over the API")
+}
+
+func TestTriggerRemote_RateLimited(t *testing.T) {
+	srv := triggerStatusServer(t, http.StatusTooManyRequests)
+	defer srv.Close()
+
+	client := apiclient.New(srv.URL, "pw")
+	client.SetToken("tok")
+	_, err := triggerRemote(client, "backup", srv.URL, "pw")
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok)
+	assert.Contains(t, ufe.Error(), "too many authentication attempts")
+}
+
+func TestTriggerRemote_OtherError(t *testing.T) {
+	srv := triggerStatusServer(t, http.StatusInternalServerError)
+	defer srv.Close()
+
+	client := apiclient.New(srv.URL, "pw")
+	client.SetToken("tok")
+	_, err := triggerRemote(client, "backup", srv.URL, "pw")
+	require.Error(t, err)
+	_, ok := isUserFacing(err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), `trigger "backup"`)
+}
+
+// TestTriggerRemote_ReauthFailsWithoutPassword exercises the 401 → re-auth path
+// where the cached token is stale but no password is available to re-handshake.
+func TestTriggerRemote_ReauthFailsWithoutPassword(t *testing.T) {
+	srv := triggerStatusServer(t, http.StatusUnauthorized)
+	defer srv.Close()
+
+	client := apiclient.New(srv.URL, "")
+	client.SetToken("stale")
+	_, err := triggerRemote(client, "backup", srv.URL, "")
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok)
+	assert.Contains(t, ufe.Error(), "password is required")
+}
+
+// TestFollowRun_PollsWhenStreamEndsWithoutDone covers followRun's fallback: the
+// SSE stream closes without a done event, so it polls GetRun for the terminal
+// exit code.
+func TestFollowRun_PollsWhenStreamEndsWithoutDone(t *testing.T) {
+	reason := model.ReasonFailed
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/log/stream"):
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			// A line but no "done" event, then the stream just ends.
+			fmt.Fprintln(w, "event: line")
+			fmt.Fprintln(w, `data: {"n":0,"stream":"stdout","text":"hi"}`)
+			fmt.Fprintln(w, "")
+		case strings.Contains(r.URL.Path, "/runs/"):
+			_ = json.NewEncoder(w).Encode(model.Run{
+				ID: "run-1", TaskName: "backup", Status: model.PhaseEnded,
+				EndReason: &reason, ExitCode: 4,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := apiclient.New(srv.URL, "pw")
+	client.SetToken("tok")
+	code, err := followRun(client, "backup", "run-1")
+	require.NoError(t, err)
+	assert.Equal(t, 4, code, "exit code must come from the polled terminal run")
+}
+
+func TestRunExec_URLWithDaemonFlagRejected(t *testing.T) {
+	t.Setenv("RUNWISP_URL", "")
+	execFlags.URL = "https://example.com"
+	execFlags.Daemon = true
+	t.Cleanup(func() { execFlags.URL = ""; execFlags.Daemon = false })
+
+	_, err := runExec("backup", Flags{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--url cannot be combined")
+}
+
+// TestRunExec_RoutesToRemoteWithEnvPassword confirms runExec dispatches to the
+// remote path when --url is set and reads the password from the environment.
+func TestRunExec_RoutesToRemoteWithEnvPassword(t *testing.T) {
+	useTempCacheDir(t)
+	stub := &remoteDaemonStub{exitCode: 0, endReason: model.ReasonSuccess}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	execFlags.URL = srv.URL
+	t.Setenv("RUNWISP_PASSWORD", "pw")
+	t.Cleanup(func() { execFlags.URL = "" })
+
+	code, err := runExec("backup", Flags{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, int32(1), stub.authCount.Load(), "env password drove one CHAP handshake")
+}

--- a/apps/runwisp/cmd/runwisp/cmd_exec_remote_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec_remote_test.go
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// remoteDaemonStub is a fake daemon that implements the minimal REST surface
+// runExecViaRemote needs: health, CHAP auth, trigger, log stream, and run
+// fetch. It mints a fresh token on each login and (optionally) rejects a
+// pre-seeded stale token on the first trigger to exercise the re-auth path.
+type remoteDaemonStub struct {
+	exitCode      int
+	endReason     model.EndReason
+	staleToken    string // if set, a trigger carrying this token gets one 401
+	staleRejected atomic.Bool
+	authCount     atomic.Int32
+	streamHits    atomic.Int32
+}
+
+func (s *remoteDaemonStub) handler(t *testing.T) http.HandlerFunc {
+	const freshToken = "fresh-jwt-token"
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/health":
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/api/auth/challenge":
+			_ = json.NewEncoder(w).Encode(map[string]string{"nonce": "test-nonce"})
+
+		case r.URL.Path == "/api/auth":
+			s.authCount.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": freshToken})
+
+		case strings.HasSuffix(r.URL.Path, "/run") && r.Method == http.MethodPost:
+			auth := r.Header.Get("Authorization")
+			if s.staleToken != "" && auth == "Bearer "+s.staleToken && !s.staleRejected.Load() {
+				s.staleRejected.Store(true)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			require.Equal(t, "Bearer "+freshToken, auth, "trigger must carry the fresh token")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(model.Run{ID: "run-123", TaskName: "backup", Status: model.PhasePending})
+
+		case strings.HasSuffix(r.URL.Path, "/log/stream"):
+			s.streamHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, "event: line")
+			fmt.Fprintln(w, `data: {"n":0,"stream":"stdout","text":"hello from backup"}`)
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "event: done")
+			fmt.Fprintln(w, `data: {"final_line":0,"status":"ended"}`)
+			fmt.Fprintln(w, "")
+
+		case strings.HasPrefix(r.URL.Path, "/api/tasks/") && strings.Contains(r.URL.Path, "/runs/"):
+			reason := s.endReason
+			_ = json.NewEncoder(w).Encode(model.Run{
+				ID:        "run-123",
+				TaskName:  "backup",
+				Status:    model.PhaseEnded,
+				EndReason: &reason,
+				ExitCode:  s.exitCode,
+			})
+
+		default:
+			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func TestRunExecViaRemote_StreamsAndPropagatesExitCode(t *testing.T) {
+	useTempCacheDir(t)
+	stub := &remoteDaemonStub{exitCode: 7, endReason: model.ReasonFailed}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	code, err := runExecViaRemote("backup", srv.URL, "pw", false)
+	require.NoError(t, err)
+	assert.Equal(t, 7, code, "exit code must propagate from the failed run")
+	assert.Equal(t, int32(1), stub.streamHits.Load(), "the log stream must be followed")
+	assert.Equal(t, int32(1), stub.authCount.Load(), "exactly one CHAP handshake")
+
+	// The minted token is cached for reuse.
+	assert.Equal(t, "fresh-jwt-token", loadCachedToken(srv.URL))
+}
+
+func TestRunExecViaRemote_SuccessReturnsZero(t *testing.T) {
+	useTempCacheDir(t)
+	stub := &remoteDaemonStub{exitCode: 0, endReason: model.ReasonSuccess}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	code, err := runExecViaRemote("backup", srv.URL, "pw", false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+}
+
+func TestRunExecViaRemote_ReauthOnExpiredToken(t *testing.T) {
+	useTempCacheDir(t)
+	stub := &remoteDaemonStub{exitCode: 0, endReason: model.ReasonSuccess, staleToken: "stale-jwt"}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	// Seed a cached (stale) token; the first trigger 401s and we re-handshake.
+	storeCachedToken(srv.URL, "stale-jwt")
+
+	code, err := runExecViaRemote("backup", srv.URL, "pw", false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.True(t, stub.staleRejected.Load(), "the stale token must have been rejected once")
+	assert.Equal(t, int32(1), stub.authCount.Load(), "exactly one re-authentication")
+}
+
+func TestRunExecViaRemote_Detach(t *testing.T) {
+	useTempCacheDir(t)
+	stub := &remoteDaemonStub{exitCode: 0, endReason: model.ReasonSuccess}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	code, err := runExecViaRemote("backup", srv.URL, "pw", true)
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, int32(0), stub.streamHits.Load(), "--detach must not follow the log stream")
+}
+
+func TestRunExecViaRemote_MissingPassword(t *testing.T) {
+	useTempCacheDir(t)
+	stub := &remoteDaemonStub{}
+	srv := httptest.NewServer(stub.handler(t))
+	defer srv.Close()
+
+	_, err := runExecViaRemote("backup", srv.URL, "", false)
+	require.Error(t, err)
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok, "missing password must be a user-facing error")
+	assert.Contains(t, ufe.Error(), "password is required")
+}
+
+func TestRunExecViaRemote_Unreachable(t *testing.T) {
+	useTempCacheDir(t)
+	// A closed server's URL is unroutable, so HealthCheck fails to dial.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	url := srv.URL
+	srv.Close()
+
+	_, err := runExecViaRemote("backup", url, "pw", false)
+	require.Error(t, err)
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok)
+	assert.Contains(t, ufe.Error(), "not reachable")
+}

--- a/apps/runwisp/cmd/runwisp/remote_token_cache.go
+++ b/apps/runwisp/cmd/runwisp/remote_token_cache.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"log/slog"
+
+	"github.com/runwisp/runwisp/internal/datadir"
+)
+
+// The CLI caches the JWT minted by a remote daemon so repeated `runwisp exec
+// --url` invocations reuse one session instead of re-running CHAP each time.
+// Re-handshaking would burn two hits (challenge + login) against the daemon's
+// per-IP auth rate limit on every call; reusing the 24h JWT keeps a script
+// that triggers often well under that ceiling. The cache is a best-effort
+// optimization: a stale or unreadable entry simply falls through to a fresh
+// handshake, and the trigger path re-authenticates on a 401 regardless.
+
+// cacheSkew trims a margin off a token's expiry so we re-handshake slightly
+// early rather than send a JWT the daemon is about to reject.
+const cacheSkew = 60 * time.Second
+
+type cachedToken struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"` // unix seconds; 0 means "unknown"
+}
+
+// tokenCachePath returns the per-user cache file path. It lives under the OS
+// cache dir, not the daemon's --data dir: a remote client has no data dir of
+// its own, and the file is keyed by daemon URL so one CLI can hold sessions
+// for several daemons.
+func tokenCachePath() (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "runwisp", "tokens.json"), nil
+}
+
+// loadCachedToken returns a non-expired cached JWT for baseURL, or "" when
+// none is usable. Any error (missing file, corrupt JSON, no cache dir) yields
+// "" so the caller falls through to a fresh handshake.
+func loadCachedToken(baseURL string) string {
+	path, err := tokenCachePath()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var cache map[string]cachedToken
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return ""
+	}
+	entry, ok := cache[normalizeBaseURL(baseURL)]
+	if !ok || entry.Token == "" {
+		return ""
+	}
+	if entry.ExpiresAt != 0 && time.Now().Add(cacheSkew).Unix() >= entry.ExpiresAt {
+		return ""
+	}
+	return entry.Token
+}
+
+// storeCachedToken persists token for baseURL, read-modify-writing the cache
+// map. Failures are logged at debug and swallowed — caching is an
+// optimization, never a precondition for the trigger.
+func storeCachedToken(baseURL, token string) {
+	path, err := tokenCachePath()
+	if err != nil {
+		slog.Debug("Skipping token cache: no user cache dir", "err", err)
+		return
+	}
+	cache := map[string]cachedToken{}
+	if data, readErr := os.ReadFile(path); readErr == nil {
+		_ = json.Unmarshal(data, &cache) // a corrupt file is simply overwritten
+	}
+	cache[normalizeBaseURL(baseURL)] = cachedToken{Token: token, ExpiresAt: jwtExpiry(token)}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		slog.Debug("Skipping token cache: marshal failed", "err", err)
+		return
+	}
+	if err := datadir.EnsureDir(filepath.Dir(path)); err != nil {
+		slog.Debug("Skipping token cache: cannot create cache dir", "err", err)
+		return
+	}
+	if err := datadir.WriteSecretFile(path, data); err != nil {
+		slog.Debug("Skipping token cache: write failed", "err", err)
+	}
+}
+
+// normalizeBaseURL matches apiclient.New's trimming so the cache key lines up
+// with the URL the client actually talks to.
+func normalizeBaseURL(baseURL string) string {
+	return strings.TrimRight(baseURL, "/")
+}
+
+// jwtExpiry pulls the `exp` claim (unix seconds) out of a JWT without
+// verifying its signature — the daemon already vouched for the token, we only
+// want its lifetime so we can drop it before it goes stale. Returns 0 when the
+// claim can't be read; callers treat 0 as "unknown" and lean on 401-retry.
+func jwtExpiry(token string) int64 {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return 0
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return 0
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return 0
+	}
+	return claims.Exp
+}

--- a/apps/runwisp/cmd/runwisp/remote_token_cache.go
+++ b/apps/runwisp/cmd/runwisp/remote_token_cache.go
@@ -13,6 +13,7 @@ import (
 
 	"log/slog"
 
+	"github.com/runwisp/runwisp/internal/apiclient"
 	"github.com/runwisp/runwisp/internal/datadir"
 )
 
@@ -61,7 +62,7 @@ func loadCachedToken(baseURL string) string {
 	if err := json.Unmarshal(data, &cache); err != nil {
 		return ""
 	}
-	entry, ok := cache[normalizeBaseURL(baseURL)]
+	entry, ok := cache[apiclient.NormalizeBaseURL(baseURL)]
 	if !ok || entry.Token == "" {
 		return ""
 	}
@@ -84,7 +85,7 @@ func storeCachedToken(baseURL, token string) {
 	if data, readErr := os.ReadFile(path); readErr == nil {
 		_ = json.Unmarshal(data, &cache) // a corrupt file is simply overwritten
 	}
-	cache[normalizeBaseURL(baseURL)] = cachedToken{Token: token, ExpiresAt: jwtExpiry(token)}
+	cache[apiclient.NormalizeBaseURL(baseURL)] = cachedToken{Token: token, ExpiresAt: jwtExpiry(token)}
 
 	data, err := json.Marshal(cache)
 	if err != nil {
@@ -98,12 +99,6 @@ func storeCachedToken(baseURL, token string) {
 	if err := datadir.WriteSecretFile(path, data); err != nil {
 		slog.Debug("Skipping token cache: write failed", "err", err)
 	}
-}
-
-// normalizeBaseURL matches apiclient.New's trimming so the cache key lines up
-// with the URL the client actually talks to.
-func normalizeBaseURL(baseURL string) string {
-	return strings.TrimRight(baseURL, "/")
 }
 
 // jwtExpiry pulls the `exp` claim (unix seconds) out of a JWT without

--- a/apps/runwisp/cmd/runwisp/remote_token_cache_test.go
+++ b/apps/runwisp/cmd/runwisp/remote_token_cache_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeJWT builds an unsigned-but-well-formed JWT carrying the given exp claim
+// (unix seconds). Only the payload segment is meaningful to jwtExpiry.
+func fakeJWT(exp int64) string {
+	payload, _ := json.Marshal(map[string]int64{"exp": exp})
+	seg := base64.RawURLEncoding.EncodeToString(payload)
+	return "header." + seg + ".signature"
+}
+
+// useTempCacheDir points os.UserCacheDir at a temp directory across platforms
+// (XDG_CACHE_HOME on Linux, HOME on macOS).
+func useTempCacheDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+	t.Setenv("HOME", dir)
+}
+
+func TestTokenCache_RoundTrip(t *testing.T) {
+	useTempCacheDir(t)
+	const url = "https://runwisp.example.com"
+
+	assert.Empty(t, loadCachedToken(url), "no token before any store")
+
+	token := fakeJWT(time.Now().Add(time.Hour).Unix())
+	storeCachedToken(url, token)
+
+	assert.Equal(t, token, loadCachedToken(url))
+	// Trailing-slash variants map to the same entry.
+	assert.Equal(t, token, loadCachedToken(url+"/"))
+}
+
+func TestTokenCache_DropsExpired(t *testing.T) {
+	useTempCacheDir(t)
+	const url = "https://runwisp.example.com"
+
+	storeCachedToken(url, fakeJWT(time.Now().Add(-time.Minute).Unix()))
+	assert.Empty(t, loadCachedToken(url), "an expired token must not be returned")
+}
+
+func TestTokenCache_UnknownExpiryIsKept(t *testing.T) {
+	useTempCacheDir(t)
+	const url = "https://runwisp.example.com"
+
+	// A token with no parseable exp claim has ExpiresAt 0 ("unknown") and is
+	// still handed back — the trigger path's 401-retry is the safety net.
+	storeCachedToken(url, "not-a-jwt")
+	assert.Equal(t, "not-a-jwt", loadCachedToken(url))
+}
+
+func TestTokenCache_CorruptFile(t *testing.T) {
+	useTempCacheDir(t)
+	cacheBase, err := os.UserCacheDir()
+	require.NoError(t, err)
+	path := filepath.Join(cacheBase, "runwisp", "tokens.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0600))
+
+	// Corrupt cache reads as "no token", and a subsequent store overwrites it.
+	assert.Empty(t, loadCachedToken("https://x"))
+	token := fakeJWT(time.Now().Add(time.Hour).Unix())
+	storeCachedToken("https://x", token)
+	assert.Equal(t, token, loadCachedToken("https://x"))
+}
+
+func TestTokenCache_SeparateURLs(t *testing.T) {
+	useTempCacheDir(t)
+	a := fakeJWT(time.Now().Add(time.Hour).Unix())
+	b := fakeJWT(time.Now().Add(time.Hour).Unix())
+	storeCachedToken("https://a.example.com", a)
+	storeCachedToken("https://b.example.com", b)
+	assert.Equal(t, a, loadCachedToken("https://a.example.com"))
+	assert.Equal(t, b, loadCachedToken("https://b.example.com"))
+}

--- a/apps/runwisp/cmd/runwisp/remote_token_cache_test.go
+++ b/apps/runwisp/cmd/runwisp/remote_token_cache_test.go
@@ -79,6 +79,62 @@ func TestTokenCache_CorruptFile(t *testing.T) {
 	assert.Equal(t, token, loadCachedToken("https://x"))
 }
 
+func TestTokenCache_MissingURLInPopulatedCache(t *testing.T) {
+	useTempCacheDir(t)
+	storeCachedToken("https://a.example.com", fakeJWT(time.Now().Add(time.Hour).Unix()))
+
+	// A different daemon URL has no entry in the otherwise-valid cache.
+	assert.Empty(t, loadCachedToken("https://b.example.com"))
+}
+
+// TestTokenCache_NoCacheDir forces os.UserCacheDir to fail (no XDG_CACHE_HOME
+// and no HOME) so both load and store fall through their error paths without a
+// panic — caching is best-effort and a missing cache dir must never break exec.
+func TestTokenCache_NoCacheDir(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("HOME", "")
+
+	_, err := tokenCachePath()
+	require.Error(t, err, "no cache dir is resolvable")
+
+	assert.Empty(t, loadCachedToken("https://x"))
+	assert.NotPanics(t, func() { storeCachedToken("https://x", "tok") })
+}
+
+// TestTokenCache_UnwritablePath points the cache at a path whose parent is a
+// regular file, so EnsureDir / WriteSecretFile fail. The store is swallowed and
+// the (unwritten) token reads back as absent.
+func TestTokenCache_UnwritablePath(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("not a dir"), 0600))
+	// os.UserCacheDir resolves to <blocker>, so tokenCachePath is
+	// <blocker>/runwisp/tokens.json — and <blocker> is a file, not a dir.
+	t.Setenv("XDG_CACHE_HOME", blocker)
+	t.Setenv("HOME", blocker)
+
+	assert.NotPanics(t, func() {
+		storeCachedToken("https://x", fakeJWT(time.Now().Add(time.Hour).Unix()))
+	})
+	assert.Empty(t, loadCachedToken("https://x"), "nothing was persisted")
+}
+
+func TestJWTExpiry(t *testing.T) {
+	t.Run("reads the exp claim", func(t *testing.T) {
+		assert.Equal(t, int64(1700000000), jwtExpiry(fakeJWT(1700000000)))
+	})
+	t.Run("wrong segment count is unknown", func(t *testing.T) {
+		assert.Equal(t, int64(0), jwtExpiry("only.two"))
+	})
+	t.Run("non-base64 payload is unknown", func(t *testing.T) {
+		assert.Equal(t, int64(0), jwtExpiry("header.!!!not-base64!!!.sig"))
+	})
+	t.Run("non-JSON payload is unknown", func(t *testing.T) {
+		seg := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+		assert.Equal(t, int64(0), jwtExpiry("header."+seg+".sig"))
+	})
+}
+
 func TestTokenCache_SeparateURLs(t *testing.T) {
 	useTempCacheDir(t)
 	a := fakeJWT(time.Now().Add(time.Hour).Unix())

--- a/apps/runwisp/internal/apiclient/client.go
+++ b/apps/runwisp/internal/apiclient/client.go
@@ -34,11 +34,19 @@ type Client struct {
 	local        bool
 }
 
+// NormalizeBaseURL trims a trailing slash so a base URL maps to a single
+// canonical form. New applies it to every Client; callers that key state by
+// daemon URL (e.g. the CLI's session-token cache) use it to line their key up
+// with the URL the client actually talks to.
+func NormalizeBaseURL(baseURL string) string {
+	return strings.TrimRight(baseURL, "/")
+}
+
 // New constructs a Client for a remote daemon. baseURL must be an http(s)
 // URL; the client will run CHAP via Authenticate to obtain a JWT.
 func New(baseURL, password string) *Client {
 	return &Client{
-		baseURL:  strings.TrimRight(baseURL, "/"),
+		baseURL:  NormalizeBaseURL(baseURL),
 		password: password,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,

--- a/apps/runwisp/internal/apiclient/client.go
+++ b/apps/runwisp/internal/apiclient/client.go
@@ -117,6 +117,18 @@ func (c *Client) IsAuthenticated() bool {
 	return c.local || c.token != ""
 }
 
+// SetToken seeds the client with a previously obtained JWT, letting callers
+// reuse a cached session instead of re-running CHAP on every invocation.
+func (c *Client) SetToken(token string) {
+	c.token = token
+}
+
+// Token returns the JWT the client is currently using (empty on Unix-socket
+// clients, which never hold one). Callers persist it to reuse the session.
+func (c *Client) Token() string {
+	return c.token
+}
+
 // IsLocal reports whether this client talks over a Unix socket. Callers can
 // use this to skip work (login prompts, password validation) that doesn't
 // apply on the local path.

--- a/apps/runwisp/internal/apiclient/client_test.go
+++ b/apps/runwisp/internal/apiclient/client_test.go
@@ -99,6 +99,49 @@ func TestAuthenticate(t *testing.T) {
 	assert.True(t, c.IsAuthenticated())
 }
 
+func TestSetTokenSkipsHandshake(t *testing.T) {
+	var sawAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/challenge", "/api/auth":
+			sawAuth = true
+			http.Error(w, "should not authenticate", http.StatusInternalServerError)
+		case "/api/tasks/my-task/run":
+			assert.Equal(t, "Bearer cached-jwt", r.Header.Get("Authorization"))
+			json.NewEncoder(w).Encode(model.Run{ID: "new-run"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.SetToken("cached-jwt")
+	assert.True(t, c.IsAuthenticated())
+	assert.Equal(t, "cached-jwt", c.Token())
+
+	run, err := c.TriggerRun("my-task")
+	require.NoError(t, err)
+	assert.Equal(t, "new-run", run.ID)
+	assert.False(t, sawAuth, "a seeded token must not trigger a CHAP handshake")
+}
+
+func TestTokenReturnsMintedValue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/challenge":
+			json.NewEncoder(w).Encode(map[string]string{"nonce": "n"})
+		case "/api/auth":
+			json.NewEncoder(w).Encode(map[string]string{"token": "fresh-jwt"})
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "pw")
+	require.NoError(t, c.Authenticate())
+	assert.Equal(t, "fresh-jwt", c.Token())
+}
+
 func TestAuthenticate_ChallengeError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "server error", http.StatusInternalServerError)

--- a/apps/runwisp/internal/cronspec/cronspec_test.go
+++ b/apps/runwisp/internal/cronspec/cronspec_test.go
@@ -161,6 +161,36 @@ func TestSpringForwardFiresOnce(t *testing.T) {
 	assert.True(t, want.Equal(next), "want %s, got %s", want, next.In(loc))
 }
 
+// TestScheduleParser_RejectsInvalidSpec confirms the DST-recovering parser
+// surfaces grammar errors from the underlying parser unchanged.
+func TestScheduleParser_RejectsInvalidSpec(t *testing.T) {
+	_, err := NewScheduleParser().Parse("every day at noon")
+	assert.Error(t, err)
+}
+
+// TestScheduleParser_EveryPassesThrough confirms an @every schedule
+// (ConstantDelaySchedule, not a wall-clock SpecSchedule) bypasses the DST-gap
+// wrapper and still advances by its fixed duration.
+func TestScheduleParser_EveryPassesThrough(t *testing.T) {
+	sched, err := NewScheduleParser().Parse("@every 1h")
+	require.NoError(t, err)
+
+	from := time.Date(2024, 6, 15, 0, 30, 0, 0, time.UTC)
+	got := sched.Next(from)
+	assert.True(t, from.Add(time.Hour).Equal(got), "want %s, got %s", from.Add(time.Hour), got)
+}
+
+// TestScheduleParser_NeverMatchingSpecReturnsZero covers the IsZero short-circuit:
+// "Feb 30" never occurs, so the underlying Next returns the zero time and the
+// wrapper hands it straight back without DST math.
+func TestScheduleParser_NeverMatchingSpecReturnsZero(t *testing.T) {
+	sched, err := NewScheduleParser().Parse("0 0 30 2 *")
+	require.NoError(t, err)
+
+	got := sched.Next(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	assert.True(t, got.IsZero(), "a spec that can never fire must yield the zero time")
+}
+
 // TestNonDSTDayUnaffected guards that the wrapper is a no-op on an ordinary day
 // with no transition between the evaluation point and the next firing.
 func TestNonDSTDayUnaffected(t *testing.T) {

--- a/apps/runwisp/internal/datadir/datadir.go
+++ b/apps/runwisp/internal/datadir/datadir.go
@@ -23,12 +23,14 @@ func EnsureDir(dir string) error {
 	return os.MkdirAll(dir, 0700)
 }
 
-// writeFileNoFollow writes data to path with mode 0600, refusing to follow
+// WriteSecretFile writes data to path with mode 0600, refusing to follow
 // symlinks. If path already exists, it must be a regular file owned by the
 // caller; otherwise the write is rejected. This prevents a TOCTOU symlink
-// attack where another local user replaces a data-dir file with a symlink to
-// a sensitive target the daemon can write (e.g. ~/.ssh/authorized_keys).
-func writeFileNoFollow(path string, data []byte) error {
+// attack where another local user replaces a file with a symlink to a
+// sensitive target the caller can write (e.g. ~/.ssh/authorized_keys). It is
+// the shared primitive for any secret-bearing file (PID file, daemon secrets,
+// the CLI's cached JWT); callers must EnsureDir the parent first.
+func WriteSecretFile(path string, data []byte) error {
 	if info, err := os.Lstat(path); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("refusing to write %s: path is a symlink", path)
@@ -79,7 +81,7 @@ func PidFilePath(dataDir string) string {
 }
 
 func WritePidFile(dataDir string) error {
-	return writeFileNoFollow(PidFilePath(dataDir), []byte(strconv.Itoa(os.Getpid())+"\n"))
+	return WriteSecretFile(PidFilePath(dataDir), []byte(strconv.Itoa(os.Getpid())+"\n"))
 }
 
 func ReadPidFile(dataDir string) (int, error) {

--- a/apps/runwisp/internal/datadir/datadir_test.go
+++ b/apps/runwisp/internal/datadir/datadir_test.go
@@ -157,13 +157,47 @@ func TestWritePidFile_OverwritesExistingRegularFile(t *testing.T) {
 
 func TestWritePidFile_RefusesNonRegularPath(t *testing.T) {
 	dataDir := t.TempDir()
-	// Replace the future PID file path with a directory; writeFileNoFollow must
+	// Replace the future PID file path with a directory; WriteSecretFile must
 	// reject "not a regular file" before any OpenFile attempt.
 	if err := os.MkdirAll(PidFilePath(dataDir), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := WritePidFile(dataDir); err == nil {
 		t.Fatal("expected WritePidFile to refuse non-regular path")
+	}
+}
+
+func TestWriteSecretFile_Perms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	if err := WriteSecretFile(path, []byte("shh")); err != nil {
+		t.Fatalf("WriteSecretFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("perm = %o, want 0600", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "shh" {
+		t.Fatalf("content = %q, want %q", data, "shh")
+	}
+}
+
+func TestWriteSecretFile_RefusesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteSecretFile(link, []byte("x")); err == nil {
+		t.Fatal("expected WriteSecretFile to refuse a symlink path")
 	}
 }
 

--- a/apps/runwisp/internal/server/api_types.go
+++ b/apps/runwisp/internal/server/api_types.go
@@ -20,6 +20,15 @@ type TaskRunInput struct {
 	RunID    string `path:"runId" minLength:"26" maxLength:"26" pattern:"^[0-9A-HJKMNP-TV-Z]{26}$" doc:"Run ULID"`
 }
 
+// TriggerRunInput drives POST /api/tasks/{taskName}/run. With wait=false
+// (default) it returns immediately with the pending run; with wait=true the
+// request blocks until the run finishes so a single call yields its exit code.
+type TriggerRunInput struct {
+	TaskName    string `path:"taskName" minLength:"1" maxLength:"100" pattern:"^[a-zA-Z0-9._:-]+$" doc:"Task name"`
+	Wait        bool   `query:"wait" doc:"Block until the run finishes and return the completed run (with exit_code and end_reason). Best for short tasks; long runs may exceed reverse-proxy timeouts — follow the log stream or poll instead."`
+	WaitTimeout int    `query:"wait_timeout" minimum:"1" maximum:"3600" default:"300" doc:"With wait=true, the maximum seconds to hold the request open. On timeout the run keeps running and the response returns it in its current (non-terminal) state."`
+}
+
 type RunsQueryInput struct {
 	Limit         int    `query:"limit" minimum:"1" maximum:"1000" default:"50" doc:"Max results per page"`
 	Offset        int    `query:"offset" minimum:"0" default:"0" doc:"Pagination offset"`

--- a/apps/runwisp/internal/server/run_service.go
+++ b/apps/runwisp/internal/server/run_service.go
@@ -119,6 +119,76 @@ func (s *runService) TriggerRun(ctx context.Context, taskName string) (*model.Ru
 	return s.taskManager.TriggerRun(taskName, model.TriggeredByAPI)
 }
 
+// terminalWaitBackstop is how often TriggerRunAndWait re-reads storage while
+// waiting. The in-memory event bus is best-effort (a slow consumer's event can
+// be dropped) and persistence is async, so neither is authoritative alone —
+// the poll is a cheap safety net that bounds worst-case latency if the live
+// event is missed.
+const terminalWaitBackstop = 2 * time.Second
+
+// TriggerRunAndWait triggers a run and blocks until it reaches a terminal state
+// or timeout elapses, returning the finished run (with exit_code / end_reason).
+// On timeout it returns the run in its latest known — possibly still running —
+// state; callers tell the two apart via the run's status. It exists so a remote
+// caller can fire a task and read its result in a single request instead of
+// trigger-then-poll.
+func (s *runService) TriggerRunAndWait(ctx context.Context, taskName string, timeout time.Duration) (*model.Run, error) {
+	// Subscribe before triggering: a fast task can finish and publish its
+	// terminal event before TriggerRun even returns, so we must already be
+	// listening. The handler forwards every terminal run; we filter by ID once
+	// we know it.
+	terminal := make(chan *model.Run, 64)
+	forward := func(e events.Event) {
+		if re, ok := e.Data.(events.RunEvent); ok && re.Run != nil {
+			select {
+			case terminal <- re.Run:
+			default: // full — the backstop poll will catch our run
+			}
+		}
+	}
+	unsubDone := s.eventBus.Subscribe(events.EventRunCompleted, forward)
+	defer unsubDone()
+	unsubFailed := s.eventBus.Subscribe(events.EventRunFailed, forward)
+	defer unsubFailed()
+
+	run, err := s.TriggerRun(ctx, taskName)
+	if err != nil {
+		return nil, err
+	}
+	return s.awaitTerminal(ctx, run, terminal, timeout), nil
+}
+
+// awaitTerminal blocks until run reaches a terminal state, timeout elapses, or
+// ctx is cancelled, returning the most authoritative run state it can find. It
+// races three signals: the live terminal event (filtered to our run), a
+// periodic storage re-read (backstop for a missed event), and the deadline.
+func (s *runService) awaitTerminal(ctx context.Context, run *model.Run, terminal <-chan *model.Run, timeout time.Duration) *model.Run {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(terminalWaitBackstop)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case r := <-terminal:
+			if r.ID == run.ID {
+				return r
+			}
+		case <-ticker.C:
+			if fresh, err := s.db.GetRun(ctx, run.ID); err == nil && fresh.Status == model.PhaseEnded {
+				return fresh
+			}
+		case <-waitCtx.Done():
+			// Deadline reached or client disconnected. Hand back the latest
+			// persisted state so the caller can see status != "ended".
+			if fresh, err := s.db.GetRun(ctx, run.ID); err == nil {
+				return fresh
+			}
+			return run
+		}
+	}
+}
+
 func (s *runService) RestartService(taskName string) error {
 	task, exists := s.tasks.Get(taskName)
 	if !exists {

--- a/apps/runwisp/internal/server/run_service_test.go
+++ b/apps/runwisp/internal/server/run_service_test.go
@@ -255,6 +255,24 @@ func TestTriggerRunAndWait_PropagatesTriggerError(t *testing.T) {
 	assert.ErrorIs(t, err, ErrTaskNotFound)
 }
 
+func TestTriggerRunAndWait_TimeoutWithGetRunErrorReturnsTriggeredRun(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	runner := new(mockTaskRunner)
+	bus := events.NewEventBus()
+	tasks := map[string]*model.Task{"t": {Name: "t", Kind: model.KindTask, APITrigger: true}}
+	svc := makeRunServiceWithBus(tasks, repo, runner, bus)
+
+	// No terminal event, and the deadline re-read of storage fails — the wait
+	// must still hand back the run it triggered rather than nil.
+	triggered := &model.Run{ID: "run-1", TaskName: "t", Status: model.PhasePending}
+	runner.On("TriggerRun", "t", model.TriggeredByAPI).Return(triggered, nil)
+	repo.On("GetRun", mock.Anything, "run-1").Return(nil, errors.New("db down"))
+
+	run, err := svc.TriggerRunAndWait(context.Background(), "t", 30*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, triggered, run)
+}
+
 func TestTriggerRun_RunnerError(t *testing.T) {
 	repo := new(testutil.MockRunRepository)
 	runner := new(mockTaskRunner)
@@ -269,6 +287,54 @@ func TestTriggerRun_RunnerError(t *testing.T) {
 	_, err := svc.TriggerRun(context.Background(), "t")
 	assert.ErrorIs(t, err, runnerErr)
 	runner.AssertExpectations(t)
+}
+
+// ---- humaTriggerRun ----
+
+func TestHumaTriggerRun_WaitReturnsTerminalRun(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	runner := new(mockTaskRunner)
+	bus := events.NewEventBus()
+	tasks := map[string]*model.Task{"t": {Name: "t", Kind: model.KindTask, APITrigger: true}}
+	svc := makeRunServiceWithBus(tasks, repo, runner, bus)
+	srv := &Server{runService: svc}
+
+	reason := model.ReasonSuccess
+	ended := &model.Run{ID: "run-1", TaskName: "t", Status: model.PhaseEnded, EndReason: &reason}
+	runner.On("TriggerRun", "t", model.TriggeredByAPI).
+		Return(&model.Run{ID: "run-1", TaskName: "t", Status: model.PhasePending}, nil).
+		Run(func(mock.Arguments) { bus.Publish(events.EventRunCompleted, events.RunEvent{Run: ended}) })
+	repo.On("GetRun", mock.Anything, "run-1").Return(ended, nil).Maybe()
+
+	out, err := srv.humaTriggerRun(context.Background(), &TriggerRunInput{TaskName: "t", Wait: true, WaitTimeout: 5})
+	require.NoError(t, err)
+	assert.Equal(t, model.PhaseEnded, out.Body.Status)
+}
+
+func TestHumaTriggerRun_WaitTaskNotFound(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	runner := new(mockTaskRunner)
+	bus := events.NewEventBus()
+	svc := makeRunServiceWithBus(map[string]*model.Task{}, repo, runner, bus)
+	srv := &Server{runService: svc}
+
+	_, err := srv.humaTriggerRun(context.Background(), &TriggerRunInput{TaskName: "missing", Wait: true, WaitTimeout: 5})
+	assert.Error(t, err)
+}
+
+func TestHumaTriggerRun_NoWaitReturnsPendingRun(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	runner := new(mockTaskRunner)
+	tasks := map[string]*model.Task{"t": {Name: "t", Kind: model.KindTask, APITrigger: true}}
+	svc := makeRunService(tasks, repo, runner)
+	srv := &Server{runService: svc}
+
+	pending := &model.Run{ID: "run-1", TaskName: "t", Status: model.PhasePending}
+	runner.On("TriggerRun", "t", model.TriggeredByAPI).Return(pending, nil)
+
+	out, err := srv.humaTriggerRun(context.Background(), &TriggerRunInput{TaskName: "t"})
+	require.NoError(t, err)
+	assert.Equal(t, model.PhasePending, out.Body.Status)
 }
 
 // ---- RestartService ----

--- a/apps/runwisp/internal/server/run_service_test.go
+++ b/apps/runwisp/internal/server/run_service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/runwisp/runwisp/internal/events"
 	"github.com/runwisp/runwisp/internal/model"
 	"github.com/runwisp/runwisp/internal/runtime"
 	"github.com/runwisp/runwisp/internal/storage"
@@ -96,6 +97,12 @@ func makeRunService(tasks map[string]*model.Task, repo *testutil.MockRunReposito
 	return newRunService(repo, runner, runtime.NewTaskRegistry(tasks), nil, "", nil)
 }
 
+// makeRunServiceWithBus is the wait-aware variant: TriggerRunAndWait observes
+// terminal events on the bus, so it needs a real one rather than nil.
+func makeRunServiceWithBus(tasks map[string]*model.Task, repo *testutil.MockRunRepository, runner *mockTaskRunner, bus events.EventBus) *runService {
+	return newRunService(repo, runner, runtime.NewTaskRegistry(tasks), nil, "", bus)
+}
+
 // ---- mapNotFound ----
 
 func TestMapNotFound_TranslatesStorageErrNotFound(t *testing.T) {
@@ -164,6 +171,88 @@ func TestTriggerRun_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expected, run)
 	runner.AssertExpectations(t)
+}
+
+// ---- TriggerRunAndWait ----
+
+func TestTriggerRunAndWait_ReturnsTerminalRunFromEvent(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	runner := new(mockTaskRunner)
+	bus := events.NewEventBus()
+	tasks := map[string]*model.Task{"t": {Name: "t", Kind: model.KindTask, APITrigger: true}}
+	svc := makeRunServiceWithBus(tasks, repo, runner, bus)
+
+	reason := model.ReasonFailed
+	ended := &model.Run{ID: "run-1", TaskName: "t", Status: model.PhaseEnded, ExitCode: 7, EndReason: &reason}
+	// The subscription is active before TriggerRun runs, so publishing the
+	// terminal event as a side effect of the trigger mimics a fast task.
+	runner.On("TriggerRun", "t", model.TriggeredByAPI).
+		Return(&model.Run{ID: "run-1", TaskName: "t", Status: model.PhasePending}, nil).
+		Run(func(mock.Arguments) {
+			bus.Publish(events.EventRunCompleted, events.RunEvent{Run: ended})
+		})
+	// Backstop poll shouldn't fire within the test window, but allow it.
+	repo.On("GetRun", mock.Anything, "run-1").Return(ended, nil).Maybe()
+
+	run, err := svc.TriggerRunAndWait(context.Background(), "t", 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, model.PhaseEnded, run.Status)
+	assert.Equal(t, 7, run.ExitCode)
+	require.NotNil(t, run.EndReason)
+	assert.Equal(t, model.ReasonFailed, *run.EndReason)
+}
+
+func TestTriggerRunAndWait_IgnoresOtherRunsEvents(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	runner := new(mockTaskRunner)
+	bus := events.NewEventBus()
+	tasks := map[string]*model.Task{"t": {Name: "t", Kind: model.KindTask, APITrigger: true}}
+	svc := makeRunServiceWithBus(tasks, repo, runner, bus)
+
+	reason := model.ReasonSuccess
+	ours := &model.Run{ID: "run-1", TaskName: "t", Status: model.PhaseEnded, EndReason: &reason}
+	runner.On("TriggerRun", "t", model.TriggeredByAPI).
+		Return(&model.Run{ID: "run-1", TaskName: "t", Status: model.PhasePending}, nil).
+		Run(func(mock.Arguments) {
+			// A different run's terminal event must not satisfy our wait.
+			bus.Publish(events.EventRunCompleted, events.RunEvent{Run: &model.Run{ID: "other", Status: model.PhaseEnded}})
+			bus.Publish(events.EventRunCompleted, events.RunEvent{Run: ours})
+		})
+	repo.On("GetRun", mock.Anything, "run-1").Return(ours, nil).Maybe()
+
+	run, err := svc.TriggerRunAndWait(context.Background(), "t", 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "run-1", run.ID)
+	assert.Equal(t, model.PhaseEnded, run.Status)
+}
+
+func TestTriggerRunAndWait_TimeoutReturnsCurrentState(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	runner := new(mockTaskRunner)
+	bus := events.NewEventBus()
+	tasks := map[string]*model.Task{"t": {Name: "t", Kind: model.KindTask, APITrigger: true}}
+	svc := makeRunServiceWithBus(tasks, repo, runner, bus)
+
+	// No terminal event is published, so the wait times out and falls back to
+	// the latest persisted state — still running.
+	runner.On("TriggerRun", "t", model.TriggeredByAPI).
+		Return(&model.Run{ID: "run-1", TaskName: "t", Status: model.PhasePending}, nil)
+	running := &model.Run{ID: "run-1", TaskName: "t", Status: model.PhaseRunning}
+	repo.On("GetRun", mock.Anything, "run-1").Return(running, nil)
+
+	run, err := svc.TriggerRunAndWait(context.Background(), "t", 30*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, model.PhaseRunning, run.Status, "timeout must surface the still-running run")
+}
+
+func TestTriggerRunAndWait_PropagatesTriggerError(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	runner := new(mockTaskRunner)
+	bus := events.NewEventBus()
+	svc := makeRunServiceWithBus(map[string]*model.Task{}, repo, runner, bus)
+
+	_, err := svc.TriggerRunAndWait(context.Background(), "missing", time.Second)
+	assert.ErrorIs(t, err, ErrTaskNotFound)
 }
 
 func TestTriggerRun_RunnerError(t *testing.T) {

--- a/apps/runwisp/internal/server/runs.go
+++ b/apps/runwisp/internal/server/runs.go
@@ -108,6 +108,7 @@ func (srv *Server) registerProtectedHumaRoutes(r chi.Router) {
 		Method:        http.MethodPost,
 		Path:          "/api/tasks/{taskName}/run",
 		Summary:       "Trigger a new run",
+		Description:   "Triggers the task and returns the pending run immediately. Pass `wait=true` to instead hold the request open until the run finishes and return it with its exit code and end reason — a one-call alternative to triggering then polling.",
 		Tags:          []string{"Runs"},
 		DefaultStatus: http.StatusCreated,
 	}, srv.humaTriggerRun)
@@ -243,7 +244,14 @@ func (srv *Server) humaGetTaskRuns(ctx context.Context, input *TaskRunsQueryInpu
 	return &RunsOutput{Body: RunsResponseBody{Runs: result.Runs, Total: result.Total}}, nil
 }
 
-func (srv *Server) humaTriggerRun(ctx context.Context, input *TaskNameInput) (*TriggerRunOutput, error) {
+func (srv *Server) humaTriggerRun(ctx context.Context, input *TriggerRunInput) (*TriggerRunOutput, error) {
+	if input.Wait {
+		run, err := srv.runService.TriggerRunAndWait(ctx, input.TaskName, time.Duration(input.WaitTimeout)*time.Second)
+		if err != nil {
+			return nil, mapDomainError(err, "Failed to trigger run")
+		}
+		return &TriggerRunOutput{Body: *run}, nil
+	}
 	run, err := srv.runService.TriggerRun(ctx, input.TaskName)
 	if err != nil {
 		return nil, mapDomainError(err, "Failed to trigger run")

--- a/apps/runwisp/openapi.json
+++ b/apps/runwisp/openapi.json
@@ -2916,6 +2916,7 @@
     },
     "/api/tasks/{taskName}/run": {
       "post": {
+        "description": "Triggers the task and returns the pending run immediately. Pass `wait=true` to instead hold the request open until the run finishes and return it with its exit code and end reason — a one-call alternative to triggering then polling.",
         "operationId": "triggerRun",
         "parameters": [
           {
@@ -2929,6 +2930,30 @@
               "minLength": 1,
               "pattern": "^[a-zA-Z0-9._:-]+$",
               "type": "string"
+            }
+          },
+          {
+            "description": "Block until the run finishes and return the completed run (with exit_code and end_reason). Best for short tasks; long runs may exceed reverse-proxy timeouts — follow the log stream or poll instead.",
+            "explode": false,
+            "in": "query",
+            "name": "wait",
+            "schema": {
+              "description": "Block until the run finishes and return the completed run (with exit_code and end_reason). Best for short tasks; long runs may exceed reverse-proxy timeouts — follow the log stream or poll instead.",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "With wait=true, the maximum seconds to hold the request open. On timeout the run keeps running and the response returns it in its current (non-terminal) state.",
+            "explode": false,
+            "in": "query",
+            "name": "wait_timeout",
+            "schema": {
+              "default": 300,
+              "description": "With wait=true, the maximum seconds to hold the request open. On timeout the run keeps running and the response returns it in its current (non-terminal) state.",
+              "format": "int64",
+              "maximum": 3600,
+              "minimum": 1,
+              "type": "integer"
             }
           }
         ],

--- a/packages/common/src/generated/api.ts
+++ b/packages/common/src/generated/api.ts
@@ -403,7 +403,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Trigger a new run */
+        /**
+         * Trigger a new run
+         * @description Triggers the task and returns the pending run immediately. Pass `wait=true` to instead hold the request open until the run finishes and return it with its exit code and end reason — a one-call alternative to triggering then polling.
+         */
         post: operations["triggerRun"];
         delete?: never;
         options?: never;
@@ -2122,7 +2125,12 @@ export interface operations {
     };
     triggerRun: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Block until the run finishes and return the completed run (with exit_code and end_reason). Best for short tasks; long runs may exceed reverse-proxy timeouts — follow the log stream or poll instead. */
+                wait?: boolean;
+                /** @description With wait=true, the maximum seconds to hold the request open. On timeout the run keeps running and the response returns it in its current (non-terminal) state. */
+                wait_timeout?: number;
+            };
             header?: never;
             path: {
                 /** @description Task name */


### PR DESCRIPTION
Trigger a single task on a remote daemon from one command or one HTTP call. `runwisp exec --url` logs in over CHAP, follows the live log stream, and exits with the task's exit code, caching the JWT session so repeated calls don't re-authenticate. `--detach` fires and prints the run ID.

On the REST side, `POST /api/tasks/{name}/run?wait=true` blocks until the run finishes and returns the completed run (with exit_code), bounded by wait_timeout, so callers get the result in one request instead of a trigger-then-poll loop.

Adds the "Trigger via API" recipe documenting both the CLI and REST paths (synchronous wait plus a poll fallback for long jobs).