### PR TITLE
Add `--json` output to status, list, and validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--json` output for `runwisp status`, `list`, and `validate`.** A schema-versioned, machine-readable document on stdout for headless and agent-driven use; failures still exit non-zero and emit JSON. See [CLI](https://docs.runwisp.com/operations/cli/#machine-readable-output-json).
+
 ### Changed
 
 - **Readable daemon logs.** Log lines now render as `2026-05-27 14:03:01 [INFO] message key=value` — colored on an interactive terminal, plain otherwise — instead of Go's terse `level=INFO msg=…` logfmt. `--log-format=json` is unchanged for pipelines. See [Logging](https://docs.runwisp.com/operations/logging/).

--- a/apps/docs/src/content/docs/operations/cli.mdx
+++ b/apps/docs/src/content/docs/operations/cli.mdx
@@ -84,6 +84,95 @@ tasks as a table. `runwisp status` pings the daemon over its local socket
 and prints a short health summary; it also flags when `runwisp.toml` has
 changed on disk since the daemon started.
 
+### Machine-readable output (`--json`)
+
+Add `--json` to `validate`, `list`, or `status` and you get a single JSON
+document on stdout instead of the human text — handy when an agent or script
+drives RunWisp headless. Every document carries a `schema_version` so you can
+trust its shape across releases (the shape only ever grows — fields are added,
+never removed or repurposed). A failure still exits non-zero **and** prints
+JSON describing what went wrong, so your script never has to grep stderr to
+learn something broke.
+
+`runwisp validate --json` tells you whether the config is valid and hands back
+counts, the resolved timezone, and errors and warnings as arrays:
+
+```json
+{
+    "schema_version": 1,
+    "valid": true,
+    "config_path": "runwisp.toml",
+    "timezone": "UTC",
+    "timezone_source": "config",
+    "tasks": 1,
+    "services": 1,
+    "warnings": [],
+    "errors": []
+}
+```
+
+On a broken config it exits non-zero with `"valid": false` and a populated
+`errors` array.
+
+`runwisp list --json` mirrors the config table. Like the human view it's
+offline and reads only `runwisp.toml`, so there's no run history here:
+
+```json
+{
+    "schema_version": 1,
+    "tasks": [
+        {
+            "name": "backup",
+            "kind": "task",
+            "schedule": "0 3 * * *",
+            "max_concurrent": 1,
+            "on_overlap": "queue",
+            "api_trigger": true,
+            "description": "nightly backup"
+        }
+    ]
+}
+```
+
+`runwisp status --json` is the live snapshot: daemon health, a system summary,
+and every task with its last run — the exit code, timing, and `failed`/`missed`
+flags are precomputed so you don't have to decode RunWisp's status names
+yourself:
+
+```json
+{
+    "schema_version": 1,
+    "healthy": true,
+    "version": "0.12.0",
+    "scheduling_active": true,
+    "config_stale": false,
+    "system": { "version": "0.12.0", "uptime": "1h2m3s", "cpu_cores": 8, "host": "my-vps" },
+    "tasks": [
+        {
+            "name": "backup",
+            "kind": "task",
+            "cron": "0 3 * * *",
+            "api_trigger": false,
+            "next_run_at": "2026-07-16 03:00:00",
+            "last_run": {
+                "id": "01JZZBACKUP0000000000000000",
+                "status": "ended",
+                "end_reason": "failed",
+                "exit_code": 1,
+                "start_at": "2026-07-15T03:00:00Z",
+                "end_at": "2026-07-15T03:00:42Z",
+                "duration_ms": 42000,
+                "failed": true,
+                "missed": false
+            }
+        }
+    ]
+}
+```
+
+A task that has never run reports `"last_run": null`. If the daemon isn't
+running, `status --json` exits non-zero with `"healthy": false` and an `error`.
+
 ## Run a task now
 
 ```sh

--- a/apps/runwisp/cmd/runwisp/cmd_list.go
+++ b/apps/runwisp/cmd/runwisp/cmd_list.go
@@ -5,38 +5,66 @@ package main
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 
 	"github.com/runwisp/runwisp/internal/config"
+	"github.com/runwisp/runwisp/internal/model"
 	"github.com/spf13/cobra"
 )
