### PR TITLE
Render daemon log lines as readable text instead of Go's terse logfmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Readable daemon logs.** Log lines now render as `2026-05-27 14:03:01 [INFO] message key=value` — colored on an interactive terminal, plain otherwise — instead of Go's terse `level=INFO msg=…` logfmt. `--log-format=json` is unchanged for pipelines. See [Logging](https://docs.runwisp.com/operations/logging/).
+
 ## [0.12.0] - 2026-07-08
 
 ### Added

--- a/apps/docs/src/content/docs/operations/logging.mdx
+++ b/apps/docs/src/content/docs/operations/logging.mdx
@@ -21,9 +21,9 @@ truth; how the daemon logs about them is not.)
 In daemon mode every run transition produces one concise line:
 
 ```
-time=2026-05-27T14:03:01.412+02:00 level=INFO msg="run started" task=backup run=01J...
-time=2026-05-27T14:03:04.918+02:00 level=INFO msg="run succeeded" task=backup run=01J... exit=0 dur=3.5s
-time=2026-05-27T14:07:00.231+02:00 level=WARN msg="run failed" task=report run=01J... exit=2 reason=failed dur=412ms
+2026-05-27 14:03:01 [INFO] run started task=backup run=01J...
+2026-05-27 14:03:04 [INFO] run succeeded task=backup run=01J... exit=0 dur=3.5s
+2026-05-27 14:07:00 [WARN] run failed task=report run=01J... exit=2 reason=failed dur=412ms
 ```
 
 That's it — start, success, failure, and a warning if a task hits the disk-space
@@ -47,11 +47,11 @@ no silent fallback to `info`.
 
 `--log-format` (or `RUNWISP_LOG_FORMAT`) picks the shape:
 
-| Value            | Output                                                               |
-| ---------------- | -------------------------------------------------------------------- |
-| `auto` (default) | Colored text on an interactive terminal; plain text everywhere else. |
-| `text`           | Text handler (color still gated by TTY / `NO_COLOR`).                |
-| `json`           | One JSON object per line — for Docker/k8s log pipelines, Loki, etc.  |
+| Value            | Output                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------- |
+| `auto` (default) | Readable `2026-… [INFO] message key=value` lines — colored on an interactive terminal, plain everywhere else. |
+| `text`           | The same readable lines, never colored (plain even on a terminal).                                            |
+| `json`           | One JSON object per line — for Docker/k8s log pipelines, Loki, etc.                                           |
 
 ```sh
 RUNWISP_LOG_FORMAT=json runwisp daemon
@@ -75,26 +75,26 @@ RunWisp detects whether stderr is a real terminal. When it isn't — piped into
 `docker logs`, journald, or a file — it automatically:
 
 - drops ANSI color (so you don't get escape-code garbage in your log files), and
-- replaces the multi-section startup banner with a handful of plain `msg=...`
-  lines carrying the same facts (version, paths, task count, warnings).
+- replaces the multi-section startup banner with a handful of plain `[INFO]`
+  summary lines carrying the same facts (version, paths, task count, warnings).
 
 The standard [`NO_COLOR`](https://no-color.org/) environment variable also
 disables color on a terminal, and `--log-format=json` is always colorless.
 
 ## Timestamps
 
-Text output is timestamped with RFC3339 (millisecond precision) in daemon mode —
+Text output is timestamped `2026-05-27 14:03:01` (local time) in daemon mode —
 a long-running process needs to record _when_ things happened. The one exception:
 under **systemd** (detected via `JOURNAL_STREAM`), RunWisp drops its own
-timestamps because journald already prepends them. JSON output always keeps the
-`time` field.
+timestamps because journald already prepends them. JSON output always keeps a
+full-precision RFC3339 `time` field.
 
 ## Readiness and shutdown
 
 Once the daemon's local API answers, it logs an accurate readiness line:
 
 ```
-msg="ready, listening" url=http://localhost:9477
+[INFO] ready, listening url=http://localhost:9477
 ```
 
 The URL respects [`[daemon] external_url`](/configuration/daemon/#external_url)
@@ -105,10 +105,10 @@ On `Ctrl+C` / `SIGTERM` the daemon names the signal, narrates the drain (HTTP
 requests, then scheduler and in-flight runs), and prints the total elapsed time:
 
 ```
