### PR TITLE
Web UI: restart a running service in one action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Restart a running service in one click.** A running service now shows a direct **Restart** button (alongside **Stop**) instead of only revealing it after a stop — restarting is one confirmed action, not stop-then-restart. See [Web UI tour](https://docs.runwisp.com/getting-started/web-ui-tour/).
 - **Selecting a run scrolls its row into view.** Opening a run from a deep link or the detail panel now brings its row on screen in the (virtualized) run list, so the highlight is always visible; an already-visible selection doesn't move. See [Web UI tour](https://docs.runwisp.com/getting-started/web-ui-tour/).
 - **Login hardened with PBKDF2.** The password challenge-response now derives its answer with PBKDF2-HMAC-SHA256 (600,000 rounds) instead of a single hash, making a captured login transcript far costlier to brute-force offline. See [Auth](https://docs.runwisp.com/operations/auth/#network-clients-web-ui-remote-rest).
 - **Web UI is push-driven, over one SSE connection shared across all tabs.** A single `/api/stream` feed (run lifecycle, system samples, config-staleness, notifications) replaces timer polling and the stream-per-concern model; an elected leader tab holds the one connection and rebroadcasts to the rest, so any number of open tabs can't exhaust the browser's per-origin connection limit. If live updates ever do stall, the UI flags it ("Updates paused") and recovers on its own.

--- a/apps/ui/src/lib/components/dashboard/TaskPage.svelte
+++ b/apps/ui/src/lib/components/dashboard/TaskPage.svelte
@@ -398,10 +398,12 @@
 
 <Modal
     bind:open={restartConfirmOpen}
-    title="Restart Service"
-    description={instanceCount > 1
-        ? `Cancel and restart all ${instanceCount} instances of ${task.name}?`
-        : `Cancel and restart ${task.name}?`}
+    title={serviceStopped ? "Start Service" : "Restart Service"}
+    description={serviceStopped
+        ? `Start ${task.name}?`
+        : instanceCount > 1
+          ? `Cancel and restart all ${instanceCount} instances of ${task.name}?`
+          : `Cancel and restart ${task.name}?`}
     size="sm"
 >
     {#snippet footer()}
@@ -411,9 +413,9 @@
                 restartConfirmOpen = false;
                 onRestart?.();
             },
-            "Restart Now",
+            serviceStopped ? "Start Now" : "Restart Now",
             "primary",
-            RefreshCcw,
+            serviceStopped ? Play : RefreshCcw,
         )}
     {/snippet}
 </Modal>

--- a/packages/ui/src/lib/components/dashboard/RunDetailPanel.svelte
+++ b/packages/ui/src/lib/components/dashboard/RunDetailPanel.svelte
@@ -473,20 +473,32 @@
                         {/if}
 
                         {#if onStopService || onRestartService}
-                            <!-- Service lifecycle replaces the run control. -->
-                            {#if serviceStopped}
-                                {#if onRestartService}
-                                    <button
-                                        type="button"
-                                        onclick={() => onRestartService()}
-                                        disabled={serviceBusy}
-                                        class="inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border border-primary-soft bg-surface-raised px-3 text-sm font-medium text-primary transition-colors hover:bg-primary-soft disabled:cursor-not-allowed disabled:opacity-60"
-                                    >
+                            <!-- Service lifecycle replaces the run control.
+                             Restart is always available (it cancels + respawns
+                             all instances in one call); Stop appears only while
+                             the service is running. Each still confirms, so
+                             neither fires accidentally. -->
+                            {#if onRestartService}
+                                <button
+                                    type="button"
+                                    onclick={() => onRestartService()}
+                                    disabled={serviceBusy}
+                                    title={serviceStopped
+                                        ? "Starts the service"
+                                        : "Cancels and respawns every instance"}
+                                    class="inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border border-primary-soft bg-surface-raised px-3 text-sm font-medium text-primary transition-colors hover:bg-primary-soft disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                    {#if serviceStopped}
+                                        <Play size={15} fill="currentColor" stroke="none" />
+                                    {:else}
                                         <RefreshCcw size={15} />
-                                        <span class="@max-md:hidden">Restart Service</span>
-                                    </button>
-                                {/if}
-                            {:else if onStopService}
+                                    {/if}
+                                    <span class="@max-md:hidden"
+                                        >{serviceStopped ? "Start" : "Restart"}</span
+                                    >
+                                </button>
+                            {/if}
+                            {#if !serviceStopped && onStopService}
                                 <button
                                     type="button"
                                     onclick={() => onStopService()}


### PR DESCRIPTION
## Problem

Restarting a service in the web UI took **4 clicks**: *Stop Service* → confirm → *Restart Service* → confirm. The UI only revealed the "Restart Service" button *after* a stop, even though restart is a single atomic backend call (`POST /api/tasks/{name}/restart`, which cancels + respawns all instances in one operation). The leading stop step was redundant.

## Change

- A running service now shows a direct **Restart** button alongside **Stop Service** — restart is one confirmed action (2 clicks), not stop-then-restart. Both still go through their existing single confirmation modal, so neither fires accidentally.
- When the service is stopped, the bring-it-back-up action now reads **Start** (Play icon, "Start {name}?") instead of "Restart", which was misleading when nothing is running to cancel.

No backend, TOML, API, or OpenAPI changes — this is purely UI button visibility and copy. `TaskPage` already passed both callbacks to their confirm modals; the gap was `RunDetailPanel` rendering Restart and Stop as mutually exclusive.

## Files

- `packages/ui/src/lib/components/dashboard/RunDetailPanel.svelte` — show Restart while running; Start icon/label when stopped.
- `apps/ui/src/lib/components/dashboard/TaskPage.svelte` — restart confirm modal copy/icon conditional on stopped state.
- `CHANGELOG.md` — entry under Unreleased → Changed.

## Verification

- `bunx moon run web-ui:build` and `web-ui:check` pass (0 type errors, Prettier clean).
- Manual smoke: with a `kind = "service"` task, a running service shows Restart + Stop; Restart confirms and recycles instances; Stop collapses to a single Start button whose modal reads "Start Service".