+
+var listJSON bool
 
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Show configured tasks and their schedules",
 	Long:  `Reads the configuration file and displays all configured tasks as a formatted table.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runList(flags)
+		return runList(cmd.OutOrStdout(), flags, listJSON)
 	},
 }
 
-func runList(f Flags) error {
+func init() {
+	listCmd.Flags().BoolVar(&listJSON, "json", false, "emit a machine-readable JSON document to stdout instead of the table")
+}
+
+func runList(out io.Writer, f Flags, asJSON bool) error {
 	cfg, err := config.Load(f.CfgFile)
 	if err != nil {
+		if asJSON {
+			// Emit an error document so an agent learns of the failure from the
+			// JSON, not from stderr text; the returned error still drives exit 1.
+			if werr := writeJSON(out, listJSONDoc{SchemaVersion: jsonSchemaVersion, Error: err.Error()}); werr != nil {
+				return werr
+			}
+		}
 		return fmt.Errorf("failed to load %s: %w", f.CfgFile, err)
 	}
 
-	if len(cfg.Tasks) == 0 {
-		fmt.Println("No tasks configured.")
+	if asJSON {
+		doc := listJSONDoc{SchemaVersion: jsonSchemaVersion, Tasks: make([]listTaskJSON, 0, len(cfg.Tasks))}
+		for _, task := range cfg.Tasks {
+			doc.Tasks = append(doc.Tasks, newListTaskJSON(task))
+		}
+		return writeJSON(out, doc)
+	}
+
+	return renderTaskTable(out, cfg.Tasks)
+}
+
+// renderTaskTable writes the human-readable task listing (the default,
+// non-JSON view) as an aligned table.
+func renderTaskTable(out io.Writer, tasks []model.Task) error {
+	if len(tasks) == 0 {
+		fmt.Fprintln(out, "No tasks configured.")
 		return nil
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NAME\tSCHEDULE\tCONCURRENCY\tPOLICY\tAPI\tDESCRIPTION")
 	fmt.Fprintln(w, "----\t--------\t-----------\t------\t---\t-----------")
 
-	for _, task := range cfg.Tasks {
+	for _, task := range tasks {
 		var schedule string
 		switch {
 		case task.Kind.IsService():

--- a/apps/runwisp/cmd/runwisp/cmd_list_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_list_test.go
@@ -5,40 +5,14 @@ package main
 
 import (
 	"bytes"
-	"io"
+	"encoding/json"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// withCapturedStdout runs fn while stdout is redirected to a pipe; returns
-// what was written. Used for commands that print straight to os.Stdout.
-func withCapturedStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-
-	var wg sync.WaitGroup
-	var buf bytes.Buffer
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_, _ = io.Copy(&buf, r)
-	}()
-
-	fn()
-
-	require.NoError(t, w.Close())
-	wg.Wait()
-	os.Stdout = old
-	return buf.String()
-}
 
 const minimalCfgEmpty = `# minimal runwisp.toml with no tasks
 `
@@ -72,19 +46,21 @@ func writeConfig(t *testing.T, body string) string {
 	return path
 }
 
+func runListString(t *testing.T, f Flags) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, runList(&buf, f, false))
+	return buf.String()
+}
+
 func TestRunList_NoTasks(t *testing.T) {
 	f := Flags{CfgFile: writeConfig(t, minimalCfgEmpty)}
-	out := withCapturedStdout(t, func() {
-		require.NoError(t, runList(f))
-	})
-	assert.Contains(t, out, "No tasks configured")
+	assert.Contains(t, runListString(t, f), "No tasks configured")
 }
 
 func TestRunList_OneCronTask(t *testing.T) {
 	f := Flags{CfgFile: writeConfig(t, minimalCfgOneTask)}
-	out := withCapturedStdout(t, func() {
-		require.NoError(t, runList(f))
-	})
+	out := runListString(t, f)
 	assert.Contains(t, out, "hello")
 	assert.Contains(t, out, "* * * * *")
 	assert.Contains(t, out, "say hello")
@@ -92,9 +68,7 @@ func TestRunList_OneCronTask(t *testing.T) {
 
 func TestRunList_ServiceTaskShowsInstances(t *testing.T) {
 	f := Flags{CfgFile: writeConfig(t, minimalCfgServiceTask)}
-	out := withCapturedStdout(t, func() {
-		require.NoError(t, runList(f))
-	})
+	out := runListString(t, f)
 	assert.Contains(t, out, "worker")
 	assert.Contains(t, out, "(service x3)")
 	assert.Contains(t, out, "yes", "api_trigger=true renders 'yes'")
@@ -102,17 +76,51 @@ func TestRunList_ServiceTaskShowsInstances(t *testing.T) {
 
 func TestRunList_LongDescriptionTruncated(t *testing.T) {
 	f := Flags{CfgFile: writeConfig(t, minimalCfgLongDescription)}
-	out := withCapturedStdout(t, func() {
-		require.NoError(t, runList(f))
-	})
-	assert.Contains(t, out, "...")
+	assert.Contains(t, runListString(t, f), "...")
 }
 
 func TestRunList_MissingConfigFile(t *testing.T) {
 	t.Parallel()
 	f := Flags{CfgFile: filepath.Join(t.TempDir(), "absent.toml")}
 
-	err := runList(f)
+	var buf bytes.Buffer
+	err := runList(&buf, f, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load")
+}
+
+func TestRunList_JSONServiceAndCron(t *testing.T) {
+	body := minimalCfgOneTask + minimalCfgServiceTask
+	f := Flags{CfgFile: writeConfig(t, body)}
+
+	var buf bytes.Buffer
+	require.NoError(t, runList(&buf, f, true))
+
+	var doc listJSONDoc
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+	assert.Equal(t, jsonSchemaVersion, doc.SchemaVersion)
+	require.Len(t, doc.Tasks, 2)
+
+	byName := map[string]listTaskJSON{}
+	for _, tk := range doc.Tasks {
+		byName[tk.Name] = tk
+	}
+	assert.Equal(t, "task", byName["hello"].Kind)
+	assert.Equal(t, "* * * * *", byName["hello"].Schedule)
+	assert.Equal(t, "service", byName["worker"].Kind)
+	assert.Equal(t, 3, byName["worker"].Instances)
+	assert.True(t, byName["worker"].APITrigger)
+}
+
+func TestRunList_JSONMissingConfigEmitsErrorDoc(t *testing.T) {
+	f := Flags{CfgFile: filepath.Join(t.TempDir(), "absent.toml")}
+
+	var buf bytes.Buffer
+	err := runList(&buf, f, true)
+	require.Error(t, err)
+
+	var doc listJSONDoc
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc), "stdout must still be valid JSON on failure")
+	assert.Equal(t, jsonSchemaVersion, doc.SchemaVersion)
+	assert.NotEmpty(t, doc.Error)
 }

--- a/apps/runwisp/cmd/runwisp/cmd_status.go
+++ b/apps/runwisp/cmd/runwisp/cmd_status.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var statusJSON bool
+
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Check if the daemon is alive",
@@ -19,17 +21,38 @@ var statusCmd = &cobra.Command{
 responsive, prints a short system summary, and warns when runwisp.toml has
 changed on disk since the daemon started (config changes apply on restart).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runStatus(cmd.OutOrStdout(), flags)
+		return runStatus(cmd.OutOrStdout(), flags, statusJSON)
 	},
 }
 
-func runStatus(out io.Writer, f Flags) error {
+func init() {
+	statusCmd.Flags().BoolVar(&statusJSON, "json", false, "emit a machine-readable JSON document to stdout instead of the human summary")
+}
+
+func runStatus(out io.Writer, f Flags, asJSON bool) error {
 	// The Unix socket is the local-trusted transport (same as exec/tui):
 	// no password needed, and unlike a TCP probe it cannot hit a different
 	// process that happens to squat on the port.
 	client := apiclient.NewUnix(localAPISocketPath(f))
 	if err := client.HealthCheck(); err != nil {
+		if asJSON {
+			// Emit an unhealthy document so an agent learns of the failure from
+			// the JSON, not from stderr text; the returned error still drives
+			// exit 1.
+			if werr := writeJSON(out, statusJSONDoc{
+				SchemaVersion: jsonSchemaVersion,
+				Healthy:       false,
+				Error:         err.Error(),
+				Tasks:         []statusTaskJSON{},
+			}); werr != nil {
+				return werr
+			}
+		}
 		return fmt.Errorf("daemon is not reachable at %s (%w) — %s", localAPISocketPath(f), err, daemonNotRunningHint)
+	}
+
+	if asJSON {
+		return writeJSON(out, buildStatusDoc(client))
 	}
 
 	info, infoErr := client.GetDaemonInfo()
@@ -47,6 +70,50 @@ func runStatus(out io.Writer, f Flags) error {
 		fmt.Fprintln(out, "\n⚠ runwisp.toml has changed since the daemon started — run 'runwisp restart' to apply")
 	}
 	return nil
+}
+
+// buildStatusDoc assembles the live snapshot for `status --json`. Health is
+// already confirmed by the caller; the remaining probes are soft — a failed
+// info/system/tasks fetch leaves its fields at their zero value rather than
+// failing the whole document, mirroring the human path's graceful degradation.
+func buildStatusDoc(client *apiclient.Client) statusJSONDoc {
+	doc := statusJSONDoc{
+		SchemaVersion: jsonSchemaVersion,
+		Healthy:       true,
+		Tasks:         []statusTaskJSON{},
+	}
+
+	if info, err := client.GetDaemonInfo(); err == nil {
+		doc.Version = info.Version
+		doc.Port = info.Port
+		doc.ExternalURL = info.ExternalURL
+		doc.SchedulingActive = info.SchedulingActive
+		doc.ConfigStale = info.ConfigStale
+		doc.ResolvedTimezone = info.ResolvedTimezone
+		doc.TimezoneSource = info.TimezoneSource
+	}
+
+	if stats, err := client.GetSystemStats(); err == nil {
+		doc.System = newStatusSystem(stats)
+	}
+
+	if tasks, err := client.ListTasks(); err == nil {
+		for _, tr := range tasks {
+			doc.Tasks = append(doc.Tasks, newStatusTaskJSON(tr, lastRunOf(client, tr.Name)))
+		}
+	}
+
+	return doc
+}
+
+// lastRunOf fetches a task's most recent run (default sort is created_at desc),
+// or nil when the task has never run or the fetch fails.
+func lastRunOf(client *apiclient.Client, taskName string) *model.Run {
+	runs, _, err := client.ListRunsByTask(taskName, apiclient.RunsParams{Limit: 1})
+	if err != nil || len(runs) == 0 {
+		return nil
+	}
+	return &runs[0]
 }
 
 func printSystemStats(out io.Writer, stats *model.SystemStats) {

--- a/apps/runwisp/cmd/runwisp/cmd_status_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_status_test.go
@@ -66,7 +66,7 @@ func TestRunStatus_HealthyWithSystem(t *testing.T) {
 	f := serveStatusSocket(t, mux)
 
 	var buf bytes.Buffer
-	require.NoError(t, runStatus(&buf, f))
+	require.NoError(t, runStatus(&buf, f, false))
 	out := buf.String()
 	assert.Contains(t, out, "RunWisp is healthy at :9477")
 	assert.Contains(t, out, "vX")
@@ -85,7 +85,7 @@ func TestRunStatus_HealthOnlySystemMissing(t *testing.T) {
 	f := serveStatusSocket(t, mux)
 
 	var buf bytes.Buffer
-	require.NoError(t, runStatus(&buf, f))
+	require.NoError(t, runStatus(&buf, f, false))
 	out := buf.String()
 	assert.Contains(t, out, "RunWisp is healthy")
 	assert.NotContains(t, out, "Version")
@@ -105,7 +105,7 @@ func TestRunStatus_HealthOnlySystemBadJSON(t *testing.T) {
 	f := serveStatusSocket(t, mux)
 
 	var buf bytes.Buffer
-	require.NoError(t, runStatus(&buf, f))
+	require.NoError(t, runStatus(&buf, f, false))
 	assert.Contains(t, buf.String(), "RunWisp is healthy")
 }
 
@@ -120,7 +120,7 @@ func TestRunStatus_ConfigStaleWarns(t *testing.T) {
 	f := serveStatusSocket(t, mux)
 
 	var buf bytes.Buffer
-	require.NoError(t, runStatus(&buf, f))
+	require.NoError(t, runStatus(&buf, f, false))
 	assert.Contains(t, buf.String(), "runwisp.toml has changed")
 }
 
@@ -132,7 +132,7 @@ func TestRunStatus_HealthNon200Errors(t *testing.T) {
 	f := serveStatusSocket(t, mux)
 
 	var buf bytes.Buffer
-	err := runStatus(&buf, f)
+	err := runStatus(&buf, f, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not reachable")
 }
@@ -142,7 +142,7 @@ func TestRunStatus_UnreachableErrors(t *testing.T) {
 	// No socket created — HealthCheck fails to dial.
 	f := Flags{DataDir: testutil.ShortTempDir(t)}
 	var buf bytes.Buffer
-	err := runStatus(&buf, f)
+	err := runStatus(&buf, f, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not reachable")
 }

--- a/apps/runwisp/cmd/runwisp/cmd_validate.go
+++ b/apps/runwisp/cmd/runwisp/cmd_validate.go
@@ -11,15 +11,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var validateJSON bool
+
 var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate runwisp.toml without starting anything",
 	Long:  `Parses and validates the configuration file. Prints a summary on success or a structured error on failure. Useful for CI pipelines and pre-commit checks.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runValidate(cmd.OutOrStdout(), flags)
