### PR TITLE
fix: address several edge cases across executor, retention, and runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Compose per-service `notify_on_failure`/`notify_on_success` overrides now reach notifications.** A `[compose.<alias>.<svc>]` notify list was parsed and discarded; it now desugars into a notify route keyed by the imported service's task name, exactly like `[services.*]`. See [Compose](https://docs.runwisp.com/configuration/compose/#per-service-overrides).
+- **Retention skips non-terminal runs.** Age- and count-based cleanup now only prunes runs that have ended, so a run still pending or running is never removed while in flight. See [Retention](https://docs.runwisp.com/configuration/tasks/#retention).
+- **Catch-up honors a task's timezone.** Missed-tick detection at startup evaluates each task's schedule in its own timezone (or the scheduler default) instead of the host's local zone. See [Missed runs](https://docs.runwisp.com/configuration/scheduling/#missed-runs).
+- **Non-service `restart` backoff now escalates.** Consecutive restarts of a non-service task apply the configured `restart_backoff` curve instead of repeating at the flat base delay. See [Tasks](https://docs.runwisp.com/configuration/tasks/).
+- **Negative `timeout`, `retry_delay`, and `restart_delay` are rejected at config load** instead of being silently ignored. See [Tasks](https://docs.runwisp.com/configuration/tasks/).
+- **`docker compose` availability is re-probed after a transient failure**, so a task using compose is no longer disabled for the daemon's lifetime when the first probe fails while Docker is still starting.
+- **A malformed Docker build response stream now fails the build** rather than spinning on the undecodable bytes.
+- **A container start cancelled mid-flight no longer leaks its container or image** — cleanup runs on a context detached from the cancelled run.
+- **Terminal events for runs that never execute are published off the runtime lock**, removing a re-entrancy deadlock reachable on skip-overlap, queue-full, catch-up, and DST-fallback paths.
+- **Assorted concurrency fixes** in run event publishing, the notification ingress path and outbound coalescer shutdown, and the cloud execution-update buffer and reconnect backoff.
 
 ## [0.13.0] - 2026-07-21
 

--- a/apps/runwisp/cmd/runwisp/daemon_services.go
+++ b/apps/runwisp/cmd/runwisp/daemon_services.go
@@ -114,7 +114,7 @@ func initDaemonServices(ctx context.Context, cfg *daemonConfig, db storage.Datab
 		// Run catch-up now that notify is subscribed, so a missed-run gap
 		// detected from persisted history raises a run.missed alert instead of
 		// emitting into a bus nobody is listening on yet.
-		boot.catchUpResult = runMissedTickCatchUp(ctx, db, tasksMap, taskManager)
+		boot.catchUpResult = runMissedTickCatchUp(ctx, db, tasksMap, taskManager, boot.schedLoc)
 	}
 
 	return &daemonServices{
@@ -145,6 +145,7 @@ func initDaemonServices(ctx context.Context, cfg *daemonConfig, db storage.Datab
 // initDaemonServices can fold them into the returned daemonServices.
 type standaloneBoot struct {
 	scheduler        *runtime.Scheduler
+	schedLoc         *time.Location
 	schedResult      runtime.ScheduleResult
 	pendingSummary   uikit.PendingRunsSummary
 	runOnStartResult runtime.RunOnStartResult
@@ -167,6 +168,7 @@ func startStandaloneScheduling(ctx context.Context, cfg *daemonConfig, db storag
 	if locErr != nil {
 		return boot, locErr
 	}
+	boot.schedLoc = schedLoc
 	scheduler := runtime.NewScheduler(taskManager, tasksMap, schedLoc)
 	boot.scheduler = scheduler
 	schedResult, err := scheduler.Start()
@@ -211,8 +213,8 @@ func startNotify(ctx context.Context, cfg *daemonConfig, db storage.Database, ev
 // runMissedTickCatchUp runs missed-tick catch-up and narrates the outcome via
 // slog only when something went wrong; the banner already shows the triggered
 // total, so default-verbosity INFO output stays uncluttered.
-func runMissedTickCatchUp(ctx context.Context, db storage.Database, tasksMap map[string]*model.Task, taskManager runtime.TaskManager) runtime.CatchUpResult {
-	catchUpResult := runtime.RunMissedTickCatchUp(ctx, db, tasksMap, taskManager, time.Now())
+func runMissedTickCatchUp(ctx context.Context, db storage.Database, tasksMap map[string]*model.Task, taskManager runtime.TaskManager, schedLoc *time.Location) runtime.CatchUpResult {
+	catchUpResult := runtime.RunMissedTickCatchUp(ctx, db, tasksMap, taskManager, time.Now(), schedLoc)
 	if catchUpResult.Errors > 0 {
 		slog.Warn("Missed-tick catch-up completed with errors",
 			"triggered", catchUpResult.Triggered, "errors", catchUpResult.Errors)

--- a/apps/runwisp/internal/cloud/backoff.go
+++ b/apps/runwisp/internal/cloud/backoff.go
@@ -14,6 +14,11 @@ const (
 	reconnectMaxDelay       = 30 * time.Second
 	reconnectMultiplier     = 2.0
 	reconnectJitterFraction = 0.20
+	// minStableSessionDuration is how long a session must stay up before a clean
+	// reconnect resets the backoff. A session shorter than this is treated as a
+	// flap, so the backoff keeps escalating instead of resetting every attempt.
+	// One full max-delay window is comfortably past the reconnect churn.
+	minStableSessionDuration = reconnectMaxDelay
 )
 
 func newReconnectBackoff() backoff.BackOff {

--- a/apps/runwisp/internal/cloud/client.go
+++ b/apps/runwisp/internal/cloud/client.go
@@ -255,7 +255,15 @@ func (client *Client) runConnectionAttempt(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	return true, client.startSession(ctx, connection)
+	// Only reset the reconnect backoff if the session actually stayed up. A peer
+	// that resets the connection immediately after sync would otherwise reset
+	// backoff on every attempt, turning the exponential curve into a tight
+	// reconnect loop that hammers a flapping control plane. startSession blocks
+	// until the session ends, so its wall-clock span is the session's lifetime.
+	sessionStart := time.Now()
+	sessionErr := client.startSession(ctx, connection)
+	stable := time.Since(sessionStart) >= minStableSessionDuration
+	return stable, sessionErr
 }
 
 func (client *Client) dialWebSocket(ctx context.Context) (*websocket.Conn, error) {

--- a/apps/runwisp/internal/cloud/execution_tracker.go
+++ b/apps/runwisp/internal/cloud/execution_tracker.go
@@ -82,8 +82,15 @@ func (t *ExecutionTracker) FlushPending(send func(any) error) {
 	for executionID, active := range t.activeExecutions {
 		runningSnapshots = append(runningSnapshots, NewExecutionUpdateMessage(executionID, protocol.ExecutionStatusRunning, nil, active.StartedAt, nil))
 	}
-	pending := append(t.pendingExecutionUpdates, runningSnapshots...)
-	t.pendingExecutionUpdates = t.pendingExecutionUpdates[:0]
+	// Copy into a fresh slice rather than appending onto pendingExecutionUpdates:
+	// append may reuse that slice's backing array, and resetting the field to
+	// [:0] keeps that array live, so a concurrent bufferUpdate would write into
+	// slots this goroutine iterates over after the unlock. Set the source to nil
+	// so the two slices share no storage.
+	pending := make([]protocol.ExecutionUpdateMessage, 0, len(t.pendingExecutionUpdates)+len(runningSnapshots))
+	pending = append(pending, t.pendingExecutionUpdates...)
+	pending = append(pending, runningSnapshots...)
+	t.pendingExecutionUpdates = nil
 	t.mu.Unlock()
 
 	for i, update := range pending {

--- a/apps/runwisp/internal/config/config.go
+++ b/apps/runwisp/internal/config/config.go
@@ -343,6 +343,9 @@ func validateDefaults(d *Defaults) error {
 	if err := validateKeepFor("defaults.keep_for", d.KeepFor); err != nil {
 		return err
 	}
+	if d.Timeout < 0 {
+		return fmt.Errorf("invalid defaults.timeout: must be zero or a positive duration")
+	}
 	if d.HealthyAfter < 0 {
 		return fmt.Errorf("invalid defaults.healthy_after: must be a positive duration")
 	}
@@ -913,6 +916,18 @@ func validateTaskLimits(task *model.Task) error {
 	}
 	if task.MaxCatchUpRuns < 0 {
 		return fmt.Errorf("invalid max_catch_up_runs for task %s: must be a positive integer", task.Name)
+	}
+	// A negative timeout would parse but then be silently ignored (the run
+	// manager only arms the timer when > 0), so the operator's intent to bound
+	// the run is dropped without a word. Reject it instead. Same for the delays.
+	if task.Timeout < 0 {
+		return fmt.Errorf("invalid timeout for task %s: must be zero or a positive duration", task.Name)
+	}
+	if task.RetryDelay < 0 {
+		return fmt.Errorf("invalid retry_delay for task %s: must be zero or a positive duration", task.Name)
+	}
+	if task.RestartDelay < 0 {
+		return fmt.Errorf("invalid restart_delay for task %s: must be zero or a positive duration", task.Name)
 	}
 	return validateExitCodes(fmt.Sprintf("exit_codes for task %s", task.Name), task.ExitCodes)
 }

--- a/apps/runwisp/internal/config/config_test.go
+++ b/apps/runwisp/internal/config/config_test.go
@@ -413,6 +413,45 @@ func TestValidate(t *testing.T) {
 			wantErr: "graceful_stop",
 		},
 		{
+			name: "negative timeout",
+			cfg: &Config{
+				Tasks: []model.Task{{
+					Name:          "task1",
+					Run:           "echo hello",
+					MaxConcurrent: 1,
+					OnOverlap:     model.PolicyQueue,
+					Timeout:       -time.Second,
+				}},
+			},
+			wantErr: "timeout",
+		},
+		{
+			name: "negative retry_delay",
+			cfg: &Config{
+				Tasks: []model.Task{{
+					Name:          "task1",
+					Run:           "echo hello",
+					MaxConcurrent: 1,
+					OnOverlap:     model.PolicyQueue,
+					RetryDelay:    -time.Second,
+				}},
+			},
+			wantErr: "retry_delay",
+		},
+		{
+			name: "negative restart_delay",
+			cfg: &Config{
+				Tasks: []model.Task{{
+					Name:          "task1",
+					Run:           "echo hello",
+					MaxConcurrent: 1,
+					OnOverlap:     model.PolicyQueue,
+					RestartDelay:  -time.Second,
+				}},
+			},
+			wantErr: "restart_delay",
+		},
+		{
 			name: "negative shutdown_timeout",
 			cfg: &Config{
 				Daemon: Daemon{ShutdownTimeout: -time.Second},

--- a/apps/runwisp/internal/executor/compose.go
+++ b/apps/runwisp/internal/executor/compose.go
@@ -307,7 +307,6 @@ type LazyComposeBackend struct {
 	mu          sync.Mutex
 	backend     *ComposeBackend
 	fingerprint string
-	probed      bool
 	avail       bool
 }
 
@@ -321,12 +320,15 @@ func NewLazyComposeBackend(fingerprint string) *LazyComposeBackend {
 func (l *LazyComposeBackend) ensureProbed(ctx context.Context) (*ComposeBackend, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.probed {
-		return l.backend, l.avail
+	if l.backend == nil {
+		l.backend = NewComposeBackend(l.fingerprint)
 	}
-	l.backend = NewComposeBackend(l.fingerprint)
-	l.avail = l.backend.Available(ctx)
-	l.probed = true
+	// Cache only success. A transient first-probe failure (docker still coming
+	// up) must not disable compose for the daemon's lifetime, so re-probe until
+	// it reports available — mirroring LazyContainerBackend's retry-on-failure.
+	if !l.avail {
+		l.avail = l.backend.Available(ctx)
+	}
 	return l.backend, l.avail
 }
 

--- a/apps/runwisp/internal/executor/container.go
+++ b/apps/runwisp/internal/executor/container.go
@@ -254,12 +254,19 @@ func gracefulStopSeconds(d time.Duration) int {
 func (b *ContainerBackend) createAndStartContainer(ctx context.Context, imageTag string, ctr *model.ContainerExecution, task *model.Task, run *model.Run) (string, client.ContainerAttachResult, error) {
 	containerConfig, hostConfig := b.buildContainerConfig(imageTag, ctr, task, run)
 
+	// Cleanup must run on a context detached from ctx: a start that fails
+	// *because* ctx was cancelled (timeout, manager stop) would otherwise pass
+	// the already-cancelled ctx to ContainerRemove/ImageRemove, which return
+	// immediately and leak the container and image. WithoutCancel keeps ctx's
+	// values but is never cancelled itself.
+	cleanupCtx := context.WithoutCancel(ctx)
+
 	created, err := b.docker.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:     containerConfig,
 		HostConfig: hostConfig,
 	})
 	if err != nil {
-		b.builder.Remove(ctx, imageTag)
+		b.builder.Remove(cleanupCtx, imageTag)
 		return "", client.ContainerAttachResult{}, fmt.Errorf("container create: %w", err)
 	}
 
@@ -272,15 +279,15 @@ func (b *ContainerBackend) createAndStartContainer(ctx context.Context, imageTag
 		Stderr: true,
 	})
 	if err != nil {
-		b.removeContainer(ctx, containerID)
-		b.builder.Remove(ctx, imageTag)
+		b.removeContainer(cleanupCtx, containerID)
+		b.builder.Remove(cleanupCtx, imageTag)
 		return "", client.ContainerAttachResult{}, fmt.Errorf("container attach: %w", err)
 	}
 
 	if _, err := b.docker.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
 		attachResp.Close()
-		b.removeContainer(ctx, containerID)
-		b.builder.Remove(ctx, imageTag)
+		b.removeContainer(cleanupCtx, containerID)
+		b.builder.Remove(cleanupCtx, imageTag)
 		return "", client.ContainerAttachResult{}, fmt.Errorf("container start: %w", err)
 	}
 

--- a/apps/runwisp/internal/executor/executor.go
+++ b/apps/runwisp/internal/executor/executor.go
@@ -248,8 +248,12 @@ func (r *RoutingExecutor) notifyRunUpdated(run *model.Run, logPath string) {
 		r.onUpdate(run)
 	}
 	if r.eventBus != nil {
+		// Copy before publishing: the execute goroutine keeps mutating this
+		// *Run (recordRunOutcome → run.End()) while SSE/cloud subscribers
+		// marshal the event on their own goroutines. Sharing the pointer is a
+		// data race, matching every other publish site.
 		r.eventBus.Publish(events.EventRunUpdated, events.RunEvent{
-			Run:     run,
+			Run:     run.Copy(),
 			LogPath: logPath,
 		})
 	}

--- a/apps/runwisp/internal/executor/image_builder.go
+++ b/apps/runwisp/internal/executor/image_builder.go
@@ -51,7 +51,11 @@ func (b *ImageBuilder) Build(ctx context.Context, ctr *model.ContainerExecution)
 			if err == io.EOF {
 				break
 			}
-			continue
+			// A non-EOF decode error means the stream is malformed; the decoder
+			// does not advance past a syntax error, so continuing would busy-loop
+			// forever on the same bytes. Bail out and surface the failure.
+			buildResp.Body.Close()
+			return "", fmt.Errorf("docker build: decode response stream: %w", err)
 		}
 		if msg.Error != "" {
 			buildResp.Body.Close()

--- a/apps/runwisp/internal/notify/coalesce/coalesce.go
+++ b/apps/runwisp/internal/notify/coalesce/coalesce.go
@@ -249,15 +249,29 @@ func (c *Channel) timerFlush(fp string) {
 		c.mu.Unlock()
 		return
 	}
+	// Skip the flush if Close has begun. Close closes timerDone (via
+	// timerCancel) before it acquires c.mu, so checking it here — and doing the
+	// wg.Add below — under c.mu makes the check-and-register atomic against
+	// Close. Without this, a timer that fired just as Close started could call
+	// wg.Add concurrently with Close's wg.Wait and panic ("WaitGroup reused").
+	select {
+	case <-c.timerDone:
+		st.timer = nil
+		c.mu.Unlock()
+		return
+	default:
+	}
+
 	count := st.pending // suppressed events folded into the window-close summary
 	ev := st.lastEvent
 	st.pending = 0
 	st.lastSent = c.clock.Now()
 	st.lastEvent = nil
 	st.timer = nil
+	// Registered under c.mu, before Close can take the lock and start wg.Wait.
+	c.wg.Add(1)
 	c.mu.Unlock()
 
-	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
 		select {

--- a/apps/runwisp/internal/notify/notify.go
+++ b/apps/runwisp/internal/notify/notify.go
@@ -19,9 +19,15 @@ import (
 // once at shutdown. A future SIGHUP-driven reload would simply call Stop and
 // then construct a fresh Service — no shared state survives the call.
 type Service struct {
-	bus         events.EventBus
-	ingressCh   chan *Event
-	ingressSize int
+	bus events.EventBus
+	// ingressCh carries mapped events from the bus publisher goroutine to
+	// runDispatch. ingressMu guards it against the send-on-closed race: Stop
+	// closes the channel while an in-flight onBusEvent (a publish that captured
+	// the handler list before unsubscribe) may still be trying to send.
+	ingressMu     sync.RWMutex
+	ingressCh     chan *Event
+	ingressClosed bool
+	ingressSize   int
 
 	router   *Router
 	disp     *dispatcher
@@ -177,7 +183,13 @@ func (s *Service) Stop(ctx context.Context) error {
 		s.retentionCancel = nil
 	}
 
+	// Close under the lock so any in-flight onBusEvent send completes first and
+	// later ones observe ingressClosed instead of sending on a closed channel.
+	// runDispatch then drains the buffered backlog and exits on the closed read.
+	s.ingressMu.Lock()
+	s.ingressClosed = true
 	close(s.ingressCh)
+	s.ingressMu.Unlock()
 
 	done := make(chan struct{})
 	go func() {
@@ -232,6 +244,15 @@ func (s *Service) onBusEvent(e events.Event) {
 		if _, muted := s.mutedMissed[ev.TaskName]; muted {
 			return
 		}
+	}
+	// RLock lets concurrent publishes send in parallel (channel sends are
+	// themselves safe) while excluding Stop's close. A closed ingress means the
+	// service is shutting down; drop rather than panic.
+	s.ingressMu.RLock()
+	defer s.ingressMu.RUnlock()
+	if s.ingressClosed {
+		s.droppedIngress.Add(1)
+		return
 	}
 	select {
 	case s.ingressCh <- ev:

--- a/apps/runwisp/internal/runtime/catchup.go
+++ b/apps/runwisp/internal/runtime/catchup.go
@@ -24,10 +24,12 @@ type CatchUpResult struct {
 }
 
 // RunMissedTickCatchUp inspects each scheduled task and triggers catch-up runs
-// for cron ticks that were missed while the daemon was down.
-func RunMissedTickCatchUp(ctx context.Context, db storage.RunRepository, tasks map[string]*model.Task, runner TaskRunner, now time.Time) CatchUpResult {
+// for cron ticks that were missed while the daemon was down. defaultLoc is the
+// scheduler's resolved timezone ([scheduler] timezone); a task's own timezone
+// overrides it, exactly as the live scheduler resolves it.
+func RunMissedTickCatchUp(ctx context.Context, db storage.RunRepository, tasks map[string]*model.Task, runner TaskRunner, now time.Time, defaultLoc *time.Location) CatchUpResult {
 	var result CatchUpResult
-	parser := cronspec.NewParser()
+	parser := cronspec.NewScheduleParser()
 
 	for _, task := range tasks {
 		// Only the no-cron guard remains: detection is independent of the
@@ -36,7 +38,7 @@ func RunMissedTickCatchUp(ctx context.Context, db storage.RunRepository, tasks m
 		if task.Cron == "" {
 			continue
 		}
-		triggered, errors := catchupOneTask(ctx, db, parser, task, runner, now)
+		triggered, errors := catchupOneTask(ctx, db, parser, task, runner, now, defaultLoc)
 		result.Triggered += triggered
 		result.Errors += errors
 	}
@@ -44,9 +46,33 @@ func RunMissedTickCatchUp(ctx context.Context, db storage.RunRepository, tasks m
 	return result
 }
 
+// catchupSchedule builds a task's schedule and the location its ticks are
+// evaluated in, mirroring Scheduler.effectiveSpec: a per-task timezone is
+// applied via a CRON_TZ= prefix (and used as the reference location), otherwise
+// the scheduler default is used. Counting missed ticks in the wrong zone would
+// mis-detect the downtime gap for any task not on the host's local time.
+func catchupSchedule(parser cron.ScheduleParser, task *model.Task, defaultLoc *time.Location) (cron.Schedule, *time.Location, error) {
+	spec := task.Cron
+	loc := defaultLoc
+	if loc == nil {
+		loc = time.Local
+	}
+	if task.Timezone != "" {
+		spec = "CRON_TZ=" + task.Timezone + " " + task.Cron
+		if l, err := time.LoadLocation(task.Timezone); err == nil {
+			loc = l
+		}
+	}
+	schedule, err := parser.Parse(spec)
+	if err != nil {
+		return nil, nil, err
+	}
+	return schedule, loc, nil
+}
+
 // catchupOneTask processes a single task's catch-up logic and returns the
 // number of runs triggered and errors encountered.
-func catchupOneTask(ctx context.Context, db storage.RunRepository, parser cron.Parser, task *model.Task, runner TaskRunner, now time.Time) (triggered, errors int) {
+func catchupOneTask(ctx context.Context, db storage.RunRepository, parser cron.ScheduleParser, task *model.Task, runner TaskRunner, now time.Time, defaultLoc *time.Location) (triggered, errors int) {
 	// Persist first-seen timestamp; INSERT OR IGNORE is a no-op on every
 	// restart after the first. On first startup firstSeenAt == now, so
 	// countMissedTicks returns 0 — no spurious initial run.
@@ -55,16 +81,21 @@ func catchupOneTask(ctx context.Context, db storage.RunRepository, parser cron.P
 		return 0, 1
 	}
 
-	schedule, err := parser.Parse(task.Cron)
+	schedule, loc, err := catchupSchedule(parser, task, defaultLoc)
 	if err != nil {
 		slog.Warn("Failed to parse schedule for catch-up", "task", task.Name, "err", err)
 		return 0, 1
 	}
+	// Evaluate ticks in the task's effective zone. For the scheduler-default
+	// case the schedule preserves the input location, so converting the anchor
+	// and now here is what pins evaluation to defaultLoc.
+	now = now.In(loc)
 
 	anchor, ok, errCount := resolveCatchupAnchor(ctx, db, task)
 	if !ok {
 		return 0, errCount
 	}
+	anchor = anchor.In(loc)
 
 	// Bound counting at max(cap, floor)+1: the +1 lets computeCatchupTriggers
 	// still see missedCount > MaxCatchUpRuns (so all/latest/skip cap correctly)

--- a/apps/runwisp/internal/runtime/catchup_anchor_test.go
+++ b/apps/runwisp/internal/runtime/catchup_anchor_test.go
@@ -65,7 +65,7 @@ func TestRunMissedTickCatchUp_RecordedRowAnchorsNextRestart(t *testing.T) {
 	}))
 
 	now1 := time.Date(2026, 4, 7, 10, 20, 0, 0, time.UTC)
-	res1 := RunMissedTickCatchUp(context.Background(), db, tasks, jm, now1)
+	res1 := RunMissedTickCatchUp(context.Background(), db, tasks, jm, now1, time.UTC)
 	assert.Equal(t, 0, res1.Errors)
 	assert.Equal(t, 0, res1.Triggered, "skip re-fires nothing")
 
@@ -86,7 +86,7 @@ func TestRunMissedTickCatchUp_RecordedRowAnchorsNextRestart(t *testing.T) {
 	// Second restart two minutes later — still inside the same */5 window, so
 	// there is nothing new to miss.
 	now2 := time.Date(2026, 4, 7, 10, 22, 0, 0, time.UTC)
-	res2 := RunMissedTickCatchUp(context.Background(), db, tasks, jm, now2)
+	res2 := RunMissedTickCatchUp(context.Background(), db, tasks, jm, now2, time.UTC)
 	assert.Equal(t, 0, res2.Errors)
 	assert.Equal(t, 0, res2.Triggered)
 

--- a/apps/runwisp/internal/runtime/catchup_test.go
+++ b/apps/runwisp/internal/runtime/catchup_test.go
@@ -28,6 +28,27 @@ func catchupTask(policy model.MissedRunPolicy) *model.Task {
 	}
 }
 
+// TestCatchupScheduleHonorsTaskTimezone verifies catch-up evaluates a task's
+// cron in the task's own timezone, not the host's. Before the fix the missed-
+// tick recalculation always used the host local zone, mis-detecting the gap for
+// any task pinned to a different timezone.
+func TestCatchupScheduleHonorsTaskTimezone(t *testing.T) {
+	task := &model.Task{Name: "tz", Cron: "0 12 * * *", Timezone: "America/New_York"}
+
+	schedule, loc, err := catchupSchedule(cronspec.NewScheduleParser(), task, time.UTC)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "America/New_York", loc.String())
+
+	// January → EST (UTC-5), so the next noon New York after midnight UTC on the
+	// 15th is 17:00 UTC that same day. Evaluated in the host zone this would land
+	// on a different instant entirely.
+	next := schedule.Next(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC))
+	assert.True(t, next.Equal(time.Date(2026, 1, 15, 17, 0, 0, 0, time.UTC)),
+		"per-task timezone must anchor the next tick at noon New York (17:00 UTC), got %s", next.UTC())
+}
+
 // mockTaskRunner is a local mock for TaskRunner to avoid circular imports.
 type mockTaskRunner struct {
 	mock.Mock
@@ -206,7 +227,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 1, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 1)
@@ -233,7 +254,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 4, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 4)
@@ -259,7 +280,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return(lastRun, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 0, result.Triggered, "skip never re-fires a missed tick")
 		assert.Equal(t, 0, result.Errors)
@@ -284,7 +305,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return(nil, nil)
 		db.On("GetTaskRegistration", mock.Anything, "my-task").Return(reg, nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 0, result.Triggered)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -309,7 +330,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 1, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 1)
@@ -333,7 +354,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 4, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 4)
@@ -359,7 +380,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 5, result.Triggered, "cap of 5 must clamp the 12-tick backlog")
 		runner.AssertNumberOfCalls(t, "TriggerRun", 5)
@@ -392,7 +413,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 			return strings.Contains(reason, "at least") && strings.Contains(reason, "+")
 		})).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 5, result.Triggered, "cap of 5 must clamp the per-second backlog")
 		runner.AssertNumberOfCalls(t, "TriggerRun", 5)
@@ -419,7 +440,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 12, result.Triggered, "backlog under the cap must be backfilled in full")
 		runner.AssertNumberOfCalls(t, "TriggerRun", 12)
@@ -436,7 +457,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 
 		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(assert.AnError)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors,
 			"failure to register the task surfaces as a catch-up error, not a silent skip")
@@ -456,7 +477,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 
 		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -474,7 +495,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(nil)
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return((*model.Run)(nil), assert.AnError)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -493,7 +514,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return((*model.Run)(nil), nil)
 		db.On("GetTaskRegistration", mock.Anything, "my-task").Return((*model.TaskRegistration)(nil), assert.AnError)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -512,7 +533,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return((*model.Run)(nil), nil)
 		db.On("GetTaskRegistration", mock.Anything, "my-task").Return((*model.TaskRegistration)(nil), nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 0, result.Errors,
 			"missing registration with no prior run isn't an error — the task simply has no anchor yet")
@@ -539,7 +560,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return((*model.Run)(nil), assert.AnError)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors)
 	})
@@ -563,7 +584,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(nil)
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return(lastRun, nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 0, result.Triggered)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -594,7 +615,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 				gotReason = args.Get(2).(string)
 			}).Return(nil)
 
-		RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		runner.AssertNumberOfCalls(t, "RecordMissedRun", 1)
 		wantTick := time.Date(2026, 4, 7, 10, 20, 0, 0, time.UTC)
@@ -626,7 +647,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) { gotReason = args.Get(2).(string) }).Return(nil)
 
-		RunMissedTickCatchUp(context.Background(), db, tasks, runner, now)
+		RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Contains(t, gotReason, "12 scheduled runs missed",
 			"alert reports the detected total even though only 5 were re-run")

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -360,6 +360,18 @@ func (m *defaultTaskManager) TriggerRun(taskName string, triggeredBy model.Trigg
 
 func (m *defaultTaskManager) TriggerRunWithOptions(taskName string, options TriggerRunOptions) (*model.Run, error) {
 	m.mu.Lock()
+	// A terminal event for a run that never executes is published after the
+	// lock is released: EventRunFailed subscribers (the cloud bridge) re-enter
+	// the manager via ServiceSnapshot → m.mu.RLock, which would deadlock if we
+	// published while still holding the write lock. The deferred flush runs
+	// after m.mu.Unlock (LIFO defer order). EventRunCreated stays inline — it
+	// has no re-entrant subscriber and must precede run.started for the same run.
+	var publishTerminal func()
+	defer func() {
+		if publishTerminal != nil {
+			publishTerminal()
+		}
+	}()
 	defer m.mu.Unlock()
 
 	// Refuse new runs once shutdown has begun. Shutdown sets isShutdown before
@@ -457,12 +469,12 @@ func (m *defaultTaskManager) TriggerRunWithOptions(taskName string, options Trig
 	case actionRejected:
 		run.End(model.ReasonSkipped, -1, m.clock())
 		m.persistence.PersistExisting(run)
-		m.publishRun(events.EventRunFailed, run)
+		publishTerminal = func() { m.publishRun(events.EventRunFailed, run) }
 		return run.Copy(), actionErr
 	case actionQueueFull:
 		run.End(model.ReasonQueueFull, -1, m.clock())
 		m.persistence.PersistExisting(run)
-		m.publishRun(events.EventRunFailed, run)
+		publishTerminal = func() { m.publishRun(events.EventRunFailed, run) }
 		return run.Copy(), actionErr
 	case actionQueued:
 		// The run sits in the queue; queueProcessLoop will later hand it to a
@@ -519,6 +531,14 @@ func (m *defaultTaskManager) triggerJittered(taskName string, tick time.Time) (s
 // then immediately ended with the supplied reason.
 func (m *defaultTaskManager) RecordSkippedFiring(taskName string, reason model.EndReason, triggeredBy model.TriggeredBy) error {
 	m.mu.Lock()
+	// See TriggerRunWithOptions: the terminal event is published after the lock
+	// is released so a re-entrant EventRunFailed subscriber cannot deadlock us.
+	var publishTerminal func()
+	defer func() {
+		if publishTerminal != nil {
+			publishTerminal()
+		}
+	}()
 	defer m.mu.Unlock()
 
 	if _, exists := m.tasks[taskName]; !exists {
@@ -537,7 +557,7 @@ func (m *defaultTaskManager) RecordSkippedFiring(taskName string, reason model.E
 	m.publishRun(events.EventRunCreated, run)
 	run.End(reason, -1, now)
 	m.persistence.PersistExisting(run)
-	m.publishRun(events.EventRunFailed, run)
+	publishTerminal = func() { m.publishRun(events.EventRunFailed, run) }
 	return nil
 }
 
@@ -552,6 +572,14 @@ func (m *defaultTaskManager) RecordSkippedFiring(taskName string, reason model.E
 // exists; the run is created and immediately ended.
 func (m *defaultTaskManager) RecordMissedRun(taskName string, scheduledAt time.Time, reason string) error {
 	m.mu.Lock()
+	// See TriggerRunWithOptions: the terminal event is published after the lock
+	// is released so a re-entrant EventRunFailed subscriber cannot deadlock us.
+	var publishTerminal func()
+	defer func() {
+		if publishTerminal != nil {
+			publishTerminal()
+		}
+	}()
 	defer m.mu.Unlock()
 
 	if _, exists := m.tasks[taskName]; !exists {
@@ -569,7 +597,7 @@ func (m *defaultTaskManager) RecordMissedRun(taskName string, scheduledAt time.T
 	m.publishRun(events.EventRunCreated, run)
 	run.End(model.ReasonMissed, -1, scheduledAt)
 	m.persistence.PersistExisting(run)
-	m.publishRunErr(events.EventRunFailed, run, reason)
+	publishTerminal = func() { m.publishRunErr(events.EventRunFailed, run, reason) }
 	return nil
 }
 

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -46,6 +46,12 @@ type TriggerRunOptions struct {
 	ExternalExecutionID string
 	RetryAttempt        int
 	RetryOfRunID        *string
+	// RestartAttempt is the number of consecutive restarts that precede this run
+	// in a non-service restart chain. It escalates the restart backoff the same
+	// way the supervisor's attempt counter does for services; without it every
+	// restart of a non-service task would wait only the flat base delay, hot-
+	// looping a task that fails immediately. In-memory only (not persisted).
+	RestartAttempt int
 	// InstanceIndex pins the run to a specific instance slot. Required for
 	// supervisor-driven restarts of services; nil for cron/API/retry runs.
 	InstanceIndex *int
@@ -337,7 +343,7 @@ func (m *defaultTaskManager) requeuePendingRun(ts *taskState, r *model.Run, resu
 func (m *defaultTaskManager) restartOrFailPendingRun(ts *taskState, r *model.Run, result *PendingRunsResult) {
 	concurrencyLimit := m.getConcurrencyLimit(ts.task)
 	if len(ts.active) < concurrencyLimit {
-		m.startRun(ts.task, r)
+		m.startRun(ts.task, r, 0)
 		result.Resumed++
 		return
 	}
@@ -417,7 +423,7 @@ func (m *defaultTaskManager) TriggerRunWithOptions(taskName string, options Trig
 		// The caller must never read fields (Status, StartAt, ...) that the run
 		// goroutine concurrently writes, so it gets an independent copy.
 		snapshot := run.Copy()
-		m.startRun(ts.task, run)
+		m.startRun(ts.task, run, options.RestartAttempt)
 		return snapshot, nil
 	}
 
@@ -471,7 +477,7 @@ func (m *defaultTaskManager) TriggerRunWithOptions(taskName string, options Trig
 
 	// Snapshot before startRun spawns the execution goroutine (see service path).
 	snapshot := run.Copy()
-	m.startRun(ts.task, run)
+	m.startRun(ts.task, run, options.RestartAttempt)
 	return snapshot, nil
 }
 
@@ -793,9 +799,11 @@ func serviceRollupState(stopped bool, running, fatal, desired int) string {
 	}
 }
 
-// startRun registers the run and spawns the execution goroutine. Assumes
-// m.mu is held.
-func (m *defaultTaskManager) startRun(task *model.Task, run *model.Run) {
+// startRun registers the run and spawns the execution goroutine. restartAttempt
+// is the non-service restart-chain depth carried onto the ActiveRun so a later
+// failure escalates the restart backoff; it is zero for every path except a
+// non-service restart. Assumes m.mu is held.
+func (m *defaultTaskManager) startRun(task *model.Task, run *model.Run, restartAttempt int) {
 	ctx := context.Background()
 	var cancel context.CancelFunc
 
@@ -806,9 +814,10 @@ func (m *defaultTaskManager) startRun(task *model.Task, run *model.Run) {
 	}
 
 	active := &ActiveRun{
-		Run:       run,
-		Cancel:    cancel,
-		StartedAt: m.clock(),
+		Run:            run,
+		Cancel:         cancel,
+		StartedAt:      m.clock(),
+		RestartAttempt: restartAttempt,
 	}
 
 	m.tasks[task.Name].active = append(m.tasks[task.Name].active, active)
@@ -916,8 +925,10 @@ func (m *defaultTaskManager) retireRun(task *model.Task, run *model.Run, runDura
 	if ts == nil {
 		return nextRestartAttempt, serviceFatal, fatalAttempts
 	}
+	var retired *ActiveRun
 	for i, ar := range ts.active {
 		if ar.Run.ID == run.ID {
+			retired = ar
 			ts.active = append(ts.active[:i], ts.active[i+1:]...)
 			break
 		}
@@ -929,6 +940,12 @@ func (m *defaultTaskManager) retireRun(task *model.Task, run *model.Run, runDura
 		if serviceFatal {
 			fatalAttempts = ts.supervisor.StartFails(run.InstanceIndex)
 		}
+	} else if retry.IsFailureReason(endReason) && retired != nil {
+		// Non-service restart backoff has no supervisor to count attempts, so we
+		// carry the chain depth on the ActiveRun. Return it as the attempt the
+		// next restart delay is computed from; scheduleRestart advances it for the
+		// respawned run so consecutive failures escalate instead of hot-looping.
+		nextRestartAttempt = retired.RestartAttempt
 	}
 	if ts.cond != nil {
 		ts.cond.Signal()

--- a/apps/runwisp/internal/runtime/retry.go
+++ b/apps/runwisp/internal/runtime/retry.go
@@ -68,6 +68,10 @@ func (m *defaultTaskManager) scheduleRestart(task *model.Task, previousRun *mode
 		// Preserve the operator's inputs across a restart (no-op for services,
 		// which never carry parameters).
 		Params: model.SuppliedFromResolved(task.Parameters, previousRun.Params),
+		// Advance the restart-chain depth so the next failure of a non-service
+		// task backs off further (attempt was the delay just applied). Ignored
+		// for services, which track attempts via their supervisor.
+		RestartAttempt: attempt + 1,
 	}
 	if task.Kind.IsService() {
 		options.TriggeredBy = model.TriggeredByService

--- a/apps/runwisp/internal/runtime/taskstate.go
+++ b/apps/runwisp/internal/runtime/taskstate.go
@@ -27,6 +27,11 @@ type ActiveRun struct {
 	// coordinator to bound total shutdown time.
 	ForceKill func()
 	StartedAt time.Time
+	// RestartAttempt carries the non-service restart-chain depth from the
+	// triggering options so retireRun can escalate the restart backoff. Zero for
+	// original, cron, API, retry, and queued runs. Read only under the manager
+	// lock; not persisted.
+	RestartAttempt int
 }
 
 // taskState holds all per-task runtime state under the manager mutex.
@@ -135,7 +140,7 @@ func (m *defaultTaskManager) queueProcessLoop(taskName string) {
 		}
 		run := ts.queue[0]
 		ts.queue = ts.queue[1:]
-		m.startRun(ts.task, run)
+		m.startRun(ts.task, run, 0)
 	}
 }
 

--- a/apps/runwisp/internal/storage/database_test.go
+++ b/apps/runwisp/internal/storage/database_test.go
@@ -206,11 +206,11 @@ func TestDeleteOldRuns(t *testing.T) {
 	old := now.Add(-25 * time.Hour)
 
 	// Run to be deleted by hours retention (24h)
-	run1 := model.Run{ID: ulid.Make().String(), TaskName: "task1", CreatedAt: old, TriggeredBy: model.TriggeredByAPI}
+	run1 := model.Run{ID: ulid.Make().String(), TaskName: "task1", Status: model.PhaseEnded, EndReason: model.EndReasonPtr(model.ReasonSuccess), CreatedAt: old, TriggeredBy: model.TriggeredByAPI}
 	require.NoError(t, db.CreateRun(ctx, &run1))
 
 	// Run to be kept
-	run2 := model.Run{ID: ulid.Make().String(), TaskName: "task1", CreatedAt: now, TriggeredBy: model.TriggeredByAPI}
+	run2 := model.Run{ID: ulid.Make().String(), TaskName: "task1", Status: model.PhaseEnded, EndReason: model.EndReasonPtr(model.ReasonSuccess), CreatedAt: now, TriggeredBy: model.TriggeredByAPI}
 	require.NoError(t, db.CreateRun(ctx, &run2))
 
 	task := &model.Task{
@@ -229,6 +229,38 @@ func TestDeleteOldRuns(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestDeleteOldRunsSkipsNonTerminal guards the retention invariant: a run that
+// is still pending or running must never be purged, even when it is older than
+// the retention cutoff. A service that runs longer than keep_for would otherwise
+// have its row (and, in production, its live log files) deleted mid-run.
+func TestDeleteOldRunsSkipsNonTerminal(t *testing.T) {
+	ctx := t.Context()
+	db := setupTestDB(t)
+	defer db.Close()
+
+	old := time.Now().Add(-25 * time.Hour)
+
+	ended := model.Run{ID: ulid.Make().String(), TaskName: "task1", Status: model.PhaseEnded, EndReason: model.EndReasonPtr(model.ReasonSuccess), CreatedAt: old, TriggeredBy: model.TriggeredByCron}
+	require.NoError(t, db.CreateRun(ctx, &ended))
+	// A long-lived service instance: created before the cutoff but still live.
+	running := model.Run{ID: ulid.Make().String(), TaskName: "task1", Status: model.PhaseRunning, CreatedAt: old, TriggeredBy: model.TriggeredByService}
+	require.NoError(t, db.CreateRun(ctx, &running))
+	pending := model.Run{ID: ulid.Make().String(), TaskName: "task1", Status: model.PhasePending, CreatedAt: old, TriggeredBy: model.TriggeredByCron}
+	require.NoError(t, db.CreateRun(ctx, &pending))
+
+	deleted, err := db.DeleteOldRuns(ctx, &model.Task{Name: "task1", KeepFor: 24 * time.Hour})
+	require.NoError(t, err)
+
+	require.Len(t, deleted, 1)
+	assert.Equal(t, ended.ID, deleted[0].ID)
+
+	// The non-terminal runs must survive.
+	_, err = db.GetRun(ctx, running.ID)
+	assert.NoError(t, err)
+	_, err = db.GetRun(ctx, pending.ID)
+	assert.NoError(t, err)
+}
+
 func TestDeleteOldRunsByCount(t *testing.T) {
 	ctx := t.Context()
 	db := setupTestDB(t)
@@ -239,6 +271,8 @@ func TestDeleteOldRunsByCount(t *testing.T) {
 		require.NoError(t, db.CreateRun(ctx, &model.Run{
 			ID:          ulid.Make().String(),
 			TaskName:    "task1",
+			Status:      model.PhaseEnded,
+			EndReason:   model.EndReasonPtr(model.ReasonSuccess),
 			CreatedAt:   time.Now().Add(time.Duration(i) * time.Second), // Different times
 			TriggeredBy: model.TriggeredByAPI,
 		}))

--- a/apps/runwisp/internal/storage/query/runs_retention.sql
+++ b/apps/runwisp/internal/storage/query/runs_retention.sql
@@ -2,12 +2,16 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- name: SelectOldRunsByAge :many
+-- Only terminal (ended) runs are eligible for retention: a run that is still
+-- pending or running must never have its row or live log files removed.
 SELECT * FROM runs
-WHERE task_name = ? AND created_at < ? AND deleted_at IS NULL
+WHERE task_name = ? AND created_at < ? AND status = 'ended' AND deleted_at IS NULL
 LIMIT ?;
 
 -- name: SelectOldRunsByCount :many
+-- Count-based retention likewise ranges over ended runs only, so in-flight
+-- runs neither count against the cap nor get purged.
 SELECT * FROM runs
-WHERE task_name = ? AND deleted_at IS NULL
+WHERE task_name = ? AND status = 'ended' AND deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?;

--- a/apps/runwisp/internal/storage/sqlcdb/querier.go
+++ b/apps/runwisp/internal/storage/sqlcdb/querier.go
@@ -76,7 +76,11 @@ type Querier interface {
 	SelectExistingForFingerprint(ctx context.Context, arg SelectExistingForFingerprintParams) (SelectExistingForFingerprintRow, error)
 	// SPDX-FileCopyrightText: PoppyCake, s.r.o.
 	// SPDX-License-Identifier: Apache-2.0
+	// Only terminal (ended) runs are eligible for retention: a run that is still
+	// pending or running must never have its row or live log files removed.
 	SelectOldRunsByAge(ctx context.Context, arg SelectOldRunsByAgeParams) ([]Run, error)
+	// Count-based retention likewise ranges over ended runs only, so in-flight
+	// runs neither count against the cap nor get purged.
 	SelectOldRunsByCount(ctx context.Context, arg SelectOldRunsByCountParams) ([]Run, error)
 	SelectRestoredRunsByFilter(ctx context.Context, arg SelectRestoredRunsByFilterParams) ([]Run, error)
 	SelectRestoredRunsByIDs(ctx context.Context, ids []string) ([]Run, error)

--- a/apps/runwisp/internal/storage/sqlcdb/runs_retention.sql.go
+++ b/apps/runwisp/internal/storage/sqlcdb/runs_retention.sql.go
@@ -13,7 +13,7 @@ import (
 const selectOldRunsByAge = `-- name: SelectOldRunsByAge :many
 
 SELECT id, external_execution_id, task_name, status, end_reason, exit_code, start_at, end_at, triggered_by, created_at, retry_attempt, retry_of_run_id, instance_index, params_json, deleted_at FROM runs
-WHERE task_name = ? AND created_at < ? AND deleted_at IS NULL
+WHERE task_name = ? AND created_at < ? AND status = 'ended' AND deleted_at IS NULL
 LIMIT ?
 `
 
@@ -25,6 +25,8 @@ type SelectOldRunsByAgeParams struct {
 
 // SPDX-FileCopyrightText: PoppyCake, s.r.o.
 // SPDX-License-Identifier: Apache-2.0
+// Only terminal (ended) runs are eligible for retention: a run that is still
+// pending or running must never have its row or live log files removed.
 func (q *Queries) SelectOldRunsByAge(ctx context.Context, arg SelectOldRunsByAgeParams) ([]Run, error) {
 	rows, err := q.db.QueryContext(ctx, selectOldRunsByAge, arg.TaskName, arg.CreatedAt, arg.Limit)
 	if err != nil {
@@ -66,7 +68,7 @@ func (q *Queries) SelectOldRunsByAge(ctx context.Context, arg SelectOldRunsByAge
 
 const selectOldRunsByCount = `-- name: SelectOldRunsByCount :many
 SELECT id, external_execution_id, task_name, status, end_reason, exit_code, start_at, end_at, triggered_by, created_at, retry_attempt, retry_of_run_id, instance_index, params_json, deleted_at FROM runs
-WHERE task_name = ? AND deleted_at IS NULL
+WHERE task_name = ? AND status = 'ended' AND deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?
 `
@@ -77,6 +79,8 @@ type SelectOldRunsByCountParams struct {
 	Offset   int64  `json:"offset"`
 }
 
+// Count-based retention likewise ranges over ended runs only, so in-flight
+// runs neither count against the cap nor get purged.
 func (q *Queries) SelectOldRunsByCount(ctx context.Context, arg SelectOldRunsByCountParams) ([]Run, error) {
 	rows, err := q.db.QueryContext(ctx, selectOldRunsByCount, arg.TaskName, arg.Limit, arg.Offset)
 	if err != nil {


### PR DESCRIPTION
A batch of small correctness fixes found while reviewing the runtime, storage, executor, notify, config, and cloud subsystems. Each fix is its own commit.

## Runtime
- Publish terminal run events after releasing the manager lock, so a synchronous re-entrant subscriber can't deadlock the manager (skip-overlap, queue-full, catch-up, DST fall-back paths).
- Evaluate missed-tick catch-up in each task's timezone (or the scheduler default) instead of the host's local zone.
- Apply the configured `restart_backoff` curve to consecutive non-service restarts instead of the flat base delay.

## Storage
- Restrict retention (`SelectOldRunsByAge`/`SelectOldRunsByCount`) to terminal runs so a still-running or pending run is never deleted mid-flight.

## Executor
- Copy the run before publishing `run.updated` to avoid a data race with the execute goroutine.
- Fail a Docker image build on an undecodable response stream instead of spinning.
- Re-probe `docker compose` availability after a transient first-probe failure.
- Run container start-failure cleanup on a context detached from cancellation so a cancelled start doesn't leak its container/image.

## Notify
- Guard the ingress channel against send-on-closed during shutdown.
- Make the coalescer's window-close flush register with its WaitGroup under the lock `Close` holds, avoiding a WaitGroup misuse panic.

## Config
- Reject negative `timeout`, `retry_delay`, and `restart_delay` at load instead of silently ignoring them.

## Cloud
- Copy pending updates in `FlushPending` to break slice aliasing with a concurrent `bufferUpdate`.
- Reset the reconnect backoff only after a session stays up past a minimum duration.

## Testing
`go build ./...`, `go vet`, and `go test ./...` pass. Added tests: retention skips non-terminal runs, catch-up honors a task's timezone, and negative-duration config rejection. The race detector needs cgo/a C compiler, which isn't available in this environment, so the concurrency fixes were verified by review and the existing suites.