### PR TITLE
Fix flaky TestCLIExecViaDaemon: exec swallowed a just-triggered run's output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Readable daemon logs.** Log lines now render as `2026-05-27 14:03:01 [INFO] message key=value` — colored on an interactive terminal, plain otherwise — instead of Go's terse `level=INFO msg=…` logfmt. `--log-format=json` is unchanged for pipelines. See [Logging](https://docs.runwisp.com/operations/logging/).
 
+### Fixed
+
+- **`runwisp exec` no longer exits before a just-triggered run's output appears.** A freshly triggered run is handed back before its record is durably persisted, so the log stream could momentarily find no run and close empty; `exec` treated that as "the run produced nothing" and exited without printing its output. It now retries until the run becomes streamable.
+
 ## [0.12.0] - 2026-07-08
 
 ### Added

--- a/apps/runwisp/cmd/runwisp/cmd_exec.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec.go
@@ -229,11 +229,17 @@ func triggerRemote(client *apiclient.Client, taskName, baseURL, password string)
 	return run, nil
 }
 
-// maxFollowReconnects bounds how many times followRun re-opens a log stream
-// that ended without a Done event. The run is terminal by the time we reconnect,
-// so a single re-open normally replays the rest off disk and delivers Done; the
-// bound only guards against a stream that keeps breaking with no progress.
-const maxFollowReconnects = 5
+// followMaxStalls bounds consecutive log-stream re-opens that deliver nothing —
+// no line and no Done event. A just-triggered run is handed back to the caller
+// before its row is durably persisted (persistence is async), so the first
+// stream(s) can find no run yet and the server closes them empty. We retry
+// until the run becomes streamable; the bound only guards against a run ID that
+// never materializes at all. followStallBackoff paces those retries so the
+// not-yet-persisted row has time to land without busy-looping.
+const (
+	followMaxStalls    = 50
+	followStallBackoff = 100 * time.Millisecond
+)
 
 // followRun follows a triggered run's SSE log stream, printing lines to
 // stdout/stderr and returning the run's exit code once it reaches a terminal
