### PR TITLE
WebUI: Scroll the selected run into view in the virtualized run list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Selecting a run scrolls its row into view.** Opening a run from a deep link or the detail panel now brings its row on screen in the (virtualized) run list, so the highlight is always visible; an already-visible selection doesn't move. See [Web UI tour](https://docs.runwisp.com/getting-started/web-ui-tour/).
 - **Login hardened with PBKDF2.** The password challenge-response now derives its answer with PBKDF2-HMAC-SHA256 (600,000 rounds) instead of a single hash, making a captured login transcript far costlier to brute-force offline. See [Auth](https://docs.runwisp.com/operations/auth/#network-clients-web-ui-remote-rest).
 - **Web UI is push-driven, over one SSE connection shared across all tabs.** A single `/api/stream` feed (run lifecycle, system samples, config-staleness, notifications) replaces timer polling and the stream-per-concern model; an elected leader tab holds the one connection and rebroadcasts to the rest, so any number of open tabs can't exhaust the browser's per-origin connection limit. If live updates ever do stall, the UI flags it ("Updates paused") and recovers on its own.
 

--- a/apps/ui/e2e/runs-page.spec.ts
+++ b/apps/ui/e2e/runs-page.spec.ts
@@ -128,6 +128,55 @@ test.describe("runs page", () => {
             .toBe(true);
     });
 
+    test("a deep-linked run below the fold scrolls into view", async ({
+        authenticatedPage: page,
+        daemonState,
+    }) => {
+        // Trigger the target first, then a stack of newer runs so the target sits
+        // well below the fold on the newest-first list. The rail only renders its
+        // visible window (virtualized), so the target's row is absent from the DOM
+        // until the list scrolls to it — which is exactly the behaviour under test.
+        const target = await triggerRunViaAPI(page, "echo-task", daemonState.token);
+        for (let i = 0; i < 20; i++) {
+            await triggerRunViaAPI(page, "echo-task", daemonState.token);
+        }
+
+        // Deep link straight to the (old) target run.
+        await page.goto(`/runs/${target.id}`);
+
+        // The detail panel confirms the target is the selected run.
+        await expect(page.getByText(target.id)).toBeVisible({ timeout: 10_000 });
+
+        // The active row is the one run-row button carrying the selected styling
+        // (`bg-surface-raised`); `btn-scale` is unique to run rows, so this can't
+        // collide with buttons in the detail panel or with runs seeded by other
+        // specs. It must have been scrolled into the viewport.
+        const activeRow = page.getByRole("main").locator("button.btn-scale.bg-surface-raised");
+        await expect(activeRow).toBeInViewport({ timeout: 10_000 });
+    });
+
+    test("selecting an already-visible run does not scroll the list", async ({
+        authenticatedPage: page,
+        daemonState,
+    }) => {
+        // A handful of runs so several rows sit above the fold together.
+        for (let i = 0; i < 5; i++) {
+            await triggerRunViaAPI(page, "echo-task", daemonState.token);
+        }
+
+        await page.goto("/runs");
+        const rows = page.getByRole("main").locator("button.btn-scale");
+        await expect(rows.first()).toBeInViewport();
+
+        // The top row is visible; clicking a lower — but still visible — row uses
+        // "auto" alignment, which only scrolls when a row is off-screen. So the
+        // top row must stay in view: a calm, non-jerky selection.
+        const topRow = rows.first();
+        await expect(topRow).toBeInViewport();
+        await rows.nth(2).click();
+        await expect(topRow).toBeInViewport();
+    });
+
     test("an execution is linkable on the cross-task view", async ({
         authenticatedPage: page,
         daemonState,

--- a/packages/ui/src/lib/components/dashboard/RunsList.svelte
+++ b/packages/ui/src/lib/components/dashboard/RunsList.svelte
@@ -119,8 +119,8 @@
         outputSearchPending?: boolean;
     } = $props();
 
-    // Task-rail rows are a single dense line (artifact ".run", 46px); the
-    // cross-task /runs view adds the task name on a second line (64px).
+    // Task-rail rows are one dense line (44px); the cross-task /runs view adds
+    // the task name on a second line (64px).
     const rowHeight = $derived(showTaskName ? 64 : 44);
     const OVERSCAN = 8;
     const LOAD_AHEAD = 10;
@@ -201,6 +201,29 @@
         if (loading) return;
         if (items.length >= total) return;
         if (last.index >= items.length - LOAD_AHEAD) onLoadMore?.();
+    });
+
+    // Scroll a programmatically-selected run (deep link, detail-panel click) into
+    // view, since its row may be outside the virtual window. Tracked on
+    // selectedRunId/items only; the virtualizer access is untracked to avoid the
+    // setOptions-style notify loop (effect_update_depth_exceeded, see above).
+    let lastScrolled: string | null = null;
+    $effect(() => {
+        const id = selectedRunId;
+        const index = items.findIndex((r: Run) => r.id === id);
+        if (!id) {
+            lastScrolled = null;
+            return;
+        }
+        // -1: not loaded yet. The effect re-runs as items grows, so a deep link
+        // resolves once its page arrives; we don't chase it with onLoadMore.
+        if (index === -1) return;
+        if (id === lastScrolled) return; // already handled; don't re-yank on re-render
+        if (!scrollElement) return;
+        lastScrolled = id;
+        // "auto" only scrolls when the row is off-screen, so visible selections
+        // (and manual clicks) don't jump.
+        untrack(() => $virtualizer.scrollToIndex(index, { align: "auto" }));
     });
 
     function isRowSelected(id: string): boolean {
@@ -361,7 +384,6 @@
         ? "flex h-full w-full flex-col overflow-hidden border-b border-outline bg-surface md:w-[300px] md:shrink-0 md:border-r md:border-b-0"
         : "flex flex-col overflow-hidden rounded-xl border border-outline bg-surface-raised shadow-sm md:col-span-4 lg:col-span-3"}
 >
-    <!-- Inline heading: master checkbox, label, selection count or controls -->
     <div
         class="flex shrink-0 items-center gap-2 border-b px-3 py-2 {hasSelection
             ? 'border-outline-faint bg-primary-soft/40'


### PR DESCRIPTION
A programmatically-selected run (deep link or detail-panel click) whose row falls outside the current virtual window is now scrolled into view with minimal-movement alignment, so its highlight is always visible while already-visible selections and manual clicks don't jump.
