### PR TITLE
docs: SEO title/description rewrites for page-1 zero-click docs pages

### DIFF
--- a/apps/docs/src/content/docs/getting-started/tui-tour.mdx
+++ b/apps/docs/src/content/docs/getting-started/tui-tour.mdx
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 title: The TUI tour
 description: A guided walkthrough of the RunWisp terminal UI — the Open Web UI shortcut, layout, views, keybindings, and how to trigger / stop / restart from the keyboard without ever opening a browser.
+head:
+    - tag: title
+      content: "RunWisp TUI: supervise and watch runs from your terminal"
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";

--- a/apps/docs/src/content/docs/getting-started/web-ui-tour.mdx
+++ b/apps/docs/src/content/docs/getting-started/web-ui-tour.mdx
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 title: The Web UI tour
 description: A tour of the embedded RunWisp Web dashboard — opening it from the TUI, the overview page, task detail, log viewer, and the notifications bell.
+head:
+    - tag: title
+      content: "RunWisp web UI: every run, every notification, all in one place"
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: PoppyCake, s.r.o.
 # SPDX-License-Identifier: Apache-2.0
 title: RunWisp documentation
-description: Reference documentation for the RunWisp daemon — installation, TOML configuration, operations, the embedded Web UI, and the REST API.
+description: Install RunWisp in one command; configure scheduled jobs and supervised services in one runwisp.toml; watch every run with the web UI or terminal UI. Zero runtime dependencies.
+head:
+    - tag: title
+      content: "RunWisp — install, configure, run cron jobs and supervised services"
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";

--- a/apps/docs/src/content/docs/notifications/routes.mdx
+++ b/apps/docs/src/content/docs/notifications/routes.mdx
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: PoppyCake, s.r.o.
 # SPDX-License-Identifier: Apache-2.0
 title: Notification rules
-description: A [[notification_route]] block matches events by kind and task name, and sends them to one or more channels. Use it when one rule should cover many tasks.
+description: A notification route matches events by kind and task name, and sends them to one or more channels — Discord, Slack, Telegram, SMTP, or a webhook. Use it when one rule should cover many tasks.
+head:
+    - tag: title
+      content: "RunWisp notifications: route runs to Discord, Slack, Telegram, SMTP, webhooks"
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";

--- a/apps/docs/src/content/docs/operations/cli.mdx
+++ b/apps/docs/src/content/docs/operations/cli.mdx
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 title: CLI reference
 description: Every runwisp subcommand and global flag — starting and attaching to the daemon, validating config, running tasks, reloading and restarting, importing crontabs and supervisord configs, autostart, and the environment variables that configure it all.
+head:
+    - tag: title
+      content: "RunWisp CLI: status, validate, import cron/supervisord, reload, run"
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";

--- a/apps/docs/src/content/docs/operations/metrics.mdx
+++ b/apps/docs/src/content/docs/operations/metrics.mdx
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 title: Metrics
 description: Scrape RunWisp from Prometheus, Grafana Agent, or any OpenMetrics-compatible collector via the daemon's public /metrics endpoint.
+head:
+    - tag: title
+      content: "RunWisp metrics: Prometheus / OpenMetrics endpoint for run health"
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";

--- a/apps/docs/src/content/docs/recipes/backup.mdx
+++ b/apps/docs/src/content/docs/recipes/backup.mdx
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: PoppyCake, s.r.o.
 # SPDX-License-Identifier: Apache-2.0
 title: Nightly backup
-description: A complete worked example for a nightly Postgres backup — pg_dump with skip-on-overlap, 90-day retention, no retries (failures should reach a human), and Slack alerting on failure.
+description: "A worked nightly Postgres backup recipe: pg_dump, 90-day retention, skip-on-overlap, no retries — and a Discord/Slack/SMTP alert if the run is missing or fails. Replaces the silent-crond version."
+head:
+    - tag: title
+      content: "Nightly Postgres backup with failure alerts (RunWisp recipe)"
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";


### PR DESCRIPTION
## What

Rewrites the SEO `<title>` and `<meta description>` on the docs pages that a GSC 90-day deep-dive flagged as ranking on Google's page 1 but earning **zero clicks** — a title/meta mismatch with search intent, not a position problem.

Each page gets an SEO-specific `<title>` via Starlight's `head` frontmatter, which overrides the auto-generated `X | RunWisp` title **without** changing the visible page H1 (`title:` stays readable; keyword-rich SERP titles would make clunky headings).

### Core rewrites (the page-1 zero-click cluster)
| Page | New `<title>` |
|---|---|
| `/` (index) | RunWisp — install, configure, run cron jobs and supervised services |
| `/operations/cli` | RunWisp CLI: status, validate, import cron/supervisord, reload, run |
| `/recipes/backup` | Nightly Postgres backup with failure alerts (RunWisp recipe) |
| `/getting-started/tui-tour` | RunWisp TUI: supervise and watch runs from your terminal |
| `/getting-started/web-ui-tour` | RunWisp web UI: every run, every notification, all in one place |

Descriptions rewritten on the index and backup pages; others kept (already strong).

### Also (lower-priority, endorsed by the source doc)
- `/notifications/routes` — title now lists channels (Discord/Slack/Telegram/SMTP/webhooks); **fixes a raw `[[notification_route]]` wikilink leaking into the meta description** (macros only expand in body, not frontmatter).
- `/operations/metrics` — title now names Prometheus/OpenMetrics.

## Out of scope
`/vs/cron` and US brand-search CTR are position/inbound-link problems, not meta edits — unchanged per the source analysis.

## Verification
- Docs build passes; each affected page renders exactly one `<title>` with the new string and correct `<meta description>`.
- `prettier --check` passes on all touched files.

Docs-only metadata; no product surface, so no CHANGELOG entry.