@@ -245,9 +251,9 @@ func followRun(client *apiclient.Client, taskName, runID string) (int, error) {
 	// Line numbers are zero-indexed; the server reads from=0 as the default
 	// tail window and clamps to anchor 0 on a fresh run, so we see every line.
 	from := int64(0)
+	stalls := 0
 
-	// Reconnect from the next unseen line to preserve the persisted tail (run is terminal).
-	for range maxFollowReconnects {
+	for {
 		ch, err := client.StreamLogLines(ctx, taskName, runID, apiclient.StreamLogOpts{FromLine: from})
 		if err != nil {
 			return 0, fmt.Errorf("open log stream: %w", err)
@@ -260,13 +266,45 @@ func followRun(client *apiclient.Client, taskName, runID string) (int, error) {
 		if ctx.Err() != nil {
 			break // interrupted (Ctrl+C) — stop reconnecting
 		}
-		if highest < from {
-			break // no progress — reconnecting won't help
+
+		if highest >= from {
+			// Progress: the SSE transport blipped mid-run (seen under heavy
+			// load) but delivered lines before closing. Re-open from the next
+			// unseen line so the persisted tail is never silently dropped — the
+			// run is terminal by now, so the server replays the rest off disk
+			// and sends Done. Making progress resets the stall budget.
+			from = highest + 1
+			stalls = 0
+			continue
 		}
-		from = highest + 1
+
+		// Stall: the stream closed without a line or a Done event. The run is
+		// not streamable yet — it was just triggered and its row lags the
+		// trigger response (persistence is async), so the server can't resolve
+		// it and closes the stream empty. Bailing here would exit 0 having
+		// silently swallowed the run's output, violating "nothing silently
+		// fails"; instead back off and retry until the row lands. (An accepted,
+		// pending, or running run keeps the stream open rather than closing it
+		// empty, so a stall only ever means "not persisted yet".)
+		stalls++
+		if stalls > followMaxStalls {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return exitCodeFromRunState(client, taskName, runID)
+		case <-time.After(followStallBackoff):
+		}
 	}
 
-	// No Done event (persistent transport trouble or cancelled); fall back to the persisted state.
+	// Stream never delivered a Done event (interrupted, or the run never became
+	// streamable); fall back to the persisted terminal state for the exit code.
+	return exitCodeFromRunState(client, taskName, runID)
+}
+
+// exitCodeFromRunState fetches the run's persisted state and derives its exit
+// code, used as followRun's fallback when the log stream ends without a Done.
+func exitCodeFromRunState(client *apiclient.Client, taskName, runID string) (int, error) {
 	final, err := client.GetRun(taskName, runID)
 	if err != nil {
 		return 0, fmt.Errorf("fetch final run state: %w", err)

--- a/apps/runwisp/cmd/runwisp/cmd_exec_follow_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec_follow_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/runwisp/runwisp/internal/apiclient"
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what was
+// written. followRun prints streamed log lines straight to os.Stdout, so this is
+// how we assert the run's output actually reached the operator.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = old })
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	return <-done
+}
+
+// TestFollowRun_RetriesEmptyStreamUntilRunIsStreamable reproduces the flaky-exec
+// bug: a just-triggered run is handed back before its row is durably persisted
+// (persistence is async), so the log-stream SSE handler can't resolve it yet and
+// closes the connection with a bare 200 — no line, no Done. followRun must not
+// treat that empty stream as "the run produced nothing and ended"; it must keep
+// re-opening until the row lands, or it would exit 0 having silently swallowed
+// the run's output.
+func TestFollowRun_RetriesEmptyStreamUntilRunIsStreamable(t *testing.T) {
+	var streamHits atomic.Int32
+	const emptyStreamsBeforeReady = 2
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/log/stream"):
+			hit := streamHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			// The first few opens mimic a not-yet-persisted run: the server
+			// resolves nothing and returns an empty stream.
+			if int(hit) <= emptyStreamsBeforeReady {
+				return
+			}
+			// Once the row has landed, the stream replays the run off disk.
+			fmt.Fprint(w, "event: line\ndata: {\"n\":0,\"stream\":\"stdout\",\"text\":\"alpha-line-1\"}\n\n")
+			fmt.Fprint(w, "event: done\ndata: {\"final_line\":0,\"status\":\"ended\"}\n\n")
+
+		case strings.Contains(r.URL.Path, "/runs/"):
+			reason := model.ReasonSuccess
+			_ = json.NewEncoder(w).Encode(model.Run{ID: "run-1", TaskName: "alpha", Status: model.PhaseEnded, EndReason: &reason})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := apiclient.New(srv.URL, "")
+
+	var code int
+	var err error
+	out := captureStdout(t, func() {
+		code, err = followRun(client, "alpha", "run-1")
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, out, "alpha-line-1", "the run's output must not be silently swallowed")
+	assert.Greater(t, streamHits.Load(), int32(emptyStreamsBeforeReady),
+		"followRun must retry past the empty (not-yet-persisted) streams")
+}


### PR DESCRIPTION
## Problem

`TestCLIExecViaDaemon` flaked under parallel CI load — `runwisp exec alpha-stream --daemon` intermittently exited **0 with no output** (failing `require.Contains(out, "alpha-line-1")`), even though the task reliably prints three lines over ~2s.

Reproduced deterministically under CPU stress (~2/72 runs) and traced to a **real product bug**, not just test timing:

1. **Persistence is async** (`internal/runtime/persistence.go`): `TriggerRun` enqueues `PersistNew` and returns the run ID *before* the DB row is committed.
2. `exec` immediately opens the run's SSE log stream. The handler's `srv.db.GetRun` hits the persistence-lag window, gets `record not found`, and returns an **empty 200 stream** (no line, no `Done`).
3. `followRun` treated that empty stream as *"the run produced nothing new; reconnecting won't help"*, fell through to `GetRun` (which reports the still-running run as exit 0), and exited — **silently swallowing the run's output**, violating the "nothing silently fails" invariant its own comment cites.

## Fix

Reworked `followRun`'s reconnect loop (`cmd/runwisp/cmd_exec.go`). An empty stream (a "stall") now means *the run isn't streamable yet*, not *done* — so it backs off (100ms) and retries until the run's row lands, bounded by `followMaxStalls`. Progress (lines delivered) resets the budget and reconnects immediately as before.

Key safety property: an accepted/pending/running run keeps the SSE stream **open**, so an empty close only ever means "not persisted yet" — never "the run finished with no output."

Chose the client-side fix over making persistence synchronous (a deliberate single-writer/non-blocking design) — the Web UI/TUI already self-heal via continuous reconnect; `exec` is the one-shot consumer that was exposed.

## Testing

- **Bug-first unit test** (`cmd_exec_follow_test.go`): drives `followRun` against a stub whose first opens return empty 200 streams. Verified it **fails without the fix** (empty output, exit 0, one stream hit) and passes with it.
- **Stress**: 112/112 real `TestCLIExecViaDaemon` runs pass under heavy CPU load (previously flaked reliably).
- `bun run ci`: all Go stages green (`runwisp:check` 0 issues, `runwisp:test` incl. `tests/e2e` ok). Playwright UI suite is unrunnable in my sandbox (no headless browser) — untouched by this Go-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)