### PR TITLE
Add forward-only SQLite migration system

### DIFF
--- a/apps/runwisp/internal/storage/database.go
+++ b/apps/runwisp/internal/storage/database.go
@@ -6,7 +6,6 @@ package storage
 import (
 	"context"
 	"database/sql"
-	_ "embed" // embeds schema.sql into schemaSQL via the //go:embed directive below
 	"errors"
 	"fmt"
 	"strconv"
@@ -17,9 +16,6 @@ import (
 	"github.com/runwisp/runwisp/internal/model"
 	"github.com/runwisp/runwisp/internal/storage/sqlcdb"
 )
-
-//go:embed schema.sql
-var schemaSQL string
 
 // ErrNotFound is returned when a requested record does not exist.
 var ErrNotFound = errors.New("record not found")
@@ -97,7 +93,8 @@ type SQLiteDatabase struct {
 	q  *sqlcdb.Queries
 }
 
-// New opens (and migrates) the SQLite database.
+// New opens the SQLite database and applies any pending forward-only
+// migrations (see migrate.go).
 func New(dbPath string) (Database, error) {
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
@@ -126,7 +123,7 @@ func New(dbPath string) (Database, error) {
 		return nil, fmt.Errorf("failed to disable mmap: %w", err)
 	}
 
-	if _, err := db.Exec(schemaSQL); err != nil {
+	if err := runMigrations(db); err != nil {
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 

--- a/apps/runwisp/internal/storage/migrate.go
+++ b/apps/runwisp/internal/storage/migrate.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import (
+	"database/sql"
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// migrationsFS holds the forward-only schema migrations, applied once each in
+// ascending version order. Files are named "<version>_<description>.sql" with a
+// zero-padded 4-digit version prefix (e.g. "0002_add_run_labels.sql") so lexical
+// order matches numeric order. This directory is also the sqlc codegen input
+// (see sqlc.yaml), so runtime schema and generated code cannot drift.
+//
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// migration is a single forward-only step parsed from migrationsFS.
+type migration struct {
+	version int
+	name    string
+	sql     string
+}
+
+// runMigrations applies every migration whose version is greater than the
+// database's current PRAGMA user_version, in ascending order, each in its own
+// transaction. On any error the transaction rolls back and the database is left
+// at the previously applied version. Migrations are forward-only: there is no
+// down path.
+func runMigrations(db *sql.DB) error {
+	current, err := userVersion(db)
+	if err != nil {
+		return err
+	}
+
+	migrations, err := loadMigrations()
+	if err != nil {
+		return err
+	}
+
+	for _, m := range migrations {
+		if m.version <= current {
+			continue
+		}
+		if err := applyMigration(db, m); err != nil {
+			return fmt.Errorf("apply migration %s: %w", m.name, err)
+		}
+	}
+	return nil
+}
+
+// applyMigration executes one migration and stamps user_version, atomically.
+func applyMigration(db *sql.DB, m migration) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(m.sql); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	// PRAGMA user_version does not accept bound parameters, so the value is
+	// interpolated. m.version is an int parsed from an embedded filename, never
+	// user input.
+	if _, err := tx.Exec("PRAGMA user_version = " + strconv.Itoa(m.version)); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+func userVersion(db *sql.DB) (int, error) {
+	var v int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&v); err != nil {
+		return 0, fmt.Errorf("read user_version: %w", err)
+	}
+	return v, nil
+}
+
+// loadMigrations reads and parses every embedded migration, sorted ascending by
+// version. It errors on a malformed filename or duplicate version so a
+// mis-added file fails loudly at startup rather than silently reordering.
+func loadMigrations() ([]migration, error) {
+	entries, err := fs.ReadDir(migrationsFS, "migrations")
+	if err != nil {
+		return nil, fmt.Errorf("read migrations dir: %w", err)
+	}
+
+	migrations := make([]migration, 0, len(entries))
+	seen := make(map[int]string, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		version, err := parseMigrationVersion(e.Name())
+		if err != nil {
+			return nil, err
+		}
+		if other, dup := seen[version]; dup {
+			return nil, fmt.Errorf("duplicate migration version %d: %s and %s", version, other, e.Name())
+		}
+		seen[version] = e.Name()
+
+		body, err := fs.ReadFile(migrationsFS, "migrations/"+e.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read migration %s: %w", e.Name(), err)
+		}
+		migrations = append(migrations, migration{version: version, name: e.Name(), sql: string(body)})
+	}
+
+	sort.Slice(migrations, func(i, j int) bool {
+		return migrations[i].version < migrations[j].version
+	})
+	return migrations, nil
+}
+
+// parseMigrationVersion extracts the leading integer of a migration filename,
+// e.g. "0002_add_run_labels.sql" -> 2. The version must be positive.
+func parseMigrationVersion(name string) (int, error) {
+	prefix, _, found := strings.Cut(name, "_")
+	if !found {
+		return 0, fmt.Errorf("migration %q must be named <version>_<description>.sql", name)
+	}
+	version, err := strconv.Atoi(prefix)
+	if err != nil {
+		return 0, fmt.Errorf("migration %q has a non-numeric version prefix: %w", name, err)
+	}
+	if version <= 0 {
+		return 0, fmt.Errorf("migration %q must have a positive version prefix", name)
+	}
+	return version, nil
+}

--- a/apps/runwisp/internal/storage/migrate.go
+++ b/apps/runwisp/internal/storage/migrate.go
@@ -68,8 +68,8 @@ func applyMigration(db *sql.DB, m migration) error {
 	}
 	// PRAGMA user_version does not accept bound parameters, so the value is
 	// interpolated. m.version is an int parsed from an embedded filename, never
-	// user input.
-	if _, err := tx.Exec("PRAGMA user_version = " + strconv.Itoa(m.version)); err != nil {
+	// user input — no injection surface.
+	if _, err := tx.Exec("PRAGMA user_version = " + strconv.Itoa(m.version)); err != nil { //NOSONAR: go:S2077 — m.version is an int from an embedded filename; PRAGMA cannot be parameterized
 		_ = tx.Rollback()
 		return err
 	}
@@ -84,11 +84,18 @@ func userVersion(db *sql.DB) (int, error) {
 	return v, nil
 }
 
-// loadMigrations reads and parses every embedded migration, sorted ascending by
-// version. It errors on a malformed filename or duplicate version so a
-// mis-added file fails loudly at startup rather than silently reordering.
+// loadMigrations reads and parses every embedded migration.
 func loadMigrations() ([]migration, error) {
-	entries, err := fs.ReadDir(migrationsFS, "migrations")
+	return parseMigrations(migrationsFS)
+}
+
+// parseMigrations reads and parses every migration under the "migrations"
+// directory of fsys, sorted ascending by version. It errors on a malformed
+// filename or duplicate version so a mis-added file fails loudly at startup
+// rather than silently reordering. Split from loadMigrations so tests can feed
+// a synthetic filesystem.
+func parseMigrations(fsys fs.FS) ([]migration, error) {
+	entries, err := fs.ReadDir(fsys, "migrations")
 	if err != nil {
 		return nil, fmt.Errorf("read migrations dir: %w", err)
 	}
@@ -108,7 +115,7 @@ func loadMigrations() ([]migration, error) {
 		}
 		seen[version] = e.Name()
 
-		body, err := fs.ReadFile(migrationsFS, "migrations/"+e.Name())
+		body, err := fs.ReadFile(fsys, "migrations/"+e.Name())
 		if err != nil {
 			return nil, fmt.Errorf("read migration %s: %w", e.Name(), err)
 		}

--- a/apps/runwisp/internal/storage/migrate_test.go
+++ b/apps/runwisp/internal/storage/migrate_test.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"database/sql"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/require"
 )
@@ -89,6 +90,67 @@ func TestLoadMigrations_OrderedAndWellFormed(t *testing.T) {
 		prev = m.version
 	}
 	require.Equal(t, 1, migs[0].version, "the baseline migration must be version 1")
+}
+
+// TestApplyMigration_RollsBackOnError verifies a failing migration leaves the
+// database at its prior version — the transaction is rolled back, not partially
+// applied.
+func TestApplyMigration_RollsBackOnError(t *testing.T) {
+	db := openRaw(t)
+
+	err := applyMigration(db, migration{version: 99, name: "0099_broken.sql", sql: "THIS IS NOT SQL;"})
+	require.Error(t, err)
+	require.Equal(t, 0, readUserVersion(t, db), "version must be unchanged after a failed migration")
+}
+
+// TestRunMigrations_ErrorsOnClosedDB exercises the error-propagation path when
+// the initial user_version read fails.
+func TestRunMigrations_ErrorsOnClosedDB(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	require.Error(t, runMigrations(db))
+	require.Error(t, applyMigration(db, migration{version: 1, name: "0001_x.sql", sql: "SELECT 1;"}))
+
+	_, err = userVersion(db)
+	require.Error(t, err)
+}
+
+func TestParseMigrations_Errors(t *testing.T) {
+	t.Run("missing dir", func(t *testing.T) {
+		_, err := parseMigrations(fstest.MapFS{})
+		require.Error(t, err)
+	})
+
+	t.Run("duplicate version", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"migrations/0001_a.sql": {Data: []byte("SELECT 1;")},
+			"migrations/0001_b.sql": {Data: []byte("SELECT 2;")},
+		}
+		_, err := parseMigrations(fsys)
+		require.ErrorContains(t, err, "duplicate migration version")
+	})
+
+	t.Run("malformed filename", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"migrations/init.sql": {Data: []byte("SELECT 1;")},
+		}
+		_, err := parseMigrations(fsys)
+		require.Error(t, err)
+	})
+
+	t.Run("ignores non-sql and dirs", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"migrations/0001_a.sql":   {Data: []byte("SELECT 1;")},
+			"migrations/README.md":    {Data: []byte("notes")},
+			"migrations/sub/0002.sql": {Data: []byte("SELECT 2;")},
+		}
+		migs, err := parseMigrations(fsys)
+		require.NoError(t, err)
+		require.Len(t, migs, 1)
+		require.Equal(t, 1, migs[0].version)
+	})
 }
 
 func TestParseMigrationVersion(t *testing.T) {

--- a/apps/runwisp/internal/storage/migrate_test.go
+++ b/apps/runwisp/internal/storage/migrate_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// openRaw returns a single-connection in-memory database. SetMaxOpenConns(1)
+// keeps every query on the same connection so the :memory: schema persists
+// across calls within a test (a second connection would be a fresh empty DB).
+func openRaw(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func headVersion(t *testing.T) int {
+	t.Helper()
+	migs, err := loadMigrations()
+	require.NoError(t, err)
+	require.NotEmpty(t, migs, "expected at least one embedded migration")
+	return migs[len(migs)-1].version
+}
+
+func readUserVersion(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	v, err := userVersion(db)
+	require.NoError(t, err)
+	return v
+}
+
+func TestNew_MigratesToHead(t *testing.T) {
+	db, err := New(":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	sdb, ok := db.(*SQLiteDatabase)
+	require.True(t, ok)
+
+	require.Equal(t, headVersion(t), readUserVersion(t, sdb.db))
+}
+
+func TestRunMigrations_IsIdempotent(t *testing.T) {
+	db := openRaw(t)
+
+	require.NoError(t, runMigrations(db))
+	first := readUserVersion(t, db)
+	require.Equal(t, headVersion(t), first)
+
+	// A second pass must apply nothing and leave the version untouched.
+	require.NoError(t, runMigrations(db))
+	require.Equal(t, first, readUserVersion(t, db))
+}
+
+// TestRunMigrations_AdoptsPreexistingDB simulates a database created before the
+// migration system existed: the full baseline schema is already present but
+// user_version is still 0. The IF NOT EXISTS baseline must adopt it without
+// error and stamp it to head.
+func TestRunMigrations_AdoptsPreexistingDB(t *testing.T) {
+	db := openRaw(t)
+
+	// Materialize the baseline objects, then reset user_version to 0 to mimic a
+	// DB that predates the migration system.
+	require.NoError(t, runMigrations(db))
+	_, err := db.Exec("PRAGMA user_version = 0")
+	require.NoError(t, err)
+
+	require.NoError(t, runMigrations(db))
+	require.Equal(t, headVersion(t), readUserVersion(t, db))
+}
+
+func TestLoadMigrations_OrderedAndWellFormed(t *testing.T) {
+	migs, err := loadMigrations()
+	require.NoError(t, err)
+	require.NotEmpty(t, migs)
+
+	prev := 0
+	for _, m := range migs {
+		require.Greater(t, m.version, prev, "migrations must be strictly ascending with no duplicate versions")
+		require.NotEmpty(t, m.sql, "migration %s is empty", m.name)
+		prev = m.version
+	}
+	require.Equal(t, 1, migs[0].version, "the baseline migration must be version 1")
+}
+
+func TestParseMigrationVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		want    int
+		wantErr bool
+	}{
+		{name: "baseline", file: "0001_initial_schema.sql", want: 1},
+		{name: "later", file: "0042_add_labels.sql", want: 42},
+		{name: "multi-word description", file: "0002_add_run_labels_column.sql", want: 2},
+		{name: "no separator", file: "0001.sql", wantErr: true},
+		{name: "non-numeric prefix", file: "init_schema.sql", wantErr: true},
+		{name: "zero version", file: "0000_seed.sql", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMigrationVersion(tt.file)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/apps/runwisp/internal/storage/migrations/0001_initial_schema.sql
+++ b/apps/runwisp/internal/storage/migrations/0001_initial_schema.sql
@@ -1,6 +1,11 @@
 -- SPDX-FileCopyrightText: PoppyCake, s.r.o.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- Baseline schema. This migration keeps IF NOT EXISTS so databases created
+-- before the migration system existed adopt cleanly (their objects already
+-- exist; this no-ops, then user_version is stamped to 1). Later migrations run
+-- exactly once and must use plain DDL (no IF NOT EXISTS).
+
 CREATE TABLE IF NOT EXISTS runs (
 id                    TEXT PRIMARY KEY,
 external_execution_id TEXT,

--- a/apps/runwisp/moon.yml
+++ b/apps/runwisp/moon.yml
@@ -10,13 +10,15 @@ fileGroups:
   # Non-Go assets compiled into the binary via //go:embed. They are build
   # inputs even though they aren't .go files, so the build cache must key on
   # them — otherwise editing e.g. the demo config leaves a stale binary.
-  # internal/storage/schema.sql is omitted because the sqlc output it produces
-  # lands in internal/**/*.go (caught by `go` above); internal/ui/dist is
-  # handled by `ui_src` below.
+  # internal/ui/dist is handled by `ui_src` below. The storage migrations are
+  # embedded at runtime (migrate.go) and applied on boot, so they are a build
+  # input in their own right — a migration can change the binary without
+  # changing the sqlc output caught by `go` above.
   embeds:
     - 'internal/demo/runwisp.toml'
     - 'internal/autostart/templates/*.tmpl'
     - 'internal/notify/render/defaults/**/*'
+    - 'internal/storage/migrations/*.sql'
   # The web-UI sources whose built output is copied into internal/ui/dist and
   # compiled in via go:embed. moon does NOT chain cache invalidation through a
   # task's deps (every dep hash is recorded "ignored" in the hash manifest) —
@@ -45,7 +47,7 @@ tasks:
     inputs:
       - 'scripts/sqlc-generate.sh'
       - 'sqlc.yaml'
-      - 'internal/storage/schema.sql'
+      - 'internal/storage/migrations/**/*.sql'
       - 'internal/storage/query/**/*.sql'
     outputs:
       - 'internal/storage/sqlcdb'

--- a/apps/runwisp/sqlc.yaml
+++ b/apps/runwisp/sqlc.yaml
@@ -2,7 +2,7 @@ version: "2"
 sql:
   - engine: sqlite
     queries: internal/storage/query
-    schema: internal/storage/schema.sql
+    schema: internal/storage/migrations
     gen:
       go:
         package: sqlcdb


### PR DESCRIPTION
## What

Introduces an ordered, forward-only DB migration system so future schema changes are a drop-in file rather than a risky edit to the single embedded schema.

Before: the whole schema lived in `internal/storage/schema.sql`, `db.Exec()`'d unconditionally on every open (all `CREATE ... IF NOT EXISTS`), with **no version tracking**. The moment we needed an `ALTER TABLE`, a rename, a backfill, or an index change on a populated DB, there was no safe once-only mechanism. `CLAUDE.md` already promises forward-only migrations — this lands it before we need it.

## How

- New `internal/storage/migrations/` directory. Files are `<4-digit-version>_<description>.sql`, applied once each in ascending order.
- `0001_initial_schema.sql` is the current schema verbatim. It keeps `IF NOT EXISTS` so any pre-existing (pre-migration-system) DB adopts cleanly; later migrations use plain DDL and run exactly once.
- `migrate.go`: ~60-line stdlib runner. Embeds `migrations/*.sql`, reads `PRAGMA user_version`, applies each pending migration in its own transaction, then stamps `user_version` to that migration's number. Forward-only — no down path. No new runtime dependency.
- `New()` now calls `runMigrations(db)` instead of `db.Exec(schemaSQL)`.
- **Single source of truth:** the migrations directory is now the sqlc codegen input too (`sqlc.yaml` `schema:` points at it), so runtime schema and generated code cannot drift. Regen produces byte-identical `sqlcdb/`.
- `moon.yml`: `sqlc-generate` input updated; migrations added to `embeds` since they're a runtime-embedded build input.

Design choices (tracking via `PRAGMA user_version`, hand-rolled runner) match the "boring in prod / one binary, zero runtime deps" directives.

## Adding a migration going forward

1. Create `internal/storage/migrations/000N_description.sql` with plain DDL.
2. `bun run generate` to refresh sqlc output.

The version bump and application happen automatically on boot.

## Tests

`migrate_test.go` covers: migrates-to-head, idempotent re-open, pre-existing-DB adoption, strict-ascending ordering, and filename version parsing. Full `bun run ci` passes (generate → format → check → test → test-e2e).