### PR TITLE
Sync cloud into main

### DIFF
--- a/apps/runwisp/cmd/runwisp/daemon_services.go
+++ b/apps/runwisp/cmd/runwisp/daemon_services.go
@@ -44,8 +44,8 @@ type daemonServices struct {
 	TaskShutdownTimeout time.Duration
 	// ServiceLaunchCancel aborts the background depends_on launcher goroutines.
 	// Called at the start of graceful shutdown so a dependent still waiting on a
-	// dependency doesn't start mid-teardown. No-op in cloud mode (services don't
-	// auto-start there).
+	// dependency doesn't start mid-teardown. Services are supervised in both
+	// standalone and cloud mode, so this is always a real cancel.
 	ServiceLaunchCancel context.CancelFunc
 	// InitWarnings holds non-fatal warnings collected during service init
 	// (notify subsystem failures, scheduler start hiccups, etc.) so the
@@ -82,17 +82,21 @@ func initDaemonServices(ctx context.Context, cfg *daemonConfig, db storage.Datab
 	// registry so a later `runwisp reload` mutation is race-free.
 	tasks := runtime.NewTaskRegistry(tasksMap)
 
-	// Default to a no-op cancel so cloud mode (no service auto-start) leaves a
-	// callable handle in daemonServices.
-	serviceLaunchCancel := context.CancelFunc(func() {})
-
 	var boot standaloneBoot
 	if mode == modeStandalone {
-		boot, serviceLaunchCancel, err = startStandaloneScheduling(ctx, cfg, db, taskManager, tasksMap, &initWarnings)
+		boot, err = startStandaloneScheduling(ctx, cfg, db, taskManager, tasksMap, &initWarnings)
 		if err != nil {
 			return nil, err
 		}
 	}
+
+	// Bring services up to their desired instance count in both modes (a
+	// timezone error above already aborted, so this never runs on a bad config).
+	// Autostart is honored by the supervisor (NewSupervisor's isStopped =
+	// !Autostart), so a non-autostart service boots stopped — StartServiceInstances
+	// no-ops on a stopped supervisor.
+	launchCtx, serviceLaunchCancel := context.WithCancel(ctx)
+	startServiceInstances(launchCtx, taskManager, tasksMap)
 
 	retentionCleaner := initRetentionCleaner(cfg, db, tasks, f.LogDir())
 
@@ -147,13 +151,13 @@ type standaloneBoot struct {
 	catchUpResult    runtime.CatchUpResult
 }
 
-// startStandaloneScheduling brings up the scheduler, resumes pending runs, fires
-// run_on_start tasks, and launches service instances — the standalone-only boot
-// steps that run before notify subscribes. It returns the collected results, the
-// cancel func that aborts the background service launchers, and a hard error
-// (timezone resolution) that must abort daemon startup. Non-fatal hiccups are
-// appended to warnings.
-func startStandaloneScheduling(ctx context.Context, cfg *daemonConfig, db storage.Database, taskManager runtime.TaskManager, tasksMap map[string]*model.Task, warnings *[]string) (standaloneBoot, context.CancelFunc, error) {
+// startStandaloneScheduling brings up the scheduler, resumes pending runs, and
+// fires run_on_start tasks — the standalone-only boot steps that run before
+// notify subscribes. It returns the collected results and a hard error (timezone
+// resolution) that must abort daemon startup. Non-fatal hiccups are appended to
+// warnings. Service instances are launched separately by initDaemonServices in
+// both modes.
+func startStandaloneScheduling(ctx context.Context, cfg *daemonConfig, db storage.Database, taskManager runtime.TaskManager, tasksMap map[string]*model.Task, warnings *[]string) (standaloneBoot, error) {
 	var boot standaloneBoot
 
 	// [scheduler] timezone is required at config-load time when any cron task
@@ -161,7 +165,7 @@ func startStandaloneScheduling(ctx context.Context, cfg *daemonConfig, db storag
 	// explicitly or there are no cron expressions to interpret.
 	schedLoc, locErr := config.ResolveTimezone("scheduler.timezone", cfg.Config.Scheduler.Timezone)
 	if locErr != nil {
-		return boot, func() {}, locErr
+		return boot, locErr
 	}
 	scheduler := runtime.NewScheduler(taskManager, tasksMap, schedLoc)
 	boot.scheduler = scheduler
@@ -185,10 +189,7 @@ func startStandaloneScheduling(ctx context.Context, cfg *daemonConfig, db storag
 	}
 	boot.runOnStartResult = runOnStartResult
 
-	launchCtx, serviceLaunchCancel := context.WithCancel(ctx)
-	startServiceInstances(launchCtx, taskManager, tasksMap)
-
-	return boot, serviceLaunchCancel, nil
+	return boot, nil
 }
 
 // startNotify initializes the notify subsystem and starts its service, routing

--- a/apps/runwisp/cmd/runwisp/depends_on_boot_test.go
+++ b/apps/runwisp/cmd/runwisp/depends_on_boot_test.go
@@ -41,6 +41,35 @@ func activeCount(tm runtime.TaskManager, name string) int {
 	return len(tm.GetActiveRuns(name))
 }
 
+// TestStartServiceInstances_HonorsAutostart proves the boot launcher starts an
+// autostart service but leaves a non-autostart one stopped. This is the
+// invariant that lets initDaemonServices run the launcher unconditionally (in
+// cloud mode too): a non-autostart service boots stopped because its supervisor
+// is created stopped and StartServiceInstances no-ops on a stopped supervisor.
+func TestStartServiceInstances_HonorsAutostart(t *testing.T) {
+	exec := testutil.NewGateExecutor()
+	bus := events.NewEventBus()
+	tm := runtime.NewTaskManager(exec, bus, time.Now)
+	t.Cleanup(tm.Shutdown)
+
+	on := bootTestService("on", time.Nanosecond)
+	off := bootTestService("off", time.Nanosecond)
+	off.Autostart = false
+	tm.UpsertTask(on)
+	tm.UpsertTask(off)
+	tasksMap := map[string]*model.Task{"on": on, "off": off}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startServiceInstances(ctx, tm, tasksMap)
+
+	require.Eventually(t, func() bool { return activeCount(tm, "on") == 1 },
+		2*time.Second, 10*time.Millisecond, "autostart service must come up at boot")
+	// Let the non-autostart launcher goroutine run; it must never spawn an instance.
+	time.Sleep(150 * time.Millisecond)
+	assert.Equal(t, 0, activeCount(tm, "off"), "a non-autostart service must boot stopped")
+}
+
 // TestStartServiceInstances_GatesDependentOnDependencyHealth proves the launcher
 // holds a dependent until its dependency is healthy: web must not start while db
 // is still short of its healthy_after, then comes up once db crosses it.

--- a/apps/runwisp/internal/cloud/client.go
+++ b/apps/runwisp/internal/cloud/client.go
@@ -30,13 +30,17 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 }
 
 var (
-	authReadTimeout            = envDuration("RUNWISP_CLOUD_AUTH_TIMEOUT", 20*time.Second)
-	heartbeatInterval          = envDuration("RUNWISP_CLOUD_HEARTBEAT_INTERVAL", 5*time.Second)
-	heartbeatSilenceTimeout    = envDuration("RUNWISP_CLOUD_HEARTBEAT_SILENCE_TIMEOUT", 15*time.Second)
-	watchdogInterval           = envDuration("RUNWISP_CLOUD_WATCHDOG_INTERVAL", 2*time.Second)
-	writeTimeout               = envDuration("RUNWISP_CLOUD_WRITE_TIMEOUT", 5*time.Second)
-	outboundMessageBufferSize  = 256
-	maxPendingExecutionUpdates = 2048
+	authReadTimeout         = envDuration("RUNWISP_CLOUD_AUTH_TIMEOUT", 20*time.Second)
+	heartbeatInterval       = envDuration("RUNWISP_CLOUD_HEARTBEAT_INTERVAL", 5*time.Second)
+	heartbeatSilenceTimeout = envDuration("RUNWISP_CLOUD_HEARTBEAT_SILENCE_TIMEOUT", 15*time.Second)
+	watchdogInterval        = envDuration("RUNWISP_CLOUD_WATCHDOG_INTERVAL", 2*time.Second)
+	writeTimeout            = envDuration("RUNWISP_CLOUD_WRITE_TIMEOUT", 5*time.Second)
+	// serviceStatusResendInterval re-pushes every service's supervisor snapshot on
+	// this cadence so the control plane's view survives its snapshot TTL (90s) for
+	// a stable service that produces no lifecycle events. Kept well under that TTL.
+	serviceStatusResendInterval = envDuration("RUNWISP_CLOUD_SERVICE_STATUS_RESEND_INTERVAL", 30*time.Second)
+	outboundMessageBufferSize   = 256
+	maxPendingExecutionUpdates  = 2048
 )
 
 const maxInboundMessageSize int64 = 4 * 1024 * 1024 // 4 MiB
@@ -362,6 +366,12 @@ func (client *Client) startSession(ctx context.Context, connection *websocket.Co
 		client.onConnected()
 	}
 	client.conn.flushPendingUpdates()
+	// Immediately re-seed the control plane's service view on (re)connect: a
+	// stable service emits no lifecycle event to trigger a fresh snapshot, so
+	// without this the view stays empty until the first resend-ticker tick.
+	if client.bridge != nil {
+		client.bridge.EmitAllServiceStatus()
+	}
 
 	sessionErr := client.sessions.run(ctx, session)
 	client.conn.detachSession()

--- a/apps/runwisp/internal/cloud/event_bridge.go
+++ b/apps/runwisp/internal/cloud/event_bridge.go
@@ -5,6 +5,7 @@ package cloud
 
 import (
 	"context"
+	"time"
 
 	"log/slog"
 
@@ -50,6 +51,27 @@ func (b *EventBridge) Start(ctx context.Context) {
 		b.eventBus.Subscribe(events.EventRunFailed, func(e events.Event) { b.handleRunEvent(ctx, e) }),
 		b.eventBus.Subscribe(events.EventLogLine, b.handleLogLineEvent),
 	)
+	// A service emits a status snapshot only on an instance lifecycle change, so a
+	// stable always-on service falls silent for as long as it keeps running — long
+	// past the control plane's snapshot TTL, which then shows the service as having
+	// no live status. Re-push all snapshots on a ticker so the view stays fresh;
+	// sendReady is a no-op while no session is attached.
+	go b.resendServiceStatusLoop(ctx)
+}
+
+// resendServiceStatusLoop periodically re-pushes every service's supervisor
+// snapshot until ctx is cancelled (daemon shutdown).
+func (b *EventBridge) resendServiceStatusLoop(ctx context.Context) {
+	ticker := time.NewTicker(serviceStatusResendInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.EmitAllServiceStatus()
+		}
+	}
 }
 
 // Shutdown removes all event subscriptions.
@@ -132,10 +154,27 @@ func (b *EventBridge) finalizeRun(ctx context.Context, run *model.Run, update pr
 	b.handler.RemoveLogListener(executionID)
 }
 
+// EmitAllServiceStatus pushes the current supervisor snapshot for every
+// registered service. Called on each (re)connect (for an immediate refresh) and
+// on the resend ticker, so the control plane's view survives its snapshot TTL
+// for a service that produces no lifecycle events. Best-effort like
+// emitServiceStatus: sendReady drops while no session is attached.
+func (b *EventBridge) EmitAllServiceStatus() {
+	if b.handler.taskManager == nil {
+		return
+	}
+	for _, svc := range b.handler.taskManager.ListServiceTasks() {
+		if svc == nil {
+			continue
+		}
+		b.emitServiceStatus(svc.Name)
+	}
+}
+
 // emitServiceStatus pushes the current supervisor snapshot for a service task
 // to the cloud. A no-op for unknown / non-service tasks. Best-effort: a full
 // outbound queue drops the snapshot rather than blocking the supervisor — the
-// next lifecycle change (or a reconnect-driven resend) corrects the view.
+// next lifecycle change or resend-ticker tick corrects the view.
 func (b *EventBridge) emitServiceStatus(taskName string) {
 	if b.handler.taskManager == nil {
 		return

--- a/apps/runwisp/internal/cloud/event_bridge_test.go
+++ b/apps/runwisp/internal/cloud/event_bridge_test.go
@@ -220,6 +220,31 @@ func TestEventBridge_HandleRunEvent_EmitsServiceStatusByBareName(t *testing.T) {
 	assert.Equal(t, 2, msg.DesiredInstances)
 }
 
+// EmitAllServiceStatus pushes one service:status per registered service (the
+// reconnect / resend-ticker refresh); non-service tasks are skipped by
+// ListServiceTasks.
+func TestEventBridge_EmitAllServiceStatus_PushesEveryService(t *testing.T) {
+	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{
+		"heartbeat": {Name: "heartbeat", Kind: model.KindService},
+		"worker":    {Name: "worker", Kind: model.KindService},
+	})
+	runner := h.taskManager.(*fakeTaskRunner)
+	runner.snapshot = model.ServiceSnapshot{State: "running", DesiredInstances: 1, RunningInstances: 1}
+	runner.snapshotOK = true
+
+	var sent []any
+	b := NewEventBridge(
+		events.NewEventBus(),
+		h,
+		NewExecutionTracker(),
+		func(msg any) error { sent = append(sent, msg); return nil },
+		func() {},
+	)
+
+	b.EmitAllServiceStatus()
+	assert.Len(t, sent, 2, "one service:status per registered service")
+}
+
 func TestEventBridge_HandleRunEvent_IgnoresWrongData(t *testing.T) {
 	b := newTestBridge(newTestInboundHandler())
 	// Data is not events.RunEvent — must return without panicking.

--- a/apps/runwisp/internal/cloud/event_bridge_test.go
+++ b/apps/runwisp/internal/cloud/event_bridge_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/runwisp/runwisp/internal/generated/protocol"
 	"github.com/runwisp/runwisp/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestBridge(h *InboundHandler) *EventBridge {
@@ -184,6 +185,40 @@ func TestEventBridge_Start_DispatchesPublishedEvents(t *testing.T) {
 }
 
 // --- handleRunEvent: guard branches ---
+
+// A service-instance lifecycle run carries no external execution id; the bridge
+// pushes the supervisor snapshot keyed by the bare task name. This is the path a
+// supervised TOML service (now running in cloud mode) takes — an old cloud drops
+// the bare-name frame, a new cloud resolves it.
+func TestEventBridge_HandleRunEvent_EmitsServiceStatusByBareName(t *testing.T) {
+	h := newDispatchHandler(shellAvailable(), nil)
+	runner := h.taskManager.(*fakeTaskRunner)
+	runner.snapshot = model.ServiceSnapshot{
+		TaskName:         "heartbeat",
+		State:            "running",
+		DesiredInstances: 2,
+		RunningInstances: 2,
+	}
+	runner.snapshotOK = true
+
+	var sent []any
+	b := NewEventBridge(
+		events.NewEventBus(),
+		h,
+		NewExecutionTracker(),
+		func(msg any) error { sent = append(sent, msg); return nil },
+		func() {},
+	)
+
+	run := &model.Run{TaskName: "heartbeat"} // no ExternalExecutionID
+	b.handleRunEvent(context.Background(), events.Event{Data: events.RunEvent{Run: run}})
+
+	require.Len(t, sent, 1)
+	msg, ok := sent[0].(protocol.ServiceStatusMessage)
+	require.True(t, ok)
+	assert.Equal(t, "heartbeat", msg.TaskID, "service:status is keyed by the bare TOML name")
+	assert.Equal(t, 2, msg.DesiredInstances)
+}
 
 func TestEventBridge_HandleRunEvent_IgnoresWrongData(t *testing.T) {
 	b := newTestBridge(newTestInboundHandler())

--- a/apps/runwisp/internal/cloud/service_handler.go
+++ b/apps/runwisp/internal/cloud/service_handler.go
@@ -5,6 +5,7 @@ package cloud
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"log/slog"
@@ -13,16 +14,35 @@ import (
 	"github.com/runwisp/runwisp/internal/model"
 )
 
-// HandleServiceApply installs (or updates) a cloud-declared service and brings
-// it up to its desired instance count when autostart is set. Unlike an
-// execution dispatch, a service is a desired-state declaration: the daemon's
-// supervisor keeps `instances` copies alive, restarting them with the
+// HandleServiceApply installs or updates a service. Two shapes resolve here:
+//
+//   - A synced TOML service, addressed by its bare name: the present payload
+//     fields are merged onto the live definition (instances/restart/env/script)
+//     while every TOML-only field (working_dir, shell, umask, run_user,
+//     depends_on, secrets) is preserved, then re-upserted so the supervisor
+//     rescales in place. Its running/stopped state is owned by service:control,
+//     so an apply never starts it.
+//   - A cloud-declared service, addressed by a ULID: built from scratch and
+//     brought up to its instance count when autostart is set (unchanged).
+//
+// Unlike an execution dispatch, a service is a desired-state declaration: the
+// daemon's supervisor keeps `instances` copies alive, restarting them with the
 // configured backoff. The task is registered with Restart=always + Kind=service
 // so the supervisor owns its lifecycle (see retry.ShouldRestart).
 func (h *InboundHandler) HandleServiceApply(message protocol.ServiceApplyMessage) error {
 	svc := message.Service
 	if svc == nil {
 		return &CloudError{Kind: CloudErrorKindValidation, Message: "service is required"}
+	}
+
+	if name, existing := h.resolveServiceTarget(svc.TaskID, svc.TaskName); existing {
+		base, _ := h.taskManager.GetTask(name)
+		if err := h.mergeServiceApply(base, svc); err != nil {
+			return err
+		}
+		h.taskManager.UpsertTask(base)
+		slog.Info("service override applied", "task", name, "instances", base.Instances)
+		return nil
 	}
 
 	task, err := h.buildServiceTask(svc)
@@ -49,7 +69,7 @@ func (h *InboundHandler) HandleServiceApply(message protocol.ServiceApplyMessage
 // The action enum is gated by the protocol; an unknown value is treated as a
 // validation error rather than silently ignored.
 func (h *InboundHandler) HandleServiceControl(message protocol.ServiceControlMessage) error {
-	taskName := sanitizeCloudTaskName(message.TaskID)
+	taskName, _ := h.resolveServiceTarget(message.TaskID, "")
 	if taskName == "" {
 		return &CloudError{Kind: CloudErrorKindValidation, Message: "taskId is required"}
 	}
@@ -139,6 +159,77 @@ func (h *InboundHandler) buildServiceTask(svc *protocol.Service) (*model.Task, e
 	applyServiceTaskConfig(task, svc.TaskConfig)
 
 	return task, nil
+}
+
+// resolveServiceTarget maps a cloud-supplied taskId/taskName onto a registered
+// task name. A synced TOML service is addressed by its bare name, so a literal
+// registry hit means "merge onto this existing definition" (existing=true). A
+// cloud-declared service carries a ULID with no literal match; it falls back to
+// the sanitized cloud-<id> form (existing=false) used by buildServiceTask, so
+// control/status/apply all resolve to the same name.
+func (h *InboundHandler) resolveServiceTarget(taskID, taskName string) (name string, existing bool) {
+	for _, raw := range []string{taskID, taskName} {
+		if n := strings.TrimSpace(raw); n != "" {
+			if _, ok := h.taskManager.GetTask(n); ok {
+				return n, true
+			}
+		}
+	}
+	if n := sanitizeCloudTaskName(taskID); n != "" {
+		return n, false
+	}
+	return sanitizeCloudTaskName(taskName), false
+}
+
+// mergeServiceApply overlays the fields a service:apply payload carries onto an
+// existing (synced TOML) service definition, leaving every field the payload
+// does not address untouched. The cloud reasserts the full effective spec on
+// each apply, so absent/zero fields mean "keep the current value". script is
+// special: a synced service's cloud Script is a config-reference placeholder the
+// cloud omits unless the operator overrode the command, so it is applied only
+// when the payload actually carries one.
+//
+// "Omits" is logical, not literal: the wire field is non-omitempty, so a nil
+// cloud Script marshals to the JSON literal `null` rather than being dropped.
+// Treat that `null` exactly like an absent field — keep the live TOML command —
+// instead of feeding it to ParseExecutionDef (which rejects it). Only a real def
+// overrides the command.
+func (h *InboundHandler) mergeServiceApply(task *model.Task, svc *protocol.Service) error {
+	if len(svc.Script) > 0 && string(svc.Script) != "null" {
+		execDef, err := model.ParseExecutionDef(svc.Script)
+		if err != nil {
+			return &CloudError{
+				Kind:    CloudErrorKindValidation,
+				Message: fmt.Sprintf("failed to parse execution def: %v", err),
+			}
+		}
+		if status := h.availability.ForType(execDef.ExecType()); !status.Available {
+			return &CloudError{
+				Kind:    CloudErrorKindConflict,
+				Message: fmt.Sprintf("execution type %q not available: %s", execDef.ExecType(), status.Reason),
+			}
+		}
+		task.ExecutionDef = execDef
+	}
+
+	if svc.Instances >= 1 {
+		task.Instances = svc.Instances
+		task.MaxConcurrent = svc.Instances
+	}
+	if svc.RestartDelay > 0 {
+		task.RestartDelay = time.Duration(svc.RestartDelay) * time.Millisecond
+	}
+	if svc.BackoffResetAfter > 0 {
+		task.HealthyAfter = time.Duration(svc.BackoffResetAfter) * time.Millisecond
+	}
+	if svc.RestartBackoff != nil {
+		if s, ok := svc.RestartBackoff.Value().(string); ok && s != "" {
+			task.RestartBackoff = s
+		}
+	}
+
+	applyServiceTaskConfig(task, svc.TaskConfig)
+	return nil
 }
 
 // applyServiceTaskConfig overlays the optional per-process knobs a service

--- a/apps/runwisp/internal/cloud/service_handler_test.go
+++ b/apps/runwisp/internal/cloud/service_handler_test.go
@@ -219,3 +219,129 @@ func TestHandleServiceApply_DefaultsToCloudServiceName(t *testing.T) {
 	require.Len(t, runner.upserted, 1)
 	assert.Equal(t, "cloud-service", runner.upserted[0].Name)
 }
+
+// A service:apply addressed by the bare name of a synced TOML service merges the
+// present fields onto the live definition: TOML-only fields (working_dir,
+// depends_on) survive, the absent script leaves the real exec def intact, and
+// the override path never starts the service (control owns running/stopped).
+func TestHandleServiceApply_MergesOntoExistingTOMLService(t *testing.T) {
+	origExec := &model.ShellExecution{Script: "heartbeat.sh"}
+	existing := &model.Task{
+		Name:          "heartbeat",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		WorkingDir:    "/srv/app",
+		DependsOn:     []string{"pg"},
+		ExecutionDef:  origExec,
+	}
+	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"heartbeat": existing})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{
+			TaskID:    "heartbeat",
+			TaskName:  "heartbeat",
+			Instances: 3,
+			Autostart: true, // ignored on the merge path
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.upserted, 1)
+	task := runner.upserted[0]
+	assert.Equal(t, "heartbeat", task.Name)
+	assert.Equal(t, 3, task.Instances)
+	assert.Equal(t, 3, task.MaxConcurrent)
+	assert.Equal(t, "/srv/app", task.WorkingDir, "TOML-only field must be preserved")
+	assert.Equal(t, []string{"pg"}, task.DependsOn, "TOML-only field must be preserved")
+	assert.Same(t, origExec, task.ExecutionDef, "absent script must leave the exec def untouched")
+	assert.Empty(t, runner.startedServices, "merge path must not start the service")
+}
+
+// The cloud's Script field is non-omitempty on the wire, so a synced service
+// with no command override arrives as the JSON literal `null`, not an absent
+// field. The merge must treat that exactly like an absent script — keep the live
+// TOML command — rather than feed `null` to ParseExecutionDef (which rejects it
+// and would fail every reconnect re-apply).
+func TestHandleServiceApply_MergeKeepsCommandOnNullScript(t *testing.T) {
+	origExec := &model.ShellExecution{Script: "heartbeat.sh"}
+	existing := &model.Task{
+		Name:          "heartbeat",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		ExecutionDef:  origExec,
+	}
+	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"heartbeat": existing})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{
+			TaskID:    "heartbeat",
+			TaskName:  "heartbeat",
+			Script:    json.RawMessage("null"),
+			Instances: 2,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.upserted, 1)
+	task := runner.upserted[0]
+	assert.Same(t, origExec, task.ExecutionDef, "null script must leave the live command untouched")
+	assert.Equal(t, 2, task.Instances, "other overlaid fields must still apply")
+}
+
+// When the payload carries a script (the operator overrode the command), the
+// merge replaces the exec def while still preserving the rest of the definition.
+func TestHandleServiceApply_MergeAppliesOverriddenScript(t *testing.T) {
+	existing := &model.Task{
+		Name:          "heartbeat",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		WorkingDir:    "/srv/app",
+		ExecutionDef:  &model.ShellExecution{Script: "old.sh"},
+	}
+	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"heartbeat": existing})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{
+			TaskID: "heartbeat",
+			Script: shellScript(t, "new.sh"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.upserted, 1)
+	task := runner.upserted[0]
+	shell, ok := task.ExecutionDef.(*model.ShellExecution)
+	require.True(t, ok)
+	assert.Equal(t, "new.sh", shell.Script)
+	assert.Equal(t, "/srv/app", task.WorkingDir, "TOML-only field must survive a script override")
+}
+
+// HandleServiceControl resolves a synced TOML service by its bare name and a
+// cloud-declared service by its ULID (→ cloud-<id>), so both addressing schemes
+// reach the supervisor.
+func TestHandleServiceControl_ResolvesBareNameAndCloudID(t *testing.T) {
+	start := protocol.ActionStart
+
+	t.Run("bare name of a synced service", func(t *testing.T) {
+		existing := &model.Task{Name: "heartbeat", Kind: model.KindService}
+		h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"heartbeat": existing})
+		runner := h.taskManager.(*fakeTaskRunner)
+		err := h.HandleServiceControl(protocol.ServiceControlMessage{TaskID: "heartbeat", Action: &start})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"heartbeat"}, runner.startedServices)
+	})
+
+	t.Run("ULID of a cloud-declared service", func(t *testing.T) {
+		h := newDispatchHandler(shellAvailable(), nil)
+		runner := h.taskManager.(*fakeTaskRunner)
+		err := h.HandleServiceControl(protocol.ServiceControlMessage{TaskID: "svc-1", Action: &start})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cloud-svc-1"}, runner.startedServices)
+	})
+}

--- a/apps/runwisp/internal/cloud/service_handler_test.go
+++ b/apps/runwisp/internal/cloud/service_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/runwisp/runwisp/internal/executor"
 	"github.com/runwisp/runwisp/internal/generated/protocol"
@@ -320,6 +321,84 @@ func TestHandleServiceApply_MergeAppliesOverriddenScript(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "new.sh", shell.Script)
 	assert.Equal(t, "/srv/app", task.WorkingDir, "TOML-only field must survive a script override")
+}
+
+// A merge overlays the present restart knobs (restartDelay, backoffResetAfter →
+// HealthyAfter, restartBackoff) onto the live definition; absent/zero fields are
+// left as they were.
+func TestHandleServiceApply_MergeOverlaysRestartFields(t *testing.T) {
+	backoff := protocol.ServiceRestartBackoffExponential
+	existing := &model.Task{
+		Name:          "heartbeat",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		ExecutionDef:  &model.ShellExecution{Script: "heartbeat.sh"},
+	}
+	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"heartbeat": existing})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{
+			TaskID:            "heartbeat",
+			TaskName:          "heartbeat",
+			RestartDelay:      2000,
+			BackoffResetAfter: 60000,
+			RestartBackoff:    &backoff,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.upserted, 1)
+	task := runner.upserted[0]
+	assert.Equal(t, 2*time.Second, task.RestartDelay)
+	assert.Equal(t, time.Minute, task.HealthyAfter)
+	assert.Equal(t, "exponential", task.RestartBackoff)
+}
+
+// An unparseable script override on the merge path surfaces as a validation
+// error (and propagates out of HandleServiceApply) rather than clobbering the
+// live definition.
+func TestHandleServiceApply_MergeInvalidScriptOverrideRejected(t *testing.T) {
+	existing := &model.Task{
+		Name:          "heartbeat",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		ExecutionDef:  &model.ShellExecution{Script: "heartbeat.sh"},
+	}
+	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"heartbeat": existing})
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{TaskID: "heartbeat", Script: json.RawMessage("not-json")},
+	})
+	require.Error(t, err)
+	var ce *CloudError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, CloudErrorKindValidation, ce.Kind)
+}
+
+// A script override whose execution type has no available backend is a conflict
+// on the merge path, mirroring the build path.
+func TestHandleServiceApply_MergeUnavailableBackendRejected(t *testing.T) {
+	existing := &model.Task{
+		Name:          "heartbeat",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		ExecutionDef:  &model.ShellExecution{Script: "heartbeat.sh"},
+	}
+	h := newDispatchHandler(executor.Availability{}, map[string]*model.Task{"heartbeat": existing})
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{TaskID: "heartbeat", Script: shellScript(t, "new.sh")},
+	})
+	require.Error(t, err)
+	var ce *CloudError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, CloudErrorKindConflict, ce.Kind)
 }
 
 // HandleServiceControl resolves a synced TOML service by its bare name and a

--- a/apps/runwisp/internal/cloud/sync_client.go
+++ b/apps/runwisp/internal/cloud/sync_client.go
@@ -61,6 +61,16 @@ type syncTask struct {
 	Enabled             *bool              `json:"enabled,omitempty"`
 	Script              json.RawMessage    `json:"script,omitempty"`
 	Schedules           []syncTaskSchedule `json:"schedules,omitempty"`
+
+	// Service-only fields. All omitempty so a cloud that predates service sync
+	// ignores them and treats the row as a plain task.
+	Kind              string                `json:"kind,omitempty"`
+	Instances         *int                  `json:"instances,omitempty"`
+	Autostart         *bool                 `json:"autostart,omitempty"`
+	RestartDelay      *int                  `json:"restartDelay,omitempty"`      // milliseconds
+	RestartBackoff    string                `json:"restartBackoff,omitempty"`    // distinct from a task's RetryBackoff
+	BackoffResetAfter *int                  `json:"backoffResetAfter,omitempty"` // milliseconds, from HealthyAfter
+	Compose           *model.TaskComposeRef `json:"compose,omitempty"`
 }
 
 type syncTaskSchedule struct {
@@ -240,16 +250,43 @@ func buildOneSyncTask(t *model.Task) (syncTask, bool) {
 	}
 	enabled := true
 	task.Enabled = &enabled
-	if strings.TrimSpace(t.Cron) != "" {
+
+	if t.Kind.IsService() {
+		// Services carry no cron, so they never emit a schedule.
+		applyServiceSyncFields(&task, t)
+	} else if cron := strings.TrimSpace(t.Cron); cron != "" {
 		task.Schedules = []syncTaskSchedule{
 			{
-				Cron:     strings.TrimSpace(t.Cron),
+				Cron:     cron,
 				Timezone: "UTC",
 				Enabled:  true,
 			},
 		}
 	}
 	return task, true
+}
+
+// applyServiceSyncFields populates the service-only fields of a sync row from a
+// service task. Kept separate from buildOneSyncTask so the task path stays
+// simple and neither grows the other's cognitive complexity.
+func applyServiceSyncFields(task *syncTask, t *model.Task) {
+	task.Kind = string(model.KindService)
+	if t.Instances > 0 {
+		instances := t.Instances
+		task.Instances = &instances
+	}
+	autostart := t.Autostart
+	task.Autostart = &autostart
+	if delayMs := durationToMillis(t.RestartDelay); delayMs > 0 {
+		task.RestartDelay = &delayMs
+	}
+	if t.RestartBackoff != "" {
+		task.RestartBackoff = t.RestartBackoff
+	}
+	if resetMs := durationToMillis(t.HealthyAfter); resetMs > 0 {
+		task.BackoffResetAfter = &resetMs
+	}
+	task.Compose = t.Compose
 }
 
 func buildTaskSyncID(tasks []syncTask) string {

--- a/apps/runwisp/internal/cloud/sync_client.go
+++ b/apps/runwisp/internal/cloud/sync_client.go
@@ -251,6 +251,8 @@ func buildOneSyncTask(t *model.Task) (syncTask, bool) {
 	enabled := true
 	task.Enabled = &enabled
 
+	task.Kind = string(t.Kind)
+
 	if t.Kind.IsService() {
 		// Services carry no cron, so they never emit a schedule.
 		applyServiceSyncFields(&task, t)
@@ -270,7 +272,6 @@ func buildOneSyncTask(t *model.Task) (syncTask, bool) {
 // service task. Kept separate from buildOneSyncTask so the task path stays
 // simple and neither grows the other's cognitive complexity.
 func applyServiceSyncFields(task *syncTask, t *model.Task) {
-	task.Kind = string(model.KindService)
 	if t.Instances > 0 {
 		instances := t.Instances
 		task.Instances = &instances

--- a/apps/runwisp/internal/cloud/sync_client_test.go
+++ b/apps/runwisp/internal/cloud/sync_client_test.go
@@ -92,6 +92,61 @@ func TestBuildOneSyncTask(t *testing.T) {
 		assert.True(t, st.Schedules[0].Enabled)
 		require.NotNil(t, st.Enabled)
 		assert.True(t, *st.Enabled)
+		// A plain task carries no service fields (omitempty regression guard).
+		assert.Empty(t, st.Kind)
+		assert.Nil(t, st.Instances)
+		assert.Nil(t, st.Autostart)
+		assert.Nil(t, st.RestartDelay)
+		assert.Nil(t, st.BackoffResetAfter)
+		assert.Nil(t, st.Compose)
+	})
+
+	t.Run("service emits service fields and no schedule", func(t *testing.T) {
+		compose := &model.TaskComposeRef{File: "compose.yml", Service: "hb", ProjectName: "proj"}
+		task := &model.Task{
+			Name:           "heartbeat",
+			Run:            "heartbeat.sh",
+			Kind:           model.KindService,
+			Restart:        model.RestartAlways,
+			Instances:      3,
+			Autostart:      true,
+			RestartDelay:   2 * time.Second,
+			RestartBackoff: model.BackoffExponential,
+			HealthyAfter:   60 * time.Second,
+			Compose:        compose,
+			// A cron on a service would be a config bug; assert it is never emitted.
+			Cron: "*/5 * * * *",
+		}
+
+		st, ok := buildOneSyncTask(task)
+		require.True(t, ok)
+		assert.Equal(t, string(model.KindService), st.Kind)
+		assert.Equal(t, string(model.RestartAlways), st.RestartPolicy)
+		require.NotNil(t, st.Instances)
+		assert.Equal(t, 3, *st.Instances)
+		require.NotNil(t, st.Autostart)
+		assert.True(t, *st.Autostart)
+		require.NotNil(t, st.RestartDelay)
+		assert.Equal(t, 2000, *st.RestartDelay)
+		assert.Equal(t, model.BackoffExponential, st.RestartBackoff)
+		require.NotNil(t, st.BackoffResetAfter)
+		assert.Equal(t, 60000, *st.BackoffResetAfter)
+		assert.Equal(t, compose, st.Compose)
+		assert.Empty(t, st.Schedules, "services never carry a schedule")
+	})
+
+	t.Run("non-autostart service still emits autostart=false", func(t *testing.T) {
+		task := &model.Task{
+			Name:      "stopped-svc",
+			Run:       "svc.sh",
+			Kind:      model.KindService,
+			Instances: 1,
+			Autostart: false,
+		}
+		st, ok := buildOneSyncTask(task)
+		require.True(t, ok)
+		require.NotNil(t, st.Autostart)
+		assert.False(t, *st.Autostart)
 	})
 
 	t.Run("task with all optional fields", func(t *testing.T) {

--- a/apps/runwisp/internal/model/model.go
+++ b/apps/runwisp/internal/model/model.go
@@ -207,11 +207,13 @@ const (
 	RestartOnFailure RestartPolicy = "on_failure"
 )
 
-// TaskKind distinguishes scheduled/manual tasks from always-on services.
+// TaskKind distinguishes scheduled/manual tasks from always-on services. The
+// value is always explicit ("task" or "service"): it is emitted verbatim on the
+// sync wire and stored verbatim by cloud, so neither side infers a missing kind.
 type TaskKind string
 
 const (
-	KindTask    TaskKind = ""
+	KindTask    TaskKind = "task"
 	KindService TaskKind = "service"
 )
 


### PR DESCRIPTION
## Description

Routine branch sync — brings `main` up to date with `cloud`. Nothing here that hasn't already been through its own PR; this just reconciles the two branches so they stop drifting apart.

## Type of Change

- [x] Refactor / cleanup

## Checklist

- [x] Validation passes locally (`bun run ci`)