-msg="received signal, shutting down" signal=interrupt
-msg="draining HTTP requests and closing cloud connection"
-msg="stopping scheduler and waiting for in-flight runs" in_flight=1 timeout=30s
-msg="shutdown complete" elapsed=842ms
+[INFO] received signal, shutting down signal=interrupt
+[INFO] draining HTTP requests and closing cloud connection
+[INFO] stopping scheduler and waiting for in-flight runs in_flight=1 timeout=30s
+[INFO] shutdown complete elapsed=842ms
 ```
 
 ---

--- a/apps/runwisp/cmd/runwisp/cmd_run.go
+++ b/apps/runwisp/cmd/runwisp/cmd_run.go
@@ -331,7 +331,7 @@ func configureBootLogRouting(logBuffer *server.DaemonLogBuffer, f Flags, headles
 		clilog.Configure(clilog.Options{
 			Level:      f.LogLevel,
 			Format:     f.LogFormat,
-			Output:     io.MultiWriter(os.Stderr, logBuffer),
+			Output:     io.MultiWriter(os.Stderr, clilog.NewPlainWriter(logBuffer)),
 			DaemonMode: true,
 		})
 		return nil

--- a/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
+++ b/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
@@ -396,7 +396,7 @@ func runWithTUI(rt *daemonRuntime, info uikit.StartupInfo, f Flags) error {
 		clilog.Configure(clilog.Options{
 			Level:      f.LogLevel,
 			Format:     f.LogFormat,
-			Output:     io.MultiWriter(os.Stderr, rt.logBuffer),
+			Output:     io.MultiWriter(os.Stderr, clilog.NewPlainWriter(rt.logBuffer)),
 			DaemonMode: true,
 		})
 		defer runlog.Subscribe(rt.svc.EventBus)()

--- a/apps/runwisp/internal/clilog/clilog.go
+++ b/apps/runwisp/internal/clilog/clilog.go
@@ -8,6 +8,7 @@
 package clilog
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-isatty"
 	"github.com/muesli/termenv"
 )
@@ -137,19 +139,44 @@ func applyHandler(opts Options) {
 	if out == nil {
 		out = os.Stderr
 	}
-	hopts := &slog.HandlerOptions{Level: opts.Level}
-	if !includeTime(opts) {
-		hopts.ReplaceAttr = dropTimeAttr
-	}
 	var h slog.Handler
 	if opts.Format == FormatJSON {
-		h = slog.NewJSONHandler(out, hopts)
+		// JSON always keeps its own time field, so no ReplaceAttr is needed.
+		h = slog.NewJSONHandler(out, &slog.HandlerOptions{Level: opts.Level})
 	} else {
-		// The text handler already formats time as RFC3339 with millis, so no
-		// ReplaceAttr is needed when timestamps are kept.
-		h = slog.NewTextHandler(out, hopts)
+		// Both text formats use the human-readable pretty handler; color is the
+		// only difference (see useColor). JSON stays machine-shaped for pipelines.
+		h = newPrettyHandler(out, opts.Level, includeTime(opts), useColor(opts))
 	}
 	slog.SetDefault(slog.New(h))
+}
+
+// useColor reports whether the pretty handler should emit ANSI color. Color is
+// for an interactive terminal only: --log-format=text is the explicit plain
+// escape hatch, NO_COLOR / non-TTY force plain, and the TUI owns its own screen.
+func useColor(opts Options) bool {
+	return opts.Format == FormatAuto && stderrTTY && !noColor && !opts.TUIMode
+}
+
+// NewPlainWriter returns an io.Writer that strips ANSI escape sequences before
+// delegating to w. It lets the colored daemon stream be mirrored into a plain
+// destination — the daemon log ring buffer, which is replayed/streamed over SSE
+// to remote TUI clients — without leaking escape codes into it. Writes with no
+// escape byte pass straight through, so the no-color path costs nothing.
+func NewPlainWriter(w io.Writer) io.Writer {
+	return &plainWriter{w: w}
+}
+
+type plainWriter struct{ w io.Writer }
+
+func (p *plainWriter) Write(b []byte) (int, error) {
+	if !bytes.ContainsRune(b, 0x1b) {
+		return p.w.Write(b)
+	}
+	if _, err := io.WriteString(p.w, ansi.Strip(string(b))); err != nil {
+		return 0, err
+	}
+	return len(b), nil
 }
 
 func includeTime(opts Options) bool {
@@ -161,11 +188,4 @@ func includeTime(opts Options) bool {
 	}
 	// systemd journal prepends its own timestamps; ours would be redundant.
 	return os.Getenv("JOURNAL_STREAM") == ""
-}
-
-func dropTimeAttr(_ []string, a slog.Attr) slog.Attr {
-	if a.Key == slog.TimeKey {
-		return slog.Attr{}
-	}
-	return a
 }

--- a/apps/runwisp/internal/clilog/clilog_test.go
+++ b/apps/runwisp/internal/clilog/clilog_test.go
@@ -63,8 +63,11 @@ func TestConfigure_DaemonModeIncludesTimestamp(t *testing.T) {
 	Configure(Options{Level: slog.LevelInfo, Format: FormatText, Output: buf, DaemonMode: true})
 
 	slog.Info("hello")
-	assert.Contains(t, buf.String(), "time=", "daemon mode must timestamp every line")
+	assert.Regexp(t, timestampRE, buf.String(), "daemon mode must timestamp every line")
 }
+
+// timestampRE matches the pretty handler's "2006-01-02 15:04:05" datetime prefix.
+const timestampRE = `\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}`
 
 func TestConfigure_JournalStreamSuppressesTimestamp(t *testing.T) {
 	t.Setenv("JOURNAL_STREAM", "8:123456")
@@ -72,7 +75,7 @@ func TestConfigure_JournalStreamSuppressesTimestamp(t *testing.T) {
 	Configure(Options{Level: slog.LevelInfo, Format: FormatText, Output: buf, DaemonMode: true})
 
 	slog.Info("hello")
-	assert.NotContains(t, buf.String(), "time=", "systemd adds its own timestamps; ours would be redundant")
+	assert.NotRegexp(t, timestampRE, buf.String(), "systemd adds its own timestamps; ours would be redundant")
 }
 
 func TestConfigure_CLIAndTUIModeSuppressTimestamp(t *testing.T) {
@@ -84,7 +87,7 @@ func TestConfigure_CLIAndTUIModeSuppressTimestamp(t *testing.T) {
 		buf := captureSlog(t)
 		Configure(Options{Level: opts.Level, Format: opts.Format, Output: buf, TUIMode: opts.TUIMode})
 		slog.Info("hello")
-		assert.NotContains(t, buf.String(), "time=")
+		assert.NotRegexp(t, timestampRE, buf.String())
 	}
 }
 

--- a/apps/runwisp/internal/clilog/pretty.go
+++ b/apps/runwisp/internal/clilog/pretty.go
@@ -116,12 +116,10 @@ func (h *prettyHandler) levelLabel(l slog.Level) string {
 	switch {
 	case l < slog.LevelInfo:
 		label, st = "[DEBUG]", prettyDebug
-	case l < slog.LevelWarn:
-		label, st = "[INFO]", prettyInfo
-	case l < slog.LevelError:
-		label, st = "[WARN]", prettyWarn
-	default:
+	case l >= slog.LevelError:
 		label, st = "[ERROR]", prettyError
+	case l >= slog.LevelWarn:
+		label, st = "[WARN]", prettyWarn
 	}
 	return h.paint(st, label)
 }

--- a/apps/runwisp/internal/clilog/pretty.go
+++ b/apps/runwisp/internal/clilog/pretty.go
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package clilog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Palette mirrors internal/tui so the live log stream and the startup banner
+// read as one product. clilog stays independent of internal/tui (see the
+// package doc), so the few shared colors are redeclared here rather than imported.
+var (
+	prettyDim   = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")) // dim gray
+	prettyMsg   = lipgloss.NewStyle().Bold(true)
+	prettyDebug = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")) // dim gray
+	prettyInfo  = lipgloss.NewStyle().Foreground(lipgloss.Color("#009371")) // green
+	prettyWarn  = lipgloss.NewStyle().Foreground(lipgloss.Color("#FBBF24")) // yellow
+	prettyError = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")) // red
+)
+
+// prettyHandler is a slog.Handler that renders a human-readable line:
+//
+//	2026-06-27 14:53:41 [INFO] ready, listening url=http://127.0.0.1:9477
+//
+// It backs both text formats — colored on an interactive terminal (see
+// useColor), plain everywhere else — replacing Go's terse logfmt default. JSON
+// stays untouched for log pipelines. Color is applied via lipgloss, which
+// resolves the global color profile at render time, so the same gating that
+// drives the banner (NO_COLOR / non-TTY → ASCII) also plays it safe here.
+type prettyHandler struct {
+	w  io.Writer
+	mu *sync.Mutex // shared across WithAttrs/WithGroup clones; serializes writes
+
+	level       slog.Leveler
+	includeTime bool
+	color       bool
+
+	groupPrefix  string // accumulated "a.b." prefix from WithGroup
+	preformatted string // attrs accrued via WithAttrs, already rendered
+}
+
+// newPrettyHandler builds a pretty handler. color is explicit (rather than read
+// from the package-level stderrTTY) so the formatter can be unit-tested with
+// color forced on or off.
+func newPrettyHandler(w io.Writer, level slog.Leveler, includeTime, color bool) *prettyHandler {
+	return &prettyHandler{w: w, mu: &sync.Mutex{}, level: level, includeTime: includeTime, color: color}
+}
+
+func (h *prettyHandler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= h.level.Level()
+}
+
+func (h *prettyHandler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+
+	if h.includeTime && !r.Time.IsZero() {
+		b.WriteString(h.paint(prettyDim, r.Time.Format("2006-01-02 15:04:05")))
+		b.WriteByte(' ')
+	}
+
+	b.WriteString(h.levelLabel(r.Level))
+	b.WriteByte(' ')
+	b.WriteString(h.paint(prettyMsg, r.Message))
+
+	b.WriteString(h.preformatted)
+	r.Attrs(func(a slog.Attr) bool {
+		h.appendAttr(&b, h.groupPrefix, a)
+		return true
+	})
+	b.WriteByte('\n')
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := io.WriteString(h.w, b.String())
+	return err
+}
+
+func (h *prettyHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	nh := h.clone()
+	var b strings.Builder
+	for _, a := range attrs {
+		nh.appendAttr(&b, h.groupPrefix, a)
+	}
+	nh.preformatted = h.preformatted + b.String()
+	return nh
+}
+
+func (h *prettyHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	nh := h.clone()
+	nh.groupPrefix = h.groupPrefix + name + "."
+	return nh
+}
+
+func (h *prettyHandler) clone() *prettyHandler {
+	c := *h // shares w and mu by value (mu is a pointer)
+	return &c
+}
+
+// levelLabel renders a bracketed, colored level tag.
+func (h *prettyHandler) levelLabel(l slog.Level) string {
+	label, st := "[INFO]", prettyInfo
+	switch {
+	case l < slog.LevelInfo:
+		label, st = "[DEBUG]", prettyDebug
+	case l < slog.LevelWarn:
+		label, st = "[INFO]", prettyInfo
+	case l < slog.LevelError:
+		label, st = "[WARN]", prettyWarn
+	default:
+		label, st = "[ERROR]", prettyError
+	}
+	return h.paint(st, label)
+}
+
+// appendAttr writes " key=value", flattening groups into dotted keys. Keys are
+// dimmed; values keep the terminal's default color and are logfmt-quoted.
+func (h *prettyHandler) appendAttr(b *strings.Builder, prefix string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+	if a.Value.Kind() == slog.KindGroup {
+		group := a.Value.Group()
+		if len(group) == 0 {
+			return
+		}
+		np := prefix
+		if a.Key != "" {
+			np = prefix + a.Key + "."
+		}
+		for _, ga := range group {
+			h.appendAttr(b, np, ga)
+		}
+		return
+	}
+	b.WriteByte(' ')
+	b.WriteString(h.paint(prettyDim, prefix+a.Key+"="))
+	b.WriteString(quoteIfNeeded(a.Value.String()))
+}
+
+// paint applies a lipgloss style only when color is on; otherwise returns the
+// raw string so the plain branch (and unit tests) stay escape-free.
+func (h *prettyHandler) paint(st lipgloss.Style, s string) string {
+	if !h.color {
+		return s
+	}
+	return st.Render(s)
+}
+
+// quoteIfNeeded matches slog's TextHandler quoting: bare tokens stay bare, but
+// anything with whitespace, '=', quotes, or control bytes gets Go-quoted.
+func quoteIfNeeded(s string) string {
+	if s == "" {
+		return `""`
+	}
+	if strings.ContainsAny(s, " =\"\n\t\r") {
+		return strconv.Quote(s)
+	}
+	return s
+}

--- a/apps/runwisp/internal/clilog/pretty_test.go
+++ b/apps/runwisp/internal/clilog/pretty_test.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package clilog
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLogger(h slog.Handler) *slog.Logger { return slog.New(h) }
+
+func TestPrettyHandler_PlainHasNoEscapes(t *testing.T) {
+	var buf bytes.Buffer
+	log := newTestLogger(newPrettyHandler(&buf, slog.LevelInfo, false, false))
+
+	log.Info("ready, listening", "url", "http://127.0.0.1:9477")
+
+	out := buf.String()
+	assert.NotContains(t, out, "\x1b", "color off must emit no escape bytes")
+	assert.Contains(t, out, "[INFO]")
+	assert.Contains(t, out, "ready, listening")
+	assert.Contains(t, out, "url=http://127.0.0.1:9477")
+}
+
+func TestPrettyHandler_ColorEmitsEscapes(t *testing.T) {
+	// lipgloss resolves the global color profile at render time; a non-TTY test
+	// env defaults to ASCII (no escapes), so force a colored profile here.
+	forceColorProfile(t)
+	var buf bytes.Buffer
+	log := newTestLogger(newPrettyHandler(&buf, slog.LevelInfo, false, true))
+
+	log.Warn("disk getting full", "pct", 91)
+
+	out := buf.String()
+	assert.Contains(t, out, "\x1b", "color on must style the line")
+	// Content survives styling (the key and value are styled separately, so the
+	// raw line splits "pct=" from "91" with an escape — assert each piece).
+	assert.Contains(t, out, "disk getting full")
+	assert.Contains(t, out, "pct=")
+	assert.Contains(t, out, "91")
+}
+
+func TestPrettyHandler_QuotesValuesWithSpaces(t *testing.T) {
+	var buf bytes.Buffer
+	log := newTestLogger(newPrettyHandler(&buf, slog.LevelInfo, false, false))
+
+	log.Info("init warning", "detail", "two words")
+
+	assert.Contains(t, buf.String(), `detail="two words"`)
+}
+
+func TestPrettyHandler_AttrsAndGroups(t *testing.T) {
+	var buf bytes.Buffer
+	h := newPrettyHandler(&buf, slog.LevelInfo, false, false)
+	log := newTestLogger(h).
+		With("version", "0.11.0").
+		WithGroup("scheduler").
+		With("tz", "Europe/Bratislava")
+
+	log.Info("starting", "tasks", 1)
+
+	out := buf.String()
+	assert.Contains(t, out, "version=0.11.0", "WithAttrs before a group keeps a bare key")
+	assert.Contains(t, out, "scheduler.tz=Europe/Bratislava", "WithGroup must prefix nested attrs")
+	assert.Contains(t, out, "scheduler.tasks=1", "record attrs inherit the active group prefix")
+}
+
+func TestPrettyHandler_LevelFiltering(t *testing.T) {
+	var buf bytes.Buffer
+	log := newTestLogger(newPrettyHandler(&buf, slog.LevelWarn, false, false))
+
+	log.Info("infoline")
+	log.Warn("warnline")
+
+	out := buf.String()
+	assert.NotContains(t, out, "infoline")
+	assert.Contains(t, out, "warnline")
+}
+
+func TestPrettyHandler_IncludeTime(t *testing.T) {
+	var withTime, withoutTime bytes.Buffer
+	rec := slog.NewRecord(refTime(), slog.LevelInfo, "hello", 0)
+
+	require.NoError(t, newPrettyHandler(&withTime, slog.LevelInfo, true, false).Handle(context.Background(), rec))
+	require.NoError(t, newPrettyHandler(&withoutTime, slog.LevelInfo, false, false).Handle(context.Background(), rec))
+
+	assert.Contains(t, withTime.String(), "2026-06-27 12:30:45", "includeTime renders a full datetime")
+	assert.NotContains(t, withoutTime.String(), "12:30:45", "without includeTime there is no timestamp")
+}
+
+func TestNewPlainWriter_StripsSGR(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewPlainWriter(&buf)
+
+	colored := "\x1b[32mINFO\x1b[0m ready\n"
+	n, err := w.Write([]byte(colored))
+	require.NoError(t, err)
+	assert.Equal(t, len(colored), n, "must report all input bytes consumed")
+	assert.Equal(t, "INFO ready\n", buf.String())
+}
+
+func TestNewPlainWriter_PassesPlainThrough(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewPlainWriter(&buf)
+
+	plain := "level=INFO msg=hello\n"
+	n, err := w.Write([]byte(plain))
+	require.NoError(t, err)
+	assert.Equal(t, len(plain), n)
+	assert.Equal(t, plain, buf.String(), "plain input must pass through byte-for-byte")
+}
+
+// refTime is a fixed, non-zero time for deterministic timestamp assertions.
+func refTime() time.Time { return time.Date(2026, 6, 27, 12, 30, 45, 0, time.UTC) }
+
+// forceColorProfile pins lipgloss to a colored profile for the duration of a
+// test and restores the previous one on cleanup.
+func forceColorProfile(t *testing.T) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}


### PR DESCRIPTION
## Summary
- Daemon logs now render as `2026-05-27 14:03:01 [INFO] message key=value` — colored on an interactive terminal, plain otherwise — instead of Go's terse `time=... level=INFO msg=...` logfmt.
- `--log-format=json` is unchanged for log pipelines.
- The daemon log ring buffer (streamed over SSE to the web UI / TUI) receives the plain (unescaped) form via a new `clilog.NewPlainWriter`.

## Test plan
- [x] `bun run ci`