+		return runValidate(cmd.OutOrStdout(), flags, validateJSON)
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,
+}
+
+func init() {
+	validateCmd.Flags().BoolVar(&validateJSON, "json", false, "emit a machine-readable JSON document to stdout instead of the human summary")
 }
 
 // runValidate loads and validates f.CfgFile. On success it prints a
@@ -28,18 +34,30 @@ var validateCmd = &cobra.Command{
 // errors. The summary covers the values an operator most often wants to
 // double-check after editing the file: task / service counts and the
 // resolved scheduler timezone (config-pinned vs system-detected).
-func runValidate(w io.Writer, f Flags) error {
+//
+// With asJSON, w receives a single validateJSONDoc instead (valid=false on
+// failure, still returning the error so the exit code stays non-zero).
+func runValidate(w io.Writer, f Flags, asJSON bool) error {
 	cfg, err := config.Load(f.CfgFile)
 	if err != nil {
+		if asJSON {
+			// Emit the error document to stdout so an agent never has to parse
+			// text to know validation failed; the returned error still drives a
+			// non-zero exit (and its human copy to stderr via main.go).
+			if werr := writeJSON(w, validateJSONDoc{
+				SchemaVersion: jsonSchemaVersion,
+				Valid:         false,
+				ConfigPath:    f.CfgFile,
+				Warnings:      messagesFromStrings(nil),
+				Errors:        []messageJSON{{Message: err.Error()}},
+			}); werr != nil {
+				return werr
+			}
+		}
 		return &userFacingError{
 			title:   fmt.Sprintf("%s is not valid", f.CfgFile),
 			details: err.Error(),
 		}
-	}
-
-	tz := cfg.Scheduler.Timezone
-	if cfg.Scheduler.Source != "" {
-		tz = fmt.Sprintf("%s (%s)", tz, cfg.Scheduler.Source)
 	}
 
 	tasks, services := 0, 0
@@ -49,6 +67,25 @@ func runValidate(w io.Writer, f Flags) error {
 		} else {
 			tasks++
 		}
+	}
+
+	if asJSON {
+		return writeJSON(w, validateJSONDoc{
+			SchemaVersion:  jsonSchemaVersion,
+			Valid:          true,
+			ConfigPath:     f.CfgFile,
+			Timezone:       cfg.Scheduler.Timezone,
+			TimezoneSource: cfg.Scheduler.Source,
+			Tasks:          tasks,
+			Services:       services,
+			Warnings:       messagesFromStrings(config.Warnings(cfg)),
+			Errors:         []messageJSON{},
+		})
+	}
+
+	tz := cfg.Scheduler.Timezone
+	if cfg.Scheduler.Source != "" {
+		tz = fmt.Sprintf("%s (%s)", tz, cfg.Scheduler.Source)
 	}
 
 	fmt.Fprintf(w, "✓ %s is valid.\n", f.CfgFile)

--- a/apps/runwisp/cmd/runwisp/cmd_validate_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_validate_test.go
@@ -33,7 +33,7 @@ run = "echo hi"
 graceful_stop = "30s"
 `)
 	var out strings.Builder
-	require.NoError(t, runValidate(&out, f))
+	require.NoError(t, runValidate(&out, f, false))
 	assert.Contains(t, out.String(), "is valid")
 	assert.Contains(t, out.String(), "! ")
 	assert.Contains(t, out.String(), "graceful_stop")
@@ -43,7 +43,7 @@ func TestRunValidateNoWarnings(t *testing.T) {
 	t.Parallel()
 	f := writeValidateConfig(t, "[tasks.t]\nrun = \"echo hi\"\n")
 	var out strings.Builder
-	require.NoError(t, runValidate(&out, f))
+	require.NoError(t, runValidate(&out, f, false))
 	assert.Contains(t, out.String(), "is valid")
 	assert.NotContains(t, out.String(), "! ")
 }
@@ -52,7 +52,7 @@ func TestRunValidateRejectsBadCron(t *testing.T) {
 	t.Parallel()
 	f := writeValidateConfig(t, "[tasks.t]\nrun = \"echo hi\"\ncron = \"61 * * * *\"\n")
 	var out strings.Builder
-	err := runValidate(&out, f)
+	err := runValidate(&out, f, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid cron")
 	assert.Contains(t, err.Error(), "expected 5 fields")
@@ -62,7 +62,7 @@ func TestRunValidate_ValidEmpty(t *testing.T) {
 	t.Parallel()
 	f := writeValidateConfig(t, "# empty\n")
 	var buf bytes.Buffer
-	require.NoError(t, runValidate(&buf, f))
+	require.NoError(t, runValidate(&buf, f, false))
 	out := buf.String()
 	assert.Contains(t, out, "is valid")
 	assert.Contains(t, out, "tasks:    0")
@@ -85,7 +85,7 @@ run = "true"
 run = "exec /usr/bin/web"
 `)
 	var buf bytes.Buffer
-	require.NoError(t, runValidate(&buf, f))
+	require.NoError(t, runValidate(&buf, f, false))
 	out := buf.String()
 	assert.Contains(t, out, "tasks:    2")
 	assert.Contains(t, out, "services: 1")
@@ -96,7 +96,7 @@ func TestRunValidate_InvalidTOMLReturnsUserFacingError(t *testing.T) {
 	f := writeValidateConfig(t, "this is not = valid toml ===\n")
 	var buf bytes.Buffer
 
-	err := runValidate(&buf, f)
+	err := runValidate(&buf, f, false)
 	require.Error(t, err)
 
 	var ufe *userFacingError
@@ -111,7 +111,7 @@ func TestRunValidate_MissingFileReturnsUserFacingError(t *testing.T) {
 	f := Flags{CfgFile: filepath.Join(t.TempDir(), "absent.toml")}
 
 	var buf bytes.Buffer
-	err := runValidate(&buf, f)
+	err := runValidate(&buf, f, false)
 	require.Error(t, err)
 
 	var ufe *userFacingError

--- a/apps/runwisp/cmd/runwisp/golden_test.go
+++ b/apps/runwisp/cmd/runwisp/golden_test.go
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// updateGolden rewrites the testdata/*.golden.json fixtures from the current
+// output instead of comparing against them. Run with:
+//
+//	go test ./cmd/runwisp -run Golden -update
+//
+// then eyeball the diff before committing — the golden files are the schema
+// contract the --json flags promise to agents.
+var updateGolden = flag.Bool("update", false, "rewrite the testdata/*.golden.json fixtures")
+
+// checkGolden compares got against the fixture at path, or rewrites it under
+// -update. got is normalized through the same indented encoder the commands
+// use so a field-order change surfaces as a diff.
+func checkGolden(t *testing.T, path string, got []byte) {
+	t.Helper()
+	if *updateGolden {
+		require.NoError(t, os.WriteFile(path, got, 0o600))
+		return
+	}
+	want, err := os.ReadFile(path)
+	require.NoErrorf(t, err, "read golden %s (run with -update to create it)", path)
+	assert.Equalf(t, string(want), string(got), "golden mismatch for %s — run with -update to refresh", filepath.Base(path))
+}
+
+func TestValidateJSONGolden(t *testing.T) {
+	f := writeValidateConfig(t, `
+[scheduler]
+timezone = "UTC"
+
+[tasks.backup]
+cron = "0 3 * * *"
+run = "true"
+
+[services.web]
+run = "exec /usr/bin/web"
+`)
+	var buf bytes.Buffer
+	require.NoError(t, runValidate(&buf, f, true))
+	// The config path is an absolute temp dir that changes every run; pin it to
+	// a stable basename so the golden stays deterministic.
+	got := bytes.ReplaceAll(buf.Bytes(), []byte(f.CfgFile), []byte("runwisp.toml"))
+	checkGolden(t, "testdata/validate.golden.json", got)
+}
+
+func TestListJSONGolden(t *testing.T) {
+	f := Flags{CfgFile: writeConfig(t, `
+[tasks.backup]
+cron = "0 3 * * *"
+run = "true"
+description = "nightly backup"
+
+[services.web]
+run = "exec /usr/bin/web"
+instances = 2
+api_trigger = true
+`)}
+	var buf bytes.Buffer
+	require.NoError(t, runList(&buf, f, true))
+	checkGolden(t, "testdata/list.golden.json", buf.Bytes())
+}
+
+func TestStatusJSONGolden(t *testing.T) {
+	start := time.Date(2026, 7, 15, 3, 0, 0, 0, time.UTC)
+	end := start.Add(42 * time.Second)
+	failed := model.ReasonFailed
+	nextRun := "2026-07-16T03:00:00Z"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/info", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(model.DaemonInfo{
+			Version: "0.12.0", Port: 9477, SchedulingActive: true,
+			ResolvedTimezone: "UTC", TimezoneSource: "config",
+		})
+	})
+	mux.HandleFunc("/api/system", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(model.SystemStats{
+			Version: "0.12.0", Uptime: "1h2m3s", CPUCores: 8,
+			Host: "test-host", OS: "linux", Arch: "amd64", Name: "runwisp", WorkDir: "/srv",
+		})
+	})
+	mux.HandleFunc("/api/tasks", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]model.TaskResponse{
+			{Task: model.Task{Name: "backup", Cron: "0 3 * * *"}, NextRunAt: &nextRun},
+			{Task: model.Task{Name: "web", Kind: model.KindService, APITrigger: true}},
+		})
+	})
+	mux.HandleFunc("/api/tasks/backup/runs", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(server.RunsResponseBody{Total: 1, Runs: []model.Run{{
+			ID: "01JZZBACKUP0000000000000000", TaskName: "backup", Status: model.PhaseEnded,
+			EndReason: &failed, ExitCode: 1, TriggeredBy: model.TriggeredByCron,
+			StartAt: &start, EndAt: &end,
+		}}})
+	})
+	mux.HandleFunc("/api/tasks/web/runs", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(server.RunsResponseBody{Total: 1, Runs: []model.Run{{
+			ID: "01JZZWEB00000000000000000000", TaskName: "web", Status: model.PhaseRunning,
+			TriggeredBy: model.TriggeredByService, StartAt: &start,
+		}}})
+	})
+	f := serveStatusSocket(t, mux)
+
+	var buf bytes.Buffer
+	require.NoError(t, runStatus(&buf, f, true))
+	checkGolden(t, "testdata/status.golden.json", buf.Bytes())
+}

