### PR TITLE
test(e2e): de-flake task-execution specs

### DIFF
--- a/apps/ui/e2e/fixtures/api.ts
+++ b/apps/ui/e2e/fixtures/api.ts
@@ -27,6 +27,34 @@ export async function triggerRunViaAPI(page: Page, taskName: string, token: stri
     return (await response.json()) as Run;
 }
 
+/**
+ * Trigger a run through the UI — the "Run" button then the "Run Now" confirm —
+ * and return the run the daemon created, captured from the trigger POST.
+ *
+ * Anchoring later assertions to this run id is what makes them reliable. The
+ * run-detail panel defaults to the newest *existing* run on load, and the
+ * single shared daemon carries runs across specs, so "wait for a SUCCESS/FAILED
+ * badge" on its own can latch onto a prior run's badge while the run we just
+ * triggered is still in flight — the API's newest run would then still be
+ * mid-run (`end_reason` unset). Reading the created run's id here removes that
+ * race: we poll for *this* run's terminal state, not "the latest".
+ */
+export async function triggerRunViaUI(page: Page, taskName: string): Promise<Run> {
+    // Attach the response listener before the click that fires the POST. Match
+    // the exact path so the runs *list* (`…/runs`) can't be mistaken for the
+    // trigger (`…/run`).
+    const triggered = page.waitForResponse(
+        (response) =>
+            response.request().method() === "POST" &&
+            new URL(response.url()).pathname === `/api/tasks/${taskName}/run`,
+    );
+    await page.getByRole("button", { name: /^Run( task)?$/ }).click();
+    await page.getByRole("button", { name: "Run Now" }).click();
+    const response = await triggered;
+    expect(response.status(), `trigger ${taskName} via UI`).toBeLessThan(400);
+    return (await response.json()) as Run;
+}
+
 /** Fetch a single run via `GET /api/tasks/{name}/runs/{id}`. */
 export async function getRun(
     page: Page,

--- a/apps/ui/e2e/task-execution.spec.ts
+++ b/apps/ui/e2e/task-execution.spec.ts
@@ -4,8 +4,8 @@
 import { test, expect } from "./fixtures/test-base";
 import {
     expectRunDetailMatchesApi,
-    getLatestRun,
     triggerRunViaAPI,
+    triggerRunViaUI,
     waitForRunEnded,
 } from "./fixtures/api";
 
@@ -18,22 +18,21 @@ test.describe("task execution", () => {
 
         await expect(page.getByRole("heading", { name: "echo-task", level: 1 })).toBeVisible();
 
-        // Trigger from the empty-state Run button (no runs yet).
-        await page.getByRole("button", { name: /^Run( task)?$/ }).click();
-        await page.getByRole("button", { name: "Run Now" }).click();
+        // Trigger via the Run button and capture the run it created. The panel
+        // may already show a prior run's SUCCESS badge (the daemon is shared
+        // across specs), so we anchor on *this* run's id rather than "the latest".
+        const triggered = await triggerRunViaUI(page, "echo-task");
 
-        // Wait for the run detail panel to settle on SUCCESS (exact match avoids
-        // the lowercase "success" in the run list, which uses CSS capitalize).
-        await expect(page.getByText("SUCCESS", { exact: true })).toBeVisible({ timeout: 30_000 });
-
-        // Cross-check the rendered outcome against the daemon's own record: the
-        // panel must show the API's status, exit code, and real timing — not a
-        // hardcoded badge.
-        const apiRun = await getLatestRun(page, "echo-task", daemonState.token);
-        expect(apiRun, "echo-task should have a run").toBeDefined();
-        if (!apiRun) return;
+        // Poll the API for this run's terminal record before asserting on it —
+        // this is the source of truth for the outcome, exit code, and timing.
+        const apiRun = await waitForRunEnded(page, "echo-task", triggered.id, daemonState.token);
         expect(apiRun.end_reason).toBe("success");
         expect(apiRun.exit_code).toBe(0);
+
+        // The panel settles on SUCCESS (exact match avoids the lowercase
+        // "success" in the run list, which uses CSS capitalize) and must show
+        // the API's status, exit code, and real timing — not a hardcoded badge.
+        await expect(page.getByText("SUCCESS", { exact: true })).toBeVisible({ timeout: 30_000 });
         await expectRunDetailMatchesApi(page, apiRun);
 
         // All captured stdout is present, in order — not just the first line.
@@ -50,17 +49,16 @@ test.describe("task execution", () => {
 
         await expect(page.getByRole("heading", { name: "fail-task", level: 1 })).toBeVisible();
 
-        // Trigger from the empty-state Run button (no runs yet).
-        await page.getByRole("button", { name: /^Run( task)?$/ }).click();
-        await page.getByRole("button", { name: "Run Now" }).click();
+        // Trigger via the Run button and anchor on the run it created — a prior
+        // fail-task run's FAILED badge may already be on screen (shared daemon),
+        // so asserting on "the latest run" would race the run we just triggered.
+        const triggered = await triggerRunViaUI(page, "fail-task");
 
-        await expect(page.getByText("FAILED", { exact: true })).toBeVisible({ timeout: 30_000 });
-
-        const apiRun = await getLatestRun(page, "fail-task", daemonState.token);
-        expect(apiRun, "fail-task should have a run").toBeDefined();
-        if (!apiRun) return;
+        const apiRun = await waitForRunEnded(page, "fail-task", triggered.id, daemonState.token);
         expect(apiRun.end_reason).toBe("failed");
         expect(apiRun.exit_code).toBe(1);
+
+        await expect(page.getByText("FAILED", { exact: true })).toBeVisible({ timeout: 30_000 });
         await expectRunDetailMatchesApi(page, apiRun);
 
         // Both stdout and stderr are captured and surfaced in the console.
@@ -68,14 +66,15 @@ test.describe("task execution", () => {
         await expect(page.getByText("fail-line-2-stderr")).toBeVisible();
     });
 
-    test("run appears in task run history", async ({ authenticatedPage: page }) => {
+    test("run appears in task run history", async ({ authenticatedPage: page, daemonState }) => {
         await page.goto("/tasks/echo-task");
 
         await expect(page.getByRole("heading", { name: "echo-task", level: 1 })).toBeVisible();
 
-        // Trigger from the empty-state Run button (no runs yet).
-        await page.getByRole("button", { name: /^Run( task)?$/ }).click();
-        await page.getByRole("button", { name: "Run Now" }).click();
+        // Trigger via the Run button and wait for this run to finish before
+        // asserting — the panel may otherwise show a prior run's badge.
+        const triggered = await triggerRunViaUI(page, "echo-task");
+        await waitForRunEnded(page, "echo-task", triggered.id, daemonState.token);
 
         await expect(page.getByText("SUCCESS", { exact: true })).toBeVisible({ timeout: 30_000 });
 
@@ -84,13 +83,17 @@ test.describe("task execution", () => {
         await expect(page.getByText("API").first()).toBeVisible();
     });
 
-    test("dashboard activity feed updates after task run", async ({ authenticatedPage: page }) => {
+    test("dashboard activity feed updates after task run", async ({
+        authenticatedPage: page,
+        daemonState,
+    }) => {
         await page.goto("/tasks/echo-task");
         await expect(page.getByRole("heading", { name: "echo-task", level: 1 })).toBeVisible();
 
-        // Trigger from the empty-state Run button (no runs yet).
-        await page.getByRole("button", { name: /^Run( task)?$/ }).click();
-        await page.getByRole("button", { name: "Run Now" }).click();
+        // Trigger via the Run button and wait for it to finish, so the activity
+        // feed has a completed run to surface.
+        const triggered = await triggerRunViaUI(page, "echo-task");
+        await waitForRunEnded(page, "echo-task", triggered.id, daemonState.token);
         await expect(page.getByText("SUCCESS", { exact: true })).toBeVisible({ timeout: 30_000 });
 
         // Navigate to dashboard


### PR DESCRIPTION
## What

Fixes the flaky `apps/ui/e2e/task-execution.spec.ts` tests that intermittently fail with:

```
expect(received).toBe(expected)
Expected: "success"   (or "failed")
Received: undefined
```

This surfaced on unrelated PRs (e.g. #157, a docs-only change) because it's a test-ordering race, not a product bug.

## Root cause

The e2e suite runs against **one shared daemon, single worker, serially**. `task-execution.spec.ts` runs after `dashboard`, `notifications`, and `runs-page`, all of which seed runs for `echo-task`/`fail-task`. So the "no runs yet" empty-state the specs assumed no longer holds.

The two failing specs:
1. Open `/tasks/{task}` — the run-detail panel auto-selects the newest **prior** run (`TaskPage.svelte` selection logic), whose `SUCCESS`/`FAILED` badge is already on screen.
2. Click **Run → Run Now** (triggers a *new* run).
3. `await expect(getByText("SUCCESS")).toBeVisible()` — satisfied immediately by the **stale prior run's badge**, before the fresh run finishes.
4. `getLatestRun(...)` returns the freshly-triggered run, still **running** → `end_reason` unset → assertion fails.

`echo-task` read as "flaky" (fast run sometimes finished in time); `fail-task` failed on both attempts.

## Fix

Anchor the assertions to **the run the button actually created**, instead of "the badge on screen" + "the latest run" — the pattern the rest of the suite already uses.

- Add `triggerRunViaUI()` to `e2e/fixtures/api.ts`: clicks Run → Run Now while capturing the trigger **POST** response, returning the created `Run`. Exact-path matcher so the runs *list* (`…/runs`) can't be mistaken for the trigger (`…/run`); listener is attached before the click so the response can't be missed.
- Both specs now poll that specific run to a terminal state via `waitForRunEnded(run.id)` before asserting `end_reason`/`exit_code`, then cross-check the UI badge and detail panel.
- Applied the same anchor to the file's other two specs and removed the now-false "no runs yet" comments.

No behavior change to what the tests verify.

## Validation

- `bunx moon run ui:check-types` → 0 errors
- `bunx moon run ui:check-lint` (prettier + eslint) → clean
- `bunx moon run runwisp:test-e2e` (builds the binary, runs the whole suite in the real order, with prior runs present on the daemon) → **34 passed, 0 failed, 0 flaky**
