### PR TITLE
fix(compose): apply per-service notification overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Compose per-service `notify_on_failure`/`notify_on_success` overrides now reach notifications.** A `[compose.<alias>.<svc>]` notify list was parsed and discarded; it now desugars into a notify route keyed by the imported service's task name, exactly like `[services.*]`. See [Compose](https://docs.runwisp.com/configuration/compose/#per-service-overrides).
+
 ## [0.13.0] - 2026-07-21
 
 ### Added

--- a/apps/docs/src/agents/reference.md
+++ b/apps/docs/src/agents/reference.md
@@ -144,7 +144,7 @@ pull:         enum =missing        — missing | always | never
 name_format:  string ={alias}.{service} — generated task name; must contain {service} in services mode
 ```
 
-Per-service override `[compose.<alias>.<svc>]` accepts: `group`, `description`, `api_trigger`, `timeout`, `graceful_stop`, `stop_signal`, `on_overlap`, `restart`, `instances`, `restart_delay`, `restart_backoff`, `healthy_after`, `start_retries`, `priority`, `autostart`, `exit_codes`, `log_max_size`, `log_on_full`, `keep_runs`, `keep_for`, `env`, `env_file`, `secrets`, `secrets_file`, `notify_on_failure`, `notify_on_success`. Not allowed: `run`/`compose_file`/`compose_service` (the parent block owns the backend), and the host-process keys `shell`/`umask`/`user`. `mode="stack"` forbids overrides and include/exclude. Caveat: per-service `notify_on_*` is currently parsed but NOT wired to notifications for compose imports.
+Per-service override `[compose.<alias>.<svc>]` accepts: `group`, `description`, `api_trigger`, `timeout`, `graceful_stop`, `stop_signal`, `on_overlap`, `restart`, `instances`, `restart_delay`, `restart_backoff`, `healthy_after`, `start_retries`, `priority`, `autostart`, `exit_codes`, `log_max_size`, `log_on_full`, `keep_runs`, `keep_for`, `env`, `env_file`, `secrets`, `secrets_file`, `notify_on_failure`, `notify_on_success`. Not allowed: `run`/`compose_file`/`compose_service` (the parent block owns the backend), and the host-process keys `shell`/`umask`/`user`. `mode="stack"` forbids overrides and include/exclude. Per-service `notify_on_failure`/`notify_on_success` desugar into notify routes keyed by the generated task name, exactly like `[services.*]`.
 
 ### [notify] (global notification settings)
 

--- a/apps/runwisp/internal/config/compose.go
+++ b/apps/runwisp/internal/config/compose.go
@@ -79,11 +79,12 @@ func expandComposeBlocks(cfg *Config, dirs sourceDirs) error {
 		existingNames[cfg.Tasks[i].Name] = struct{}{}
 	}
 
+	var notify []composeNotifySugar
 	for _, alias := range aliases {
 		if err := model.ValidateTaskName(alias); err != nil {
 			return fmt.Errorf("invalid compose alias %q: %w", alias, err)
 		}
-		newTasks, err := expandComposeAlias(alias, blocks[alias], dirs.dir(alias), existingNames)
+		newTasks, newNotify, err := expandComposeAlias(alias, blocks[alias], dirs.dir(alias), existingNames)
 		if err != nil {
 			return fmt.Errorf("compose.%s: %w", alias, err)
 		}
@@ -91,8 +92,38 @@ func expandComposeBlocks(cfg *Config, dirs sourceDirs) error {
 			existingNames[newTasks[i].Name] = struct{}{}
 		}
 		cfg.Tasks = append(cfg.Tasks, newTasks...)
+		notify = append(notify, newNotify...)
 	}
-	return nil
+
+	// Compose blocks expand after toNotifyConfig has already built cfg.Notify,
+	// so their per-service notify_on_* sugar desugars into synthetic routes on
+	// the finished config rather than through desugar{Task,Service}Notify.
+	return appendComposeNotify(&cfg.Notify, notify)
+}
+
+// composeNotifySugar carries one imported service's notify_on_failure /
+// notify_on_success selections, keyed by the generated task name, from
+// expansion to the notify-route desugaring step.
+type composeNotifySugar struct {
+	taskName  string
+	onFailure []string
+	onSuccess []string
+}
+
+// appendComposeNotify turns collected compose per-service notify sugar into
+// synthetic routes on an already-built NotifyConfig, then resolves any inline
+// "<id>:<override>" tokens the new routes introduced. This mirrors what
+// desugarServiceNotify + expandInlineTokens do for [services.*], but runs late
+// because compose expansion happens after toNotifyConfig.
+func appendComposeNotify(out *NotifyConfig, sugar []composeNotifySugar) error {
+	if len(sugar) == 0 {
+		return nil
+	}
+	from := len(out.Routes)
+	for _, s := range sugar {
+		appendSynthRoutes(out, s.taskName, s.onFailure, s.onSuccess)
+	}
+	return expandInlineTokensFrom(out, from)
 }
 
 // composeBlockWire is the TOML-decodable form of the scalar/array keys in a
@@ -168,30 +199,31 @@ type composeServiceOverrideWire struct {
 	NotifyOnSuccess []string `toml:"notify_on_success,omitempty"`
 }
 
-func expandComposeAlias(alias string, raw map[string]any, baseDir string, existingNames map[string]struct{}) ([]model.Task, error) {
+func expandComposeAlias(alias string, raw map[string]any, baseDir string, existingNames map[string]struct{}) ([]model.Task, []composeNotifySugar, error) {
 	block, err := parseComposeBlock(alias, raw)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	resolvedFile, err := resolveComposeFile(block.File, baseDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	block.File = resolvedFile
 
 	if err := resolveComposeBlockPaths(block, baseDir, resolvedFile); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	project, err := composespec.Load(resolvedFile, block.Profiles, block.EnvFile, block.WorkingDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	switch block.Mode {
 	case model.ComposeModeStack:
-		return expandComposeStack(block, project, existingNames)
+		tasks, err := expandComposeStack(block, project, existingNames)
+		return tasks, nil, err
 	default:
 		return expandComposeServices(block, project, existingNames)
 	}
@@ -347,7 +379,7 @@ func decodeServiceOverride(svcName string, raw map[string]any) (*composeServiceO
 	return &w, nil
 }
 
-func expandComposeServices(block *composeBlock, project *composespec.Project, existingNames map[string]struct{}) ([]model.Task, error) {
+func expandComposeServices(block *composeBlock, project *composespec.Project, existingNames map[string]struct{}) ([]model.Task, []composeNotifySugar, error) {
 	available := project.ServiceNames()
 	availableSet := make(map[string]struct{}, len(available))
 	for _, n := range available {
@@ -356,7 +388,7 @@ func expandComposeServices(block *composeBlock, project *composespec.Project, ex
 
 	imported, err := selectImportedComposeServices(block, available, availableSet)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	importedSet := make(map[string]struct{}, len(imported))
 	for _, n := range imported {
@@ -364,28 +396,46 @@ func expandComposeServices(block *composeBlock, project *composespec.Project, ex
 	}
 
 	if err := validateComposeOverridesExist(block.Overrides, importedSet, availableSet); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	tasks := make([]model.Task, 0, len(imported))
+	var notify []composeNotifySugar
 	for _, svcName := range imported {
 		svc := project.Service(svcName)
 		taskName := applyNameFormat(block.NameFormat, block.Alias, svcName)
 		if err := model.ValidateTaskName(taskName); err != nil {
-			return nil, fmt.Errorf("name_format %q produced invalid task name %q: %w", block.NameFormat, taskName, err)
+			return nil, nil, fmt.Errorf("name_format %q produced invalid task name %q: %w", block.NameFormat, taskName, err)
 		}
 		if _, dup := existingNames[taskName]; dup {
-			return nil, fmt.Errorf("name %q (from compose service %q) collides with an existing task or service", taskName, svcName)
+			return nil, nil, fmt.Errorf("name %q (from compose service %q) collides with an existing task or service", taskName, svcName)
 		}
 
 		task, err := buildComposeServiceTask(block, svc, svcName, taskName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		tasks = append(tasks, task)
+		if s, ok := composeServiceNotify(block.Overrides[svcName], taskName); ok {
+			notify = append(notify, s)
+		}
 		existingNames[taskName] = struct{}{}
 	}
-	return tasks, nil
+	return tasks, notify, nil
+}
+
+// composeServiceNotify extracts a service override's notify_on_* selections
+// into notify sugar keyed by the generated task name. Reports ok=false when the
+// override is absent or declares neither list, so the caller adds no route.
+func composeServiceNotify(w *composeServiceOverrideWire, taskName string) (composeNotifySugar, bool) {
+	if w == nil || (len(w.NotifyOnFailure) == 0 && len(w.NotifyOnSuccess) == 0) {
+		return composeNotifySugar{}, false
+	}
+	return composeNotifySugar{
+		taskName:  taskName,
+		onFailure: w.NotifyOnFailure,
+		onSuccess: w.NotifyOnSuccess,
+	}, true
 }
 
 // selectImportedComposeServices rejects service names colliding with a reserved
@@ -564,8 +614,11 @@ func applyComposeOverrideSupervision(task *model.Task, w *composeServiceOverride
 	}
 }
 
-// applyComposeOverrideEnv copies the override's env / secrets / notify fields
-// onto the task, leaving unset values at their compose-import default.
+// applyComposeOverrideEnv copies the override's env / secrets fields onto the
+// task, leaving unset values at their compose-import default. The notify_on_*
+// lists are handled separately (see composeNotifySugar): they never land on the
+// Task — like [services.*] they desugar into synthetic notify routes keyed by
+// the generated task name.
 func applyComposeOverrideEnv(task *model.Task, w *composeServiceOverrideWire) {
 	if len(w.Env) > 0 {
 		task.Env = w.Env
@@ -578,13 +631,6 @@ func applyComposeOverrideEnv(task *model.Task, w *composeServiceOverrideWire) {
 	}
 	if w.SecretsFile != "" {
 		task.SecretsFile = w.SecretsFile
-	}
-	if len(w.NotifyOnFailure) > 0 {
-		// Field not on Task today; consumed by notify config at expansion time.
-		// Stored on task via the same pathway as [services.*] — but the
-		// compose pipeline doesn't yet propagate notify lists. Leave a hook
-		// for a follow-up once notify wiring is extended.
-		_ = w.NotifyOnFailure
 	}
 }
 

--- a/apps/runwisp/internal/config/compose_test.go
+++ b/apps/runwisp/internal/config/compose_test.go
@@ -262,7 +262,104 @@ func TestComposeExpansion_NoComposeFileFoundProducesClearError(t *testing.T) {
 	assert.Contains(t, err.Error(), "no compose file")
 }
 
+func TestComposeExpansion_PerServiceNotifyDesugarsToRoutes(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `[[notifier]]
+id = "slack-prod"
+type = "slack"
+webhook_url = "https://example/hook"
+
+[[notifier]]
+id = "slack-ok"
+type = "slack"
+webhook_url = "https://example/ok"
+
+[compose.myapp]
+
+[compose.myapp.web]
+notify_on_failure = ["slack-prod"]
+notify_on_success = ["slack-ok"]
+`))
+	require.NoError(t, err)
+	require.NoError(t, Validate(cfg))
+
+	failure := findRoute(t, cfg, "myapp.web", "run.failed")
+	// notify_on_failure fans out across all failure kinds plus the appended
+	// global default channel (inapp).
+	assert.ElementsMatch(t,
+		[]string{"run.failed", "run.timeout", "run.crashed", "run.missed", "service.fatal"},
+		failure.Kinds)
+	assert.ElementsMatch(t, []string{"slack-prod", "inapp"}, failure.NotifierID)
+
+	success := findRoute(t, cfg, "myapp.web", "run.succeeded")
+	assert.ElementsMatch(t, []string{"run.succeeded"}, success.Kinds)
+	assert.ElementsMatch(t, []string{"slack-ok", "inapp"}, success.NotifierID)
+
+	// A service without notify overrides produces no task-scoped route.
+	for _, r := range cfg.Notify.Routes {
+		assert.NotEqual(t, "myapp.worker", r.TaskGlob, "unconfigured service must not get a route")
+	}
+}
+
+func TestComposeExpansion_PerServiceNotifyInlineTokenMaterialisesNotifier(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `[[notifier]]
+id = "slack-prod"
+type = "slack"
+webhook_url = "https://example/hook"
+channel = "#default"
+
+[compose.myapp]
+
+[compose.myapp.web]
+notify_on_failure = ["slack-prod:#alerts"]
+`))
+	require.NoError(t, err)
+	require.NoError(t, Validate(cfg))
+
+	failure := findRoute(t, cfg, "myapp.web", "run.failed")
+	assert.Contains(t, failure.NotifierID, "slack-prod:#alerts")
+
+	// The late inline-token pass must materialise a synthetic notifier whose
+	// channel is the override, cloned from the parent's credentials.
+	var synth *NotifierSpec
+	for i := range cfg.Notify.Notifiers {
+		if cfg.Notify.Notifiers[i].ID == "slack-prod:#alerts" {
+			synth = &cfg.Notify.Notifiers[i]
+		}
+	}
+	require.NotNil(t, synth, "inline override token must materialise a synthetic notifier")
+	assert.Equal(t, "#alerts", synth.SlackChannel)
+	assert.Equal(t, "https://example/hook", synth.WebhookURL, "synthetic notifier inherits parent credentials")
+}
+
+func TestComposeExpansion_PerServiceNotifyUnknownNotifierRejected(t *testing.T) {
+	_, err := Load(writeConfig(t, `[compose.myapp]
+
+[compose.myapp.web]
+notify_on_failure = ["ghost"]
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+}
+
 // --- test helpers ---
+
+// findRoute returns the notify route matching taskGlob that fires on kind.
+// Fails the test when no such route exists.
+func findRoute(t *testing.T, cfg *Config, taskGlob, kind string) NotificationRoute {
+	t.Helper()
+	for _, r := range cfg.Notify.Routes {
+		if r.TaskGlob != taskGlob {
+			continue
+		}
+		for _, k := range r.Kinds {
+			if k == kind {
+				return r
+			}
+		}
+	}
+	t.Fatalf("no notify route for task %q with kind %q", taskGlob, kind)
+	return NotificationRoute{}
+}
 
 func taskNames(cfg *Config) []string {
 	names := make([]string, 0, len(cfg.Tasks))

--- a/apps/runwisp/internal/config/notify_schema.go
+++ b/apps/runwisp/internal/config/notify_schema.go
@@ -175,13 +175,24 @@ func buildNotifierSpecs(notifiers []notifierWire, out *NotifyConfig) error {
 // IDs cannot collide with user IDs. Tokens are deduped: "slack:#ops" referenced
 // from three tasks produces one synthetic spec.
 func expandInlineTokens(out *NotifyConfig) error {
+	return expandInlineTokensFrom(out, 0)
+}
+
+// expandInlineTokensFrom resolves inline "<id>:<override>" tokens for the
+// routes at index >= fromRoute, appending one synthetic NotifierSpec per unique
+// token. Seeding the seen-set from the existing notifier IDs (which can never
+// contain ":", enforced in buildNotifierSpecs) makes this safe to call a second
+// time after new routes are appended — compose per-service notify sugar rides
+// this path — without re-materialising tokens an earlier pass already resolved.
+func expandInlineTokensFrom(out *NotifyConfig, fromRoute int) error {
 	parentByID := make(map[string]*NotifierSpec, len(out.Notifiers))
+	seen := make(map[string]struct{}, len(out.Notifiers))
 	for i := range out.Notifiers {
 		parentByID[out.Notifiers[i].ID] = &out.Notifiers[i]
+		seen[out.Notifiers[i].ID] = struct{}{}
 	}
-	seen := make(map[string]struct{})
 
-	for _, route := range out.Routes {
+	for _, route := range out.Routes[fromRoute:] {
 		for _, tok := range route.NotifierID {
 			spec, ok, err := resolveInlineToken(tok, parentByID, seen)
 			if err != nil {


### PR DESCRIPTION
Docker Compose service overrides now carry `notify_on_failure` and `notify_on_success` into the same notification configuration path used by regular `[services.*]` tasks. Per-service `[compose.<alias>.<svc>]` notify lists desugar into synthetic notify routes keyed by the generated task name, and inline `id:override` tokens in those lists are resolved into notifier specs, matching the existing service behavior.

Focused coverage was added for both the failure and success paths:
- an imported Compose service carries both `notify_on_failure` and `notify_on_success` selections through to the resulting notify routes (including the appended global channel);
- an inline `id:override` token materializes a synthetic notifier cloned from its parent;
- an unknown notifier id referenced by a Compose override is rejected at validation.

The agent reference and CHANGELOG were updated to match.

## Tests run

Go 1.25.0 (linux/arm64), from `apps/runwisp`:

- `go test ./internal/config/ -run 'TestComposeExpansion' -count=1 -v` — PASS (all 20 compose tests, incl. the 3 new notify tests); `ok internal/config 0.736s`
- `go test ./internal/config/ -run 'TestComposeExpansion|TestDesugar|TestDecode_NotifierAndRoutes|Notify|Schema' -count=1` — PASS; `ok internal/config 0.792s`
- `go test $(go list ./... | grep -v '/tests/e2e') -count=1` — PASS, exit 0; every package `ok`, no skips
- `go vet ./internal/config/` — clean
- `gofmt -l` on changed files — clean

golangci-lint was not run (not installed in this environment).