--- a/apps/runwisp/cmd/runwisp/json_output.go
+++ b/apps/runwisp/cmd/runwisp/json_output.go
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/runtime/retry"
+)
+
+// jsonSchemaVersion identifies the shape of every --json document RunWisp's
+// read commands emit. Agents branch on it to trust the fields below. It is a
+// compatibility promise: once shipped, only additive changes are allowed —
+// bump it if a field is ever removed or its meaning changes.
+const jsonSchemaVersion = 1
+
+// writeJSON marshals v as an indented JSON document with a trailing newline.
+// It is the single stdout sink for every --json code path, so stdout stays a
+// single valid JSON document and nothing else.
+func writeJSON(w io.Writer, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, "\n")
+	return err
+}
+
+// taskKindString normalizes model.KindTask ("") to the explicit "task" so the
+// JSON always carries a concrete kind an agent can switch on.
+func taskKindString(k model.TaskKind) string {
+	if k.IsService() {
+		return string(model.KindService)
+	}
+	return "task"
+}
+
+// --- status ---------------------------------------------------------------
+
+// statusJSONDoc is the machine-readable form of `runwisp status`. It is the
+// live snapshot: daemon reachability, a system summary, and every task with
+// its last run. See statusTaskJSON / lastRunJSON.
+type statusJSONDoc struct {
+	SchemaVersion    int              `json:"schema_version"`
+	Healthy          bool             `json:"healthy"`
+	Error            string           `json:"error,omitempty"`
+	Version          string           `json:"version,omitempty"`
+	Port             int              `json:"port,omitempty"`
+	ExternalURL      string           `json:"external_url,omitempty"`
+	SchedulingActive bool             `json:"scheduling_active"`
+	ConfigStale      bool             `json:"config_stale"`
+	ResolvedTimezone string           `json:"resolved_timezone,omitempty"`
+	TimezoneSource   string           `json:"timezone_source,omitempty"`
+	System           *statusSystem    `json:"system,omitempty"`
+	Tasks            []statusTaskJSON `json:"tasks"`
+}
+
+// statusSystem is a curated subset of model.SystemStats — the identity and
+// resource fields an operator or agent branches on, without the churny
+// percentages that would make golden output non-deterministic.
+type statusSystem struct {
+	Version  string `json:"version"`
+	Uptime   string `json:"uptime"`
+	CPUCores int    `json:"cpu_cores"`
+	Host     string `json:"host"`
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
+	Name     string `json:"name"`
+	WorkDir  string `json:"work_dir"`
+}
+
+type statusTaskJSON struct {
+	Name       string       `json:"name"`
+	Kind       string       `json:"kind"`
+	Cron       string       `json:"cron,omitempty"`
+	APITrigger bool         `json:"api_trigger"`
+	NextRunAt  *string      `json:"next_run_at,omitempty"`
+	LastRun    *lastRunJSON `json:"last_run"`
+}
+
+// lastRunJSON is the most recent run of a task. failed/missed are precomputed
+// so an agent never has to know RunWisp's end-reason taxonomy: failed reuses
+// retry.IsFailureReason, missed is the single ReasonMissed value.
+type lastRunJSON struct {
+	ID          string     `json:"id"`
+	Status      string     `json:"status"`
+	EndReason   *string    `json:"end_reason,omitempty"`
+	ExitCode    int        `json:"exit_code"`
+	TriggeredBy string     `json:"triggered_by"`
+	StartAt     *time.Time `json:"start_at,omitempty"`
+	EndAt       *time.Time `json:"end_at,omitempty"`
+	DurationMS  *int64     `json:"duration_ms,omitempty"`
+	Failed      bool       `json:"failed"`
+	Missed      bool       `json:"missed"`
+}
+
+func newStatusSystem(s *model.SystemStats) *statusSystem {
+	if s == nil {
+		return nil
+	}
+	return &statusSystem{
+		Version:  s.Version,
+		Uptime:   s.Uptime,
+		CPUCores: s.CPUCores,
+		Host:     s.Host,
+		OS:       s.OS,
+		Arch:     s.Arch,
+		Name:     s.Name,
+		WorkDir:  s.WorkDir,
+	}
+}
+
+func newStatusTaskJSON(tr model.TaskResponse, last *model.Run) statusTaskJSON {
+	st := statusTaskJSON{
+		Name:       tr.Name,
+		Kind:       taskKindString(tr.Kind),
+		Cron:       tr.Cron,
+		APITrigger: tr.APITrigger,
+		NextRunAt:  tr.NextRunAt,
+	}
+	if last != nil {
+		lr := newLastRunJSON(last)
+		st.LastRun = &lr
+	}
+	return st
+}
+
+func newLastRunJSON(r *model.Run) lastRunJSON {
+	lr := lastRunJSON{
+		ID:          r.ID,
+		Status:      string(r.Status),
+		ExitCode:    r.ExitCode,
+		TriggeredBy: string(r.TriggeredBy),
+		StartAt:     r.StartAt,
+		EndAt:       r.EndAt,
+	}
+	if r.EndReason != nil {
+		reason := string(*r.EndReason)
+		lr.EndReason = &reason
+		lr.Failed = retry.IsFailureReason(*r.EndReason)
+		lr.Missed = *r.EndReason == model.ReasonMissed
+	}
+	if r.StartAt != nil && r.EndAt != nil {
+		ms := r.EndAt.Sub(*r.StartAt).Milliseconds()
+		lr.DurationMS = &ms
+	}
+	return lr
+}
+
+// --- list ------------------------------------------------------------------
+
+// listJSONDoc is the machine-readable form of `runwisp list`. Like the human
+// table it is offline and config-only — no last-run state (that lives in
+// `status --json`, which talks to the daemon).
+type listJSONDoc struct {
+	SchemaVersion int            `json:"schema_version"`
+	Error         string         `json:"error,omitempty"`
+	Tasks         []listTaskJSON `json:"tasks"`
+}
+
+type listTaskJSON struct {
+	Name          string `json:"name"`
+	Kind          string `json:"kind"`
+	Schedule      string `json:"schedule"`
+	Instances     int    `json:"instances,omitempty"`
+	MaxConcurrent int    `json:"max_concurrent"`
+	OnOverlap     string `json:"on_overlap"`
+	APITrigger    bool   `json:"api_trigger"`
+	Description   string `json:"description,omitempty"`
+}
+
+func newListTaskJSON(t model.Task) listTaskJSON {
+	lt := listTaskJSON{
+		Name:          t.Name,
+		Kind:          taskKindString(t.Kind),
+		Schedule:      t.Cron,
+		MaxConcurrent: t.MaxConcurrent,
+		OnOverlap:     string(t.OnOverlap),
+		APITrigger:    t.APITrigger,
+		Description:   t.Description,
+	}
+	if t.Kind.IsService() {
+		lt.Instances = t.Instances
+	}
+	return lt
+}
+
+// --- validate --------------------------------------------------------------
+
+// validateJSONDoc is the machine-readable form of `runwisp validate`. valid is
+// the single field an agent needs to branch on; errors/warnings carry the
+// human messages. On failure the document is still emitted and the command
+// still exits non-zero.
+type validateJSONDoc struct {
+	SchemaVersion  int           `json:"schema_version"`
+	Valid          bool          `json:"valid"`
+	ConfigPath     string        `json:"config_path"`
+	Timezone       string        `json:"timezone,omitempty"`
+	TimezoneSource string        `json:"timezone_source,omitempty"`
+	Tasks          int           `json:"tasks"`
+	Services       int           `json:"services"`
+	Warnings       []messageJSON `json:"warnings"`
+	Errors         []messageJSON `json:"errors"`
+}
+
+// messageJSON is a validation error or advisory warning. Location is reserved
+// (always empty today): the config layer bakes task/field/line into the
+// message string, so there is no structured location to surface yet.
+type messageJSON struct {
+	Message  string `json:"message"`
+	Location string `json:"location,omitempty"`
+}
+
+func messagesFromStrings(ss []string) []messageJSON {
+	out := make([]messageJSON, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, messageJSON{Message: s})
+	}
+	return out
+}

--- a/apps/runwisp/cmd/runwisp/json_output_test.go
+++ b/apps/runwisp/cmd/runwisp/json_output_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/runwisp/runwisp/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunValidate_JSONInvalidEmitsErrorDoc(t *testing.T) {
+	t.Parallel()
+	f := writeValidateConfig(t, "[tasks.t]\nrun = \"echo hi\"\ncron = \"61 * * * *\"\n")
+
+	var buf bytes.Buffer
+	err := runValidate(&buf, f, true)
+	require.Error(t, err, "invalid config must still exit non-zero")
+
+	var doc validateJSONDoc
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc), "stdout must be valid JSON even on failure")
+	assert.Equal(t, jsonSchemaVersion, doc.SchemaVersion)
+	assert.False(t, doc.Valid)
+	require.Len(t, doc.Errors, 1)
+	assert.Contains(t, doc.Errors[0].Message, "invalid cron")
+	assert.Empty(t, doc.Warnings, "warnings is an empty array, not null")
+}
+
+func TestRunStatus_JSONUnreachableEmitsUnhealthyDoc(t *testing.T) {
+	t.Parallel()
+	// No socket bound — HealthCheck fails to dial.
+	f := Flags{DataDir: testutil.ShortTempDir(t)}
+
+	var buf bytes.Buffer
+	err := runStatus(&buf, f, true)
+	require.Error(t, err, "an unreachable daemon must still exit non-zero")
+
+	var doc statusJSONDoc
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc), "stdout must be valid JSON even when unreachable")
+	assert.Equal(t, jsonSchemaVersion, doc.SchemaVersion)
+	assert.False(t, doc.Healthy)
+	assert.NotEmpty(t, doc.Error)
+}

--- a/apps/runwisp/cmd/runwisp/testdata/list.golden.json
+++ b/apps/runwisp/cmd/runwisp/testdata/list.golden.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "tasks": [
+    {
+      "name": "backup",
+      "kind": "task",
+      "schedule": "0 3 * * *",
+      "max_concurrent": 1,
+      "on_overlap": "queue",
+      "api_trigger": true,
+      "description": "nightly backup"
+    },
+    {
+      "name": "web",
+      "kind": "service",
+      "schedule": "",
+      "instances": 2,
+      "max_concurrent": 1,
+      "on_overlap": "skip",
+      "api_trigger": true
+    }
+  ]
+}

--- a/apps/runwisp/cmd/runwisp/testdata/status.golden.json
+++ b/apps/runwisp/cmd/runwisp/testdata/status.golden.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "healthy": true,
+  "version": "0.12.0",
+  "port": 9477,
+  "scheduling_active": true,
+  "config_stale": false,
+  "resolved_timezone": "UTC",
+  "timezone_source": "config",
+  "system": {
+    "version": "0.12.0",
+    "uptime": "1h2m3s",
+    "cpu_cores": 8,
+    "host": "test-host",
+    "os": "linux",
+    "arch": "amd64",
+    "name": "runwisp",
+    "work_dir": "/srv"
+  },
+  "tasks": [
+    {
+      "name": "backup",
+      "kind": "task",
+      "cron": "0 3 * * *",
+      "api_trigger": false,
+      "next_run_at": "2026-07-16T03:00:00Z",
+      "last_run": {
+        "id": "01JZZBACKUP0000000000000000",
+        "status": "ended",
+        "end_reason": "failed",
+        "exit_code": 1,
+        "triggered_by": "cron",
+        "start_at": "2026-07-15T03:00:00Z",
+        "end_at": "2026-07-15T03:00:42Z",
+        "duration_ms": 42000,
+        "failed": true,
+        "missed": false
+      }
+    },
+    {
+      "name": "web",
+      "kind": "service",
+      "api_trigger": true,
+      "last_run": {
+        "id": "01JZZWEB00000000000000000000",
+        "status": "running",
+        "exit_code": 0,
+        "triggered_by": "service",
+        "start_at": "2026-07-15T03:00:00Z",
+        "failed": false,
+        "missed": false
+      }
+    }
+  ]
+}

