### PR TITLE
docs: correct stale Ofelia comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Full configuration reference, REST API docs, and operational guides live at **[d
 | **crond / crontab**           | Silent failures, no history, no output capture, no overlap handling | Persisting every run (exit code, duration, stdout/stderr) to embedded SQLite: browsable, streamable, and searchable. |
 | **systemd timers**            | One `.timer` + one `.service` per job, OS-locked, painful in Docker | One TOML file. Cross-platform. Same binary on your MacBook, in CI, and in production.                                |
 | **supervisord**               | No scheduling, Python install, dated XML-RPC API, basic web UI      | Cron scheduling and process supervision in one binary. Modern REST API. Svelte dashboard. Built-in log rotation.     |
-| **supercronic / Ofelia**      | Logs to stdout only; no history, no UI                              | Same Docker-friendly footprint, plus per-run logs, persistent history, live streaming, and one-click re-trigger.     |
+| **supercronic / Ofelia**      | Docker-scoped; supercronic is stdout-only, and Ofelia's history/UI (fork's `--enable-web`) stays in-memory/flat-file and container-bound | Same Docker-friendly footprint, plus host-and-container cron *with* resident-service supervision, persistent queryable per-run history in SQLite, live streaming, and one-click re-trigger. |
 | **Airflow / Cronicle / Dagu** | Heavy, multi-process, requires an external DB and a team to operate | Single binary. ~25 MB RAM idle. No external DB. No ops team. Running in five minutes.                                |
 
 ---


### PR DESCRIPTION
The `netresearch/ofelia` fork (v0.27.0) ships an optional `--enable-web` UI with per-job history. The current row claims Ofelia has 'no history, no UI', which is no longer accurate.