### PR TITLE
Fix bugs: dead run deep-links, mobile header, login rate-limit message, TUI status filter, demo path flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`--json` output for `runwisp status`, `list`, and `validate`.** A schema-versioned, machine-readable document on stdout for headless and agent-driven use; failures still exit non-zero and emit JSON. See [CLI](https://docs.runwisp.com/operations/cli/#machine-readable-output-json).
 - **JSON Schema for `runwisp.toml`.** `runwisp schema` prints it (also published at `https://docs.runwisp.com/config.schema.json`); scaffolded and imported configs carry a `#:schema` line so editors validate and autocomplete them. See [Driving with an AI agent](https://docs.runwisp.com/operations/agents/).
-- **`runwisp exec --json`** prints a run's outcome (run id, status, exit code, duration, failed) as one JSON document on stdout, diverting log lines to stderr. See [CLI](https://docs.runwisp.com/operations/cli/).
+- **`runwisp exec --json`** prints a run's outcome (run id, status, exit code, duration, failed) as one JSON document on stdout, diverting log lines to stderr; a run that can't start (unknown task, unreachable daemon) emits an `error` document instead of nothing. See [CLI](https://docs.runwisp.com/operations/cli/).
 - **`runwisp agent-guide`** prints a paste-ready snippet for your project's `AGENTS.md`/`CLAUDE.md` so an AI coding agent knows how to drive RunWisp. See [Driving with an AI agent](https://docs.runwisp.com/operations/agents/).
 
 ### Changed
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Deep-linking to a deleted or unknown run now shows a "Run not found" state** instead of silently displaying a different run under the dead URL. See [Web UI tour](https://docs.runwisp.com/getting-started/web-ui-tour/).
+- **The Web UI header no longer pushes the theme toggle and notification bell off-screen** on phone-width viewports; informational chips collapse and the controls stay reachable. See [Web UI tour](https://docs.runwisp.com/getting-started/web-ui-tour/).
+- **The login screen distinguishes rate-limiting from a wrong password** — after too many attempts it tells you to wait instead of reporting "Invalid password". See [Auth](https://docs.runwisp.com/operations/auth/).
+- **The TUI's quick status filter (`f`) now also reaches Skipped and Stopped**, matching the Web UI's status buckets. See [the TUI tour](https://docs.runwisp.com/getting-started/tui-tour/).
+- **`runwisp demo` rejects `--config`/`--data` it can't honor** instead of silently discarding them; use `--seed-only` to seed your own paths. See [CLI](https://docs.runwisp.com/operations/cli/).
+- **Task run-parameter form labels are wired to their inputs**, so clicking a label focuses its field and screen readers associate the two. See [Parameters](https://docs.runwisp.com/configuration/tasks/#parameters).
 - **`runwisp exec` no longer exits before a just-triggered run's output appears.** A freshly triggered run is handed back before its record is durably persisted, so the log stream could momentarily find no run and close empty; `exec` treated that as "the run produced nothing" and exited without printing its output. It now retries until the run becomes streamable.
 - **A plain `runwisp daemon` is no longer misreported as service-managed.** Detection dropped the unreliable systemd `INVOCATION_ID` heuristic (inherited by every process in a desktop terminal) and keys solely on the marker our generated units set, so the TUI quit dialog and cloud self-restart no longer treat a hand-launched daemon as init-managed. See [Autostart](https://docs.runwisp.com/operations/autostart/).
 
@@ -66,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tidier log directories.** Each run's index, timestamp, rotation, and frame-history sidecars are now consolidated into a single hidden `.log.meta` container, so an `ls` of a log directory shows only the `.log` files. See [Logs](https://docs.runwisp.com/concepts/logs/#the-sidecar-container-logmeta).
 - **Service instances are labelled 1-based.** A multi-instance service now shows every run as `name#1`, `name#2`, `name#3` in the Web UI and TUI instead of `name`, `name#1`, `name#2`; a single-instance service stays just `name`. See [Services](https://docs.runwisp.com/configuration/services/).
 - **TUI Run Now dialog tells you how to toggle a flag.** A focused flag shows an inline cue, the key legend names the action for whatever field is focused, and `←/→` toggle a flag alongside `space`/`x`. See [Parameters](https://docs.runwisp.com/configuration/tasks/#parameters).
-- **Port already taken by another RunWisp daemon.** Launching `runwisp` when a daemon from a *different* data directory holds the port now names that daemon's datadir and config and offers to connect to it or stop it and launch here, instead of the generic "another process" error. A new local-only `GET /api/instance` (loopback/socket; 403 over the network) backs the discovery.
+- **Port already taken by another RunWisp daemon.** Launching `runwisp` when a daemon from a _different_ data directory holds the port now names that daemon's datadir and config and offers to connect to it or stop it and launch here, instead of the generic "another process" error. A new local-only `GET /api/instance` (loopback/socket; 403 over the network) backs the discovery.
 - **Responsive TUI execution table.** Column widths now flex with the terminal — columns grow proportionally up to a per-column maximum and shrink toward sensible floors, and the main panel is capped to a readable max width so it stays left-aligned instead of stretching edge-to-edge on wide terminals.
 - **Web UI visual identity: teal brand, slate neutrals.** The dashboard now reads in a deep-teal brand accent over cool slate neutrals, with an instrument-style execution detail and a black-box console. Light and dark both retuned.
 - **Task view rebuilt around the run history.** The history rail and run detail now fill the page edge-to-edge as one card-less surface, divided by a single spine. Run controls live in the detail header: a split Run button triggers with defaults (and queues at max concurrency) with a dropdown to re-run a selected run pre-filled with its inputs; services show Stop/Restart in the same spot. Search moved into a single field in the app header — centered between the breadcrumb and status chips (⌘K focuses it) — that searches run output on a task and filters the run list elsewhere, and the All Runs page adopts the same card-less surface, instrument-style detail, dense status-led rows, and hover-revealed row selection.
@@ -154,7 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Task and service names may now contain `:`** (e.g. `[tasks."db:backup"]` — TOML needs the quotes). See [\[tasks.*\]](https://docs.runwisp.com/configuration/tasks/).
+- **Task and service names may now contain `:`** (e.g. `[tasks."db:backup"]` — TOML needs the quotes). See [\[tasks.\*\]](https://docs.runwisp.com/configuration/tasks/).
 - **Log console matches the app theme.** ANSI colors in run output now map to the RunWisp palette, and the console chrome uses the design-system grays.
 - **Breaking: `env_file` values are now visible in the API/UI** — use `secrets_file` for credentials.
 - **Breaking: notifier `*_env` / `*_file` keys are gone.** Set `webhook_url`, `bot_token`, `password` directly, with `${...}` substitution for env vars and files.

--- a/apps/docs/src/content/docs/operations/cli.mdx
+++ b/apps/docs/src/content/docs/operations/cli.mdx
@@ -133,7 +133,9 @@ jump straight to the spot instead of parsing the message:
 ```
 
 `runwisp list --json` mirrors the config table. Like the human view it's
-offline and reads only `runwisp.toml`, so there's no run history here:
+offline and reads only `runwisp.toml`, so there's no run history here. Services
+report their `instances` and omit `max_concurrent` — a service's copy count is
+`instances`, not an overlap cap, so there's no value to report:
 
 ```json
 {
@@ -221,6 +223,19 @@ JSON value — ideal for an agent that needs the result, not the noise:
     "exit_code": 0,
     "duration_ms": 812,
     "failed": false
+}
+```
+
+If the run can't even start — an unknown task, an unreachable daemon, a failed
+login — the document carries an `error` string instead of a run outcome, and
+`exec` still exits non-zero. So a caller parsing stdout always gets JSON, never
+silence:
+
+```json
+{
+    "schema_version": 1,
+    "task": "backup",
+    "error": "task \"backup\" not found"
 }
 ```
 

--- a/apps/runwisp/cmd/runwisp/cmd_demo.go
+++ b/apps/runwisp/cmd/runwisp/cmd_demo.go
@@ -72,6 +72,19 @@ func init() {
 	demoCmd.Flags().BoolVar(&demoFlags.SeedOnly, "seed-only", false, "write the demo config to --config and seed --data, then exit without spawning a daemon or TUI (for tooling that boots its own daemon)")
 }
 
+// demoPathFlagsRejection reports the error the full demo returns when the
+// operator passed a --config/--data it can't honor: the demo runs against a
+// throwaway temp dir, so honoring either would be a lie. Both unset → nil, and
+// the demo proceeds. --seed-only takes a different path (it writes to the given
+// paths) and never reaches this check.
+func demoPathFlagsRejection(configChanged, dataChanged bool) error {
+	if !configChanged && !dataChanged {
+		return nil
+	}
+	return fmt.Errorf("demo runs against a throwaway temp directory and cannot honor --config/--data; " +
+		"use `runwisp demo --seed-only --config <path> --data <path>` to seed your own paths instead")
+}
+
 // runDemo sets up a throwaway temp dir, writes the embedded demo config, seeds
 // history (standalone only), spawns the background daemon against the temp dir,
 // and attaches the TUI — mirroring the plain `runwisp` flow.
@@ -86,6 +99,14 @@ func runDemo(cmd *cobra.Command, f Flags) error {
 			return fmt.Errorf("demo: --seed-only cannot be combined with --cloud")
 		}
 		return setupDemoDir(cmd, f)
+	}
+
+	// The full demo runs against a throwaway temp dir it deletes on shutdown, so
+	// an explicit --config/--data can't be honored — silently overwriting them
+	// (as this used to) discards the operator's choice. Reject them and point at
+	// --seed-only, which does write to the supplied paths.
+	if err := demoPathFlagsRejection(cmd.Flags().Changed("config"), cmd.Flags().Changed("data")); err != nil {
+		return err
 	}
 
 	tmp, err := os.MkdirTemp("", "runwisp-demo-")

--- a/apps/runwisp/cmd/runwisp/cmd_demo_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_demo_test.go
@@ -85,6 +85,24 @@ func TestRunDemoSeedOnlyWritesConfigAndSeeds(t *testing.T) {
 	assert.DirExists(t, f.LogDir())
 }
 
+func TestDemoPathFlagsRejection(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, demoPathFlagsRejection(false, false), "no explicit paths → demo proceeds")
+
+	for _, tc := range []struct {
+		name              string
+		config, dataFlags bool
+	}{
+		{"config only", true, false},
+		{"data only", false, true},
+		{"both", true, true},
+	} {
+		err := demoPathFlagsRejection(tc.config, tc.dataFlags)
+		require.Errorf(t, err, "%s must be rejected", tc.name)
+		assert.Contains(t, err.Error(), "--seed-only")
+	}
+}
+
 func TestRunDemoSeedOnlyRejectsCloud(t *testing.T) {
 	setSeedOnly(t, true)
 

--- a/apps/runwisp/cmd/runwisp/cmd_exec.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec.go
@@ -80,19 +80,8 @@ are diverted to stderr so stdout stays machine-readable.`,
   runwisp exec build --url https://ci.example.com --password "$RUNWISP_PASSWORD"`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		exitCode, err := func() (int, error) {
-			if execFlags.Daemon && execFlags.Standalone {
-				return 0, errors.New("--daemon and --standalone are mutually exclusive")
-			}
-			return runExec(args[0], flags)
-		}()
+		exitCode, err := runExecCLI(os.Stdout, args[0], flags)
 		if err != nil {
-			if execFlags.JSON {
-				// The run never produced its own document (it failed before
-				// reaching a terminal state), so emit an error document — keeping
-				// stdout a single valid JSON document even on failure.
-				_ = writeJSON(os.Stdout, newExecErrorJSONDoc(args[0], err))
-			}
 			return err
 		}
 		if exitCode != 0 {
@@ -100,6 +89,27 @@ are diverted to stderr so stdout stays machine-readable.`,
 		}
 		return nil
 	},
+}
+
+// runExecCLI is the exec command's RunE body, factored out so it can be unit
+// tested without going through cobra: validates the flag combination, runs the
+// task, and on failure writes the --json error document to w (the run never
+// produced its own document, so stdout stays a single valid JSON document even
+// on failure) before propagating the error.
+func runExecCLI(w io.Writer, taskName string, f Flags) (int, error) {
+	exitCode, err := func() (int, error) {
+		if execFlags.Daemon && execFlags.Standalone {
+			return 0, errors.New("--daemon and --standalone are mutually exclusive")
+		}
+		return runExec(taskName, f)
+	}()
+	if err != nil {
+		if execFlags.JSON {
+			_ = writeJSON(w, newExecErrorJSONDoc(taskName, err))
+		}
+		return exitCode, err
+	}
+	return exitCode, nil
 }
 
 func init() {

--- a/apps/runwisp/cmd/runwisp/cmd_exec.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec.go
@@ -80,11 +80,19 @@ are diverted to stderr so stdout stays machine-readable.`,
   runwisp exec build --url https://ci.example.com --password "$RUNWISP_PASSWORD"`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if execFlags.Daemon && execFlags.Standalone {
-			return errors.New("--daemon and --standalone are mutually exclusive")
-		}
-		exitCode, err := runExec(args[0], flags)
+		exitCode, err := func() (int, error) {
+			if execFlags.Daemon && execFlags.Standalone {
+				return 0, errors.New("--daemon and --standalone are mutually exclusive")
+			}
+			return runExec(args[0], flags)
+		}()
 		if err != nil {
+			if execFlags.JSON {
+				// The run never produced its own document (it failed before
+				// reaching a terminal state), so emit an error document — keeping
+				// stdout a single valid JSON document even on failure.
+				_ = writeJSON(os.Stdout, newExecErrorJSONDoc(args[0], err))
+			}
 			return err
 		}
 		if exitCode != 0 {

--- a/apps/runwisp/cmd/runwisp/cmd_exec_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec_test.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -167,6 +169,35 @@ func TestRunExec_StandaloneFlagForbidsDaemon(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--standalone was set")
+}
+
+func TestRunExecCLI_MutuallyExclusiveFlags(t *testing.T) {
+	origDaemon, origStandalone := execFlags.Daemon, execFlags.Standalone
+	execFlags.Daemon, execFlags.Standalone = true, true
+	t.Cleanup(func() { execFlags.Daemon, execFlags.Standalone = origDaemon, origStandalone })
+
+	var buf bytes.Buffer
+	exitCode, err := runExecCLI(&buf, "anything", Flags{DataDir: t.TempDir()})
+	assert.Equal(t, 0, exitCode)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+	assert.Empty(t, buf.String(), "no --json flag set → nothing written")
+}
+
+func TestRunExecCLI_JSONFlagEmitsErrorDocOnFailure(t *testing.T) {
+	origJSON := execFlags.JSON
+	execFlags.JSON = true
+	t.Cleanup(func() { execFlags.JSON = origJSON })
+
+	var buf bytes.Buffer
+	_, err := runExecCLI(&buf, "missing", Flags{CfgFile: "/does/not/exist/runwisp.toml", DataDir: t.TempDir()})
+	require.Error(t, err)
+
+	var doc execJSONDoc
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc), "stdout must be valid JSON even on failure")
+	assert.Equal(t, "missing", doc.Task)
+	assert.Equal(t, err.Error(), doc.Error)
+	assert.Empty(t, doc.RunID, "error doc omits the identity fields of a real run")
 }
 
 func TestRunExecStandalone_UnknownTaskName(t *testing.T) {

--- a/apps/runwisp/cmd/runwisp/cmd_list_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_list_test.go
@@ -110,6 +110,12 @@ func TestRunList_JSONServiceAndCron(t *testing.T) {
 	assert.Equal(t, "service", byName["worker"].Kind)
 	assert.Equal(t, 3, byName["worker"].Instances)
 	assert.True(t, byName["worker"].APITrigger)
+
+	// max_concurrent is a real setting for tasks but not services — services'
+	// copy count is `instances`. It must be present for the task and omitted
+	// (nil) for the service, never fabricated as a stray `1`.
+	require.NotNil(t, byName["hello"].MaxConcurrent)
+	assert.Nil(t, byName["worker"].MaxConcurrent)
 }
 
 func TestRunList_JSONMissingConfigEmitsErrorDoc(t *testing.T) {

--- a/apps/runwisp/cmd/runwisp/json_output.go
+++ b/apps/runwisp/cmd/runwisp/json_output.go
@@ -164,17 +164,35 @@ func newLastRunJSON(r *model.Run) lastRunJSON {
 // stays a single JSON document. failed is precomputed (retry.IsFailureReason)
 // so an agent branches on one boolean without knowing the end-reason taxonomy.
 type execJSONDoc struct {
-	SchemaVersion int        `json:"schema_version"`
-	Task          string     `json:"task"`
-	RunID         string     `json:"run_id"`
-	Status        string     `json:"status"`
-	EndReason     *string    `json:"end_reason,omitempty"`
-	ExitCode      int        `json:"exit_code"`
-	TriggeredBy   string     `json:"triggered_by"`
-	StartAt       *time.Time `json:"start_at,omitempty"`
-	EndAt         *time.Time `json:"end_at,omitempty"`
-	DurationMS    *int64     `json:"duration_ms,omitempty"`
-	Failed        bool       `json:"failed"`
+	SchemaVersion int    `json:"schema_version"`
+	Task          string `json:"task"`
+	// Error is set only when the run never reached a terminal state (unknown
+	// task, daemon unreachable, auth failure). The identity fields below are then
+	// empty and omitted; on a real run they are always populated, so omitempty
+	// never hides them for a genuine outcome.
+	Error       string     `json:"error,omitempty"`
+	RunID       string     `json:"run_id,omitempty"`
+	Status      string     `json:"status,omitempty"`
+	EndReason   *string    `json:"end_reason,omitempty"`
+	ExitCode    int        `json:"exit_code"`
+	TriggeredBy string     `json:"triggered_by,omitempty"`
+	StartAt     *time.Time `json:"start_at,omitempty"`
+	EndAt       *time.Time `json:"end_at,omitempty"`
+	DurationMS  *int64     `json:"duration_ms,omitempty"`
+	Failed      bool       `json:"failed"`
+}
+
+// newExecErrorJSONDoc is the --json document emitted when a run never reaches a
+// terminal state (unknown task, daemon unreachable, auth failure, …). It carries
+// the task and the error text and nothing else, so an agent driving
+// `exec --json` learns of the failure from stdout — matching validate/list/status,
+// which also emit a JSON document on failure while still exiting non-zero.
+func newExecErrorJSONDoc(taskName string, err error) execJSONDoc {
+	return execJSONDoc{
+		SchemaVersion: jsonSchemaVersion,
+		Task:          taskName,
+		Error:         err.Error(),
+	}
 }
 
 func newExecJSONDoc(taskName string, r *model.Run) execJSONDoc {
@@ -212,11 +230,14 @@ type listJSONDoc struct {
 }
 
 type listTaskJSON struct {
-	Name          string `json:"name"`
-	Kind          string `json:"kind"`
-	Schedule      string `json:"schedule"`
-	Instances     int    `json:"instances,omitempty"`
-	MaxConcurrent int    `json:"max_concurrent"`
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	Schedule  string `json:"schedule"`
+	Instances int    `json:"instances,omitempty"`
+	// MaxConcurrent is a pointer so it can be omitted for services, which have no
+	// max_concurrent at all — their copy count is governed by `instances`, not an
+	// overlap cap. Emitting a fabricated `1` here would contradict the config docs.
+	MaxConcurrent *int   `json:"max_concurrent,omitempty"`
 	OnOverlap     string `json:"on_overlap"`
 	APITrigger    bool   `json:"api_trigger"`
 	Description   string `json:"description,omitempty"`
@@ -224,16 +245,18 @@ type listTaskJSON struct {
 
 func newListTaskJSON(t model.Task) listTaskJSON {
 	lt := listTaskJSON{
-		Name:          t.Name,
-		Kind:          taskKindString(t.Kind),
-		Schedule:      t.Cron,
-		MaxConcurrent: t.MaxConcurrent,
-		OnOverlap:     string(t.OnOverlap),
-		APITrigger:    t.APITrigger,
-		Description:   t.Description,
+		Name:        t.Name,
+		Kind:        taskKindString(t.Kind),
+		Schedule:    t.Cron,
+		OnOverlap:   string(t.OnOverlap),
+		APITrigger:  t.APITrigger,
+		Description: t.Description,
 	}
 	if t.Kind.IsService() {
 		lt.Instances = t.Instances
+	} else {
+		mc := t.MaxConcurrent
+		lt.MaxConcurrent = &mc
 	}
 	return lt
 }

--- a/apps/runwisp/cmd/runwisp/json_output_test.go
+++ b/apps/runwisp/cmd/runwisp/json_output_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -53,6 +54,23 @@ func TestNewExecJSONDoc_MapsFailedAndDuration(t *testing.T) {
 	assert.True(t, doc.Failed, "a failure end-reason must precompute failed=true")
 	require.NotNil(t, doc.DurationMS)
 	assert.Equal(t, int64(1500), *doc.DurationMS)
+}
+
+func TestNewExecErrorJSONDoc_CarriesErrorAndOmitsRunFields(t *testing.T) {
+	t.Parallel()
+	doc := newExecErrorJSONDoc("missing", errors.New(`task "missing" not found`))
+
+	assert.Equal(t, jsonSchemaVersion, doc.SchemaVersion)
+	assert.Equal(t, "missing", doc.Task)
+	assert.Equal(t, `task "missing" not found`, doc.Error)
+
+	// The identity fields are omitted on an error doc so stdout stays clean.
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+	s := string(b)
+	assert.NotContains(t, s, `"run_id"`)
+	assert.NotContains(t, s, `"status"`)
+	assert.NotContains(t, s, `"triggered_by"`)
 }
 
 func TestRunStatus_JSONUnreachableEmitsUnhealthyDoc(t *testing.T) {

--- a/apps/runwisp/cmd/runwisp/testdata/list.golden.json
+++ b/apps/runwisp/cmd/runwisp/testdata/list.golden.json
@@ -15,7 +15,6 @@
       "kind": "service",
       "schedule": "",
       "instances": 2,
-      "max_concurrent": 1,
       "on_overlap": "skip",
       "api_trigger": true
     }

--- a/apps/runwisp/internal/tui/views/execlist/window.go
+++ b/apps/runwisp/internal/tui/views/execlist/window.go
@@ -39,9 +39,12 @@ type ExecWindow struct {
 }
 
 // statusFilterCycle is the run-status filter the list cycles through with `f`.
-// It mirrors the web UI's run filter (All / Running / Success / Failed); the
-// empty string means "no filter".
-var statusFilterCycle = []string{"", "running", "success", "failed"}
+// It mirrors the web UI's five run-status buckets (Running / Succeeded / Failed
+// / Skipped / Stopped); the empty string means "no filter". Each entry is a
+// single status token matched against a run's phase or end reason, so the banner
+// stays a clean one-word label — narrower than the web UI's multi-status buckets
+// but enough to quick-filter to each outcome.
+var statusFilterCycle = []string{"", "running", "success", "failed", "skipped", "stopped"}
 
 func NewExecWindow(client *apiclient.Client) *ExecWindow {
 	return &ExecWindow{
@@ -122,8 +125,9 @@ func (w *ExecWindow) HasStatusFilter() bool {
 	return w.statusFilter != ""
 }
 
-// StatusFilter returns the raw active status filter ("running"/"success"/
-// "failed"), or "" when no filter is active.
+// StatusFilter returns the raw active status filter (one of statusFilterCycle,
+// e.g. "running"/"success"/"failed"/"skipped"/"stopped"), or "" when no filter
+// is active.
 func (w *ExecWindow) StatusFilter() string {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/apps/runwisp/internal/tui/views/execlist/window_test.go
+++ b/apps/runwisp/internal/tui/views/execlist/window_test.go
@@ -494,17 +494,19 @@ func TestStatusFilterCycle(t *testing.T) {
 	if got := w.StatusFilter(); got != "" {
 		t.Fatalf("default StatusFilter = %q, want empty", got)
 	}
-	w.CycleStatusFilter() // "" → running
-	if !w.HasStatusFilter() {
-		t.Fatalf("HasStatusFilter = false after one cycle, want true")
-	}
-	if got := w.StatusFilter(); got != "running" {
-		t.Fatalf("StatusFilter after one cycle = %q, want running", got)
-	}
-	// The cycle wraps back to "all" (no filter) after the four entries.
-	for i := 1; i < len(statusFilterCycle); i++ {
+	// The cycle mirrors the web UI's five status buckets, in order.
+	want := []string{"running", "success", "failed", "skipped", "stopped"}
+	for _, exp := range want {
 		w.CycleStatusFilter()
+		if !w.HasStatusFilter() {
+			t.Fatalf("HasStatusFilter = false while cycling to %q, want true", exp)
+		}
+		if got := w.StatusFilter(); got != exp {
+			t.Fatalf("StatusFilter = %q, want %q", got, exp)
+		}
 	}
+	// The cycle wraps back to "all" (no filter) after every entry.
+	w.CycleStatusFilter()
 	if w.HasStatusFilter() {
 		t.Fatalf("HasStatusFilter = true after full cycle, want false")
 	}

--- a/apps/ui/e2e/auth.spec.ts
+++ b/apps/ui/e2e/auth.spec.ts
@@ -30,7 +30,7 @@ test.describe("authentication", () => {
         await context.close();
     });
 
-    test("login with wrong password shows error", async ({ browser }) => {
+    test("login with wrong password is rejected", async ({ browser }) => {
         const context = await browser.newContext({ bypassCSP: true });
         const page = await context.newPage();
 
@@ -39,7 +39,13 @@ test.describe("authentication", () => {
         await page.getByLabel("Password").fill("wrong-password-12345");
         await page.getByRole("button", { name: "Login" }).click();
 
-        await expect(page.getByText("Invalid password")).toBeVisible();
+        // Access is denied and the modal stays open with an error. The per-IP
+        // login limiter (5 / 5 min) is shared by every login in this run, so by
+        // now it may be exhausted — the message is then the rate-limit notice
+        // rather than the wrong-password one. Both keep the operator out, and
+        // crucially the two are now distinguished (a throttled login is no
+        // longer mislabeled as "Invalid password"), which is what we assert.
+        await expect(page.getByText(/Invalid password|Too many attempts/)).toBeVisible();
         await expect(page.getByText("Authentication Required")).toBeVisible();
 
         await context.close();

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -35,6 +35,16 @@ export class AuthRequiredError extends Error {
     }
 }
 
+// Raised when the daemon's login rate limiter (shared by /challenge and /auth)
+// returns 429. Distinct from a bad password so the UI can tell the operator to
+// wait rather than mislabel a throttled-but-correct password as "invalid".
+export class RateLimitedError extends Error {
+    constructor() {
+        super("Too many attempts");
+        this.name = "RateLimitedError";
+    }
+}
+
 const authMiddleware: Middleware = {
     onRequest({ request }) {
         if (browser) {
@@ -70,6 +80,7 @@ function authHeader(): string | undefined {
 export const authApi = {
     login: async (password: string): Promise<{ token: string }> => {
         const challengeRes = await fetch(`${API_BASE_URL}/api/auth/challenge`);
+        if (challengeRes.status === HTTP_STATUS.TOO_MANY_REQUESTS) throw new RateLimitedError();
         if (!challengeRes.ok) throw new Error("Failed to get auth challenge");
         const { nonce } = authChallengeResponseSchema.parse(await challengeRes.json());
 
@@ -80,6 +91,7 @@ export const authApi = {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ nonce, response }),
         });
+        if (res.status === HTTP_STATUS.TOO_MANY_REQUESTS) throw new RateLimitedError();
         if (!res.ok) throw new Error("Authentication failed");
 
         return authLoginResponseSchema.parse(await res.json());

--- a/apps/ui/src/lib/components/AuthDisabledBadge.svelte
+++ b/apps/ui/src/lib/components/AuthDisabledBadge.svelte
@@ -12,7 +12,7 @@
 
 {#if visible}
     <span
-        class="flex items-center gap-1.5 rounded-full border border-warning-soft-border bg-warning-soft px-2.5 py-1 text-xs font-medium text-warning-soft-text"
+        class="flex shrink-0 items-center gap-1.5 rounded-full border border-warning-soft-border bg-warning-soft px-2.5 py-1 text-xs font-medium whitespace-nowrap text-warning-soft-text"
         title="RUNWISP_NO_AUTH is set — the API and Web UI are reachable without a password. Local/dev use only."
     >
         <ShieldOff size={12} class="shrink-0" />

--- a/apps/ui/src/lib/components/AuthModal.svelte
+++ b/apps/ui/src/lib/components/AuthModal.svelte
@@ -4,7 +4,7 @@
 <script lang="ts">
     import { browser } from "$app/environment";
     import { Button, Input, Logo, Modal } from "@runwisp/ui";
-    import { authApi } from "$lib/api";
+    import { authApi, RateLimitedError } from "$lib/api";
     import { authStore } from "$lib/stores";
     import { browserTokenStorage, browserAuthEventBus } from "$lib/adapters/browser";
     import { createLogger } from "$lib/utils/logger";
@@ -73,7 +73,11 @@
 
             browserAuthEventBus.emitAuthSuccess();
         } catch (err) {
-            error = "Invalid password. Please try again.";
+            if (err instanceof RateLimitedError) {
+                error = "Too many attempts. Please wait a few minutes and try again.";
+            } else {
+                error = "Invalid password. Please try again.";
+            }
             logger.error("Authentication failed", err);
         } finally {
             loading = false;

--- a/apps/ui/src/lib/components/CloudModeBadge.svelte
+++ b/apps/ui/src/lib/components/CloudModeBadge.svelte
@@ -13,7 +13,7 @@
 
 {#if visible}
     <span
-        class="flex items-center gap-1.5 rounded-full border border-info-soft-border bg-info-soft px-2.5 py-1 text-xs font-medium text-info-soft-text"
+        class="flex shrink-0 items-center gap-1.5 rounded-full border border-info-soft-border bg-info-soft px-2.5 py-1 text-xs font-medium whitespace-nowrap text-info-soft-text"
         title="This runner is managed by RunWisp Cloud — scheduling and dispatch happen in the cloud; this page shows what runs on this machine."
     >
         <Cloud size={12} class="shrink-0" />

--- a/apps/ui/src/lib/components/dashboard/ParamForm.svelte
+++ b/apps/ui/src/lib/components/dashboard/ParamForm.svelte
@@ -47,6 +47,15 @@
         valid?: boolean;
     } = $props();
 
+    // A stable id per parameter, shared between each FormField's <label for> and
+    // the control it wraps, so clicking the label focuses the field and screen
+    // readers associate the two. Scoped to this form instance so two forms on a
+    // page never collide.
+    const idBase = `param-${Math.random().toString(36).slice(2, 10)}`;
+    function fieldId(key: string): string {
+        return `${idBase}-${key}`;
+    }
+
     function initialValue(p: TaskParam): string {
         if (p.kind === "flag") return p.default === "true" ? "true" : "false";
         return p.default ?? "";
@@ -184,11 +193,13 @@
             />
         {:else if p.choices && p.choices.length > 0 && !p.allow_custom}
             <FormField
+                id={fieldId(p.key)}
                 label={p.key}
                 required={p.required ?? false}
                 description={p.description ?? ""}
             >
                 <Select
+                    id={fieldId(p.key)}
                     value={vals[p.key] ?? ""}
                     options={choiceOptions(p.choices)}
                     placeholder="Select…"
@@ -201,12 +212,14 @@
             </FormField>
         {:else if p.choices && p.choices.length > 0 && p.allow_custom}
             <FormField
+                id={fieldId(p.key)}
                 label={p.key}
                 required={p.required ?? false}
                 description={p.description ?? ""}
             >
                 <div class="space-y-2">
                     <Select
+                        id={fieldId(p.key)}
                         value={customMode[p.key] ? CUSTOM_OPTION : (vals[p.key] ?? "")}
                         options={comboOptions(p.choices)}
                         placeholder="Select…"
@@ -231,11 +244,13 @@
             </FormField>
         {:else}
             <FormField
+                id={fieldId(p.key)}
                 label={p.key}
                 required={p.required ?? false}
                 description={p.description ?? ""}
             >
                 <Input
+                    id={fieldId(p.key)}
                     type={p.type === "number" ? "number" : "text"}
                     value={vals[p.key] ?? ""}
                     error={touched[p.key] ? fieldError(p) : undefined}

--- a/apps/ui/src/lib/components/dashboard/RunsPage.svelte
+++ b/apps/ui/src/lib/components/dashboard/RunsPage.svelte
@@ -21,6 +21,7 @@
         fetchLineHistory,
         getInstanceCount = () => 1,
         initialRunId = null,
+        runNotFound = false,
         onSelectRun,
     } = $props<{
         items: Run[];
@@ -32,6 +33,10 @@
         onOptimisticRestore: (runs: Run[]) => void;
         getInstanceCount?: (taskName: string) => number;
         initialRunId?: string | null;
+        // True when the deep-linked run id (initialRunId) was fetched and doesn't
+        // exist. Distinguishes "deleted/bad permalink" from a stale selection that
+        // merely scrolled out of the loaded window.
+        runNotFound?: boolean;
         // Notified when the user picks a run, so the route can mirror it into
         // the address bar. The auto-fallback to newest is not reported.
         onSelectRun?: (runId: string | null) => void;
@@ -80,10 +85,22 @@
         },
     });
 
+    // The deep-linked run genuinely doesn't exist: its id is the current URL
+    // selection, the fetch confirmed it missing, and it isn't in the list. In
+    // that case we show a "not found" panel instead of silently falling back to
+    // the newest run under a URL that still points at the dead id.
+    let deepLinkMissing = $derived(
+        runNotFound &&
+            userSelectedRunId !== null &&
+            userSelectedRunId === initialRunId &&
+            !items.some((r: Run) => r.id === userSelectedRunId),
+    );
+
     let selectedRunId = $derived.by(() => {
         if (userSelectedRunId && items.some((r: Run) => r.id === userSelectedRunId)) {
             return userSelectedRunId;
         }
+        if (deepLinkMissing) return null;
         return items[0]?.id ?? null;
     });
 
@@ -125,5 +142,6 @@
         showTaskName
         onDelete={deleteSingle}
         {getInstanceCount}
+        notFound={deepLinkMissing}
     />
 </div>

--- a/apps/ui/src/lib/components/dashboard/TaskPage.svelte
+++ b/apps/ui/src/lib/components/dashboard/TaskPage.svelte
@@ -40,6 +40,7 @@
         initialRunId = null,
         initialHighlightLine = null,
         selectRunId = null,
+        runNotFound = false,
         onSelectRun,
     } = $props<{
         task: Task;
@@ -74,6 +75,10 @@
         initialRunId?: string | null;
         initialHighlightLine?: number | null;
         selectRunId?: string | null;
+        // True when the deep-linked run id (initialRunId) was fetched and doesn't
+        // exist under this task — surfaces a "not found" panel instead of quietly
+        // falling back to the running/newest run under a dead URL.
+        runNotFound?: boolean;
         // Notified whenever the user picks a run (click or freshly triggered),
         // so the route can mirror it into the address bar. The auto-fallback
         // selection (newest/running) is deliberately not reported.
@@ -246,10 +251,22 @@
         onSelectRun?.(userSelectedRunId);
     });
 
+    // The deep-linked run genuinely doesn't exist under this task: its id is the
+    // current URL selection, the fetch confirmed it missing, and it isn't in the
+    // list. Show a "not found" panel rather than silently falling back to the
+    // running/newest run while the URL still points at the dead id.
+    let deepLinkMissing = $derived(
+        runNotFound &&
+            userSelectedRunId !== null &&
+            userSelectedRunId === initialRunId &&
+            !items.some((r: Run) => r.id === userSelectedRunId),
+    );
+
     let selectedRunId = $derived.by(() => {
         if (userSelectedRunId && items.some((r: Run) => r.id === userSelectedRunId)) {
             return userSelectedRunId;
         }
+        if (deepLinkMissing) return null;
         const running = items.find((r: Run) => r.status === "running");
         if (running) return running.id;
         return items[0]?.id ?? null;
@@ -344,6 +361,7 @@
             historyVisible={historyExpanded}
             {highlightLine}
             getInstanceCount={() => instanceCount}
+            notFound={deepLinkMissing}
         />
     </div>
 </div>

--- a/apps/ui/src/lib/config/constants.ts
+++ b/apps/ui/src/lib/config/constants.ts
@@ -24,4 +24,5 @@ export const SSE_CONFIG = {
 
 export const HTTP_STATUS = {
     UNAUTHORIZED: 401,
+    TOO_MANY_REQUESTS: 429,
 } as const;

--- a/apps/ui/src/lib/layouts/AppLayout.svelte
+++ b/apps/ui/src/lib/layouts/AppLayout.svelte
@@ -232,7 +232,7 @@
             class="flex h-16 items-center justify-between border-b border-outline bg-surface-raised px-6 shadow-sm"
         >
             <!-- Breadcrumb / Title -->
-            <div class="flex items-center gap-3">
+            <div class="flex min-w-0 items-center gap-3">
                 <button
                     type="button"
                     aria-label="Open navigation"
@@ -248,7 +248,7 @@
                 {#if activeTaskName}
                     <!-- On a task page the breadcrumb is the page's primary heading:
                          the task name appears here and nowhere else. -->
-                    <h1 class="truncate text-base font-semibold text-on-surface">
+                    <h1 class="min-w-0 truncate text-base font-semibold text-on-surface">
                         {activeTaskName}
                     </h1>
                 {:else}
@@ -264,10 +264,10 @@
                 <HeaderSearch />
             </div>
 
-            <div class="flex items-center gap-3">
+            <div class="flex shrink-0 items-center gap-2 sm:gap-3">
                 {#if systemStore.timezone}
                     <span
-                        class="flex items-center gap-1.5 rounded-full border border-outline bg-surface-sunken px-2.5 py-1 text-xs font-medium text-on-surface-muted"
+                        class="hidden items-center gap-1.5 rounded-full border border-outline bg-surface-sunken px-2.5 py-1 text-xs font-medium whitespace-nowrap text-on-surface-muted lg:flex"
                         title={systemStore.timezoneSource === "system"
                             ? "Detected from the host system; pin [scheduler] timezone in runwisp.toml to make it explicit."
                             : "Set in runwisp.toml under [scheduler] timezone."}

--- a/apps/ui/src/routes/runs/[[runId]]/+page.svelte
+++ b/apps/ui/src/routes/runs/[[runId]]/+page.svelte
@@ -48,20 +48,39 @@
         });
     });
 
+    // Whether the deep-linked run id resolved to no run. Surfaced to RunsPage so
+    // a dead permalink shows a "not found" panel instead of silently swapping in
+    // the newest run.
+    let runNotFound = $state(false);
+    let checkedMissingId = $state<string | null>(null);
+
     // Restore a deep-linked run (/runs/{runId}) that isn't on the loaded page.
     // The run ULID is globally unique, so we can fetch it without a task name.
     $effect(() => {
         const initialRunId = runIdParam;
-        if (!initialRunId || source.items.length === 0) return;
-        if (source.items.some((r) => r.id === initialRunId)) return;
+        if (!initialRunId) {
+            runNotFound = false;
+            checkedMissingId = null;
+            return;
+        }
+        if (source.items.length === 0) return;
+        if (source.items.some((r) => r.id === initialRunId)) {
+            runNotFound = false;
+            return;
+        }
+        if (checkedMissingId === initialRunId) return; // already resolved as missing
         void (async () => {
             try {
                 const run = await runsApi.getById(initialRunId);
-                if (run) source.upsert(run);
+                if (run) {
+                    source.upsert(run);
+                    return;
+                }
             } catch {
-                // Run not found / not authorized — RunsPage falls back to the
-                // newest run, keeping the view usable.
+                // Fall through: not found / not authorized is treated as missing.
             }
+            checkedMissingId = initialRunId;
+            runNotFound = true;
         })();
     });
 </script>
@@ -82,6 +101,7 @@
         fetchLineHistory={logSession.fetchLineHistory}
         {getInstanceCount}
         initialRunId={runIdParam}
+        {runNotFound}
         onSelectRun={selectRun}
     />
 {/if}

--- a/apps/ui/src/routes/tasks/[id]/[[runId]]/+page.svelte
+++ b/apps/ui/src/routes/tasks/[id]/[[runId]]/+page.svelte
@@ -79,18 +79,37 @@
         return () => taskData.abort();
     });
 
+    // Whether the deep-linked run id resolved to no run under this task. Surfaced
+    // to TaskPage so a dead permalink shows a "not found" panel instead of quietly
+    // selecting the running/newest run.
+    let runNotFound = $state(false);
+    let checkedMissingId = $state<string | null>(null);
+
     $effect(() => {
         const initialRunId = runIdParam;
-        if (!initialRunId || !taskName || source.items.length === 0) return;
-        if (source.items.some((r) => r.id === initialRunId)) return;
+        if (!initialRunId || !taskName) {
+            runNotFound = false;
+            checkedMissingId = null;
+            return;
+        }
+        if (source.items.length === 0) return;
+        if (source.items.some((r) => r.id === initialRunId)) {
+            runNotFound = false;
+            return;
+        }
+        if (checkedMissingId === initialRunId) return; // already resolved as missing
         void (async () => {
             try {
                 const run = await tasksApi.getRun(taskName, initialRunId);
-                if (run) source.upsert(run);
+                if (run) {
+                    source.upsert(run);
+                    return;
+                }
             } catch {
-                // Run not found / not authorized — TaskPage's fallback selection
-                // (running run, else newest) keeps the UI usable.
+                // Fall through: not found / not authorized is treated as missing.
             }
+            checkedMissingId = initialRunId;
+            runNotFound = true;
         })();
     });
 
@@ -183,6 +202,7 @@
                     return Number.isFinite(n) ? n : null;
                 })()}
                 {selectRunId}
+                {runNotFound}
                 onSelectRun={selectRun}
             />
         {/if}

--- a/packages/ui/src/lib/components/FormField.svelte
+++ b/packages/ui/src/lib/components/FormField.svelte
@@ -12,6 +12,11 @@
         required?: boolean;
         children: Snippet;
         class?: string;
+        // The id of the control this field labels. Pass the SAME id to the wrapped
+        // input/select so the <label for> actually points at it — otherwise the
+        // label is dead (clicking it does nothing; screen readers can't associate
+        // it). Falls back to a generated id when the field has no focusable target.
+        id?: string;
     }
 
     let {
@@ -22,14 +27,16 @@
         required = false,
         children,
         class: className = "",
+        id,
     }: Props = $props();
 
     const generatedId = `field-${Math.random().toString(36).slice(2, 10)}`;
+    const fieldId = $derived(id ?? generatedId);
 </script>
 
 <div class="space-y-1.5 {className}">
     {#if label}
-        <label for={generatedId} class="block text-sm font-medium text-on-surface-muted">
+        <label for={fieldId} class="block text-sm font-medium text-on-surface-muted">
             {label}
             {#if required}
                 <span class="text-danger-soft-text">*</span>

--- a/packages/ui/src/lib/components/dashboard/RunDetailPanel.svelte
+++ b/packages/ui/src/lib/components/dashboard/RunDetailPanel.svelte
@@ -21,6 +21,7 @@
         Maximize2,
         Minimize2,
         TextWrap,
+        SearchX,
     } from "@lucide/svelte";
     import Button from "../Button.svelte";
     import EmptyState from "../EmptyState.svelte";
@@ -67,6 +68,7 @@
         historyVisible = false,
         highlightLine = null,
         getInstanceCount = () => 1,
+        notFound = false,
     }: {
         run: Run | undefined;
         fetchLogs: (
@@ -112,6 +114,10 @@
         // Resolves a task's currently configured instance count so multi-instance
         // services render a 1-based #N suffix. Defaults to single-instance.
         getInstanceCount?: (taskName: string) => number;
+        // True when a deep-linked run id resolved to no run (deleted by retention,
+        // or never existed). The empty state then says so plainly instead of the
+        // generic "Select a run" — the caller must not silently substitute another.
+        notFound?: boolean;
     } = $props();
 
     let canDelete = $derived.by(() => {
@@ -837,13 +843,15 @@
         class="flex min-w-0 flex-1 flex-col items-center justify-center gap-4 bg-surface-sunken/30"
     >
         <EmptyState
-            title={onRunTask ? "No runs yet" : "Select a run"}
-            description={onRunTask
-                ? "This task hasn't run yet. Trigger it to see its output here."
-                : "Pick a run from the list to view details and logs."}
-            icon={MousePointerClick}
+            title={notFound ? "Run not found" : onRunTask ? "No runs yet" : "Select a run"}
+            description={notFound
+                ? "This run doesn't exist — it may have been deleted by retention, or the link is wrong. Pick a run from the list to continue."
+                : onRunTask
+                  ? "This task hasn't run yet. Trigger it to see its output here."
+                  : "Pick a run from the list to view details and logs."}
+            icon={notFound ? SearchX : MousePointerClick}
         />
-        {#if onRunTask}
+        {#if onRunTask && !notFound}
             <button
                 type="button"
                 onclick={() => onRunTask()}


### PR DESCRIPTION
## Summary

- Deep-linking to a deleted/unknown run now shows a "Run not found" state instead of silently rendering a different run under the dead URL.
- The Web UI header no longer pushes the theme toggle and notification bell off-screen on phone-width viewports.
- The login screen distinguishes rate-limiting from a wrong password.
- The TUI's quick status filter (`f`) now also reaches Skipped and Stopped.
- `runwisp demo` rejects `--config`/`--data` it can't honor instead of silently discarding them; `--seed-only` is the escape hatch.
- Task run-parameter form labels are wired to their inputs (a11y + click-to-focus).
- `runwisp exec --json` emits an error document on failure instead of nothing.

See CHANGELOG.md for the full entries and doc links.

## Test plan

- [x] `bun run ci` (generate → format → check → test → test-e2e) passes clean