--- a/apps/runwisp/cmd/runwisp/testdata/validate.golden.json
+++ b/apps/runwisp/cmd/runwisp/testdata/validate.golden.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "valid": true,
+  "config_path": "runwisp.toml",
+  "timezone": "UTC",
+  "timezone_source": "config",
+  "tasks": 1,
+  "services": 1,
+  "warnings": [],
+  "errors": []
+}


### PR DESCRIPTION
## What

Adds a `--json` flag to the three read commands so an AI agent or script can drive RunWisp headless without scraping column-aligned text.

- **`runwisp status --json`** — live snapshot: daemon health, a system summary, and every task with its last run (exit code, timing, `duration_ms`, and precomputed `failed`/`missed` flags). Unreachable daemon → `{"healthy": false, "error": …}` + exit 1.
- **`runwisp list --json`** — offline JSON mirror of the config table (stays config-only, like the human view).
- **`runwisp validate --json`** — `valid` flag + counts + `errors`/`warnings` arrays. A broken config still exits non-zero **and** emits the JSON error document to stdout (human copy goes to stderr).

Every document carries `"schema_version": 1` as an additive-only compatibility promise. Default (flagless) output is byte-for-byte unchanged.

## Notes / decisions

- Last-run state lives in `status --json` (the daemon-connected command); `list` stays offline by design (local-first invariant), so it carries config only — not last-run exit codes.
- `validate --json` errors expose `message` only. `location` is reserved-but-empty: the config layer bakes task/field/line into the message string, and surfacing structured locations would need an `internal/config` error-type refactor (out of scope).

## Tests

- Golden tests (`-update` harness + `testdata/*.golden.json`) lock all three JSON shapes; the `status` golden is made deterministic via a fake daemon with fixed data.
- Failure-path tests assert non-zero exit + valid JSON for bad-config `validate` and unreachable `status`.
- `bun run ci` passes (unit + e2e). Manually verified end-to-end against a live daemon.

## Docs

- New "Machine-readable output" section in `operations/cli.mdx` with an example response per command.
- `CHANGELOG.md` entry under Unreleased → Added.