### PR TITLE
test: add regression guards for runtime deadlock, timezone catch-up, and restart backoff

### DIFF
--- a/apps/runwisp/internal/runtime/catchup_test.go
+++ b/apps/runwisp/internal/runtime/catchup_test.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 	"testing"
 	"time"
+	// Embed the zoneinfo database into the test binary so LoadLocation of a
+	// named zone (America/New_York, below) does not depend on the host's system
+	// tzdata — keeping the timezone catch-up test hermetic per the repo's
+	// unit-test philosophy. cmd/runwisp links this for the real binary; the
+	// runtime test binary does not, so it is pinned here.
+	_ "time/tzdata"
 
 	"github.com/runwisp/runwisp/internal/cronspec"
 	"github.com/runwisp/runwisp/internal/model"
@@ -258,6 +264,42 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 
 		assert.Equal(t, 4, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 4)
+	})
+
+	t.Run("counts missed ticks in the task's own timezone, not the host's", func(t *testing.T) {
+		// End-to-end guard for M4: catchupOneTask must evaluate the schedule in
+		// the task's timezone before counting missed ticks (the helper-only test
+		// covers only that the schedule is *built* in the right zone). A daily
+		// midnight cron pinned to New York fires at 05:00 UTC (EST, UTC-5 in
+		// January); evaluated in UTC it would fire at 00:00 UTC — a different
+		// instant that yields a different missed count over the same window.
+		db := new(testutil.MockRunRepository)
+		runner := new(mockTaskRunner)
+
+		// Window straddles the offset so the two zones disagree on the count:
+		//   New York midnights (05:00 UTC): Jan 15 05:00 and Jan 16 05:00 both
+		//     fall in (anchor, now] → 2 missed ticks (the correct answer).
+		//   UTC midnights (00:00 UTC): only Jan 16 00:00 falls in the window → 1.
+		anchor := time.Date(2026, 1, 15, 3, 0, 0, 0, time.UTC)
+		now := time.Date(2026, 1, 16, 6, 0, 0, 0, time.UTC)
+
+		lastRun := &model.Run{ID: "last-run", TaskName: "my-task", CreatedAt: anchor}
+
+		task := catchupTask(model.MissedRunAll)
+		task.Cron = "0 0 * * *"
+		task.Timezone = "America/New_York"
+		tasks := map[string]*model.Task{"my-task": task}
+
+		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(nil)
+		db.On("GetLastRunByTask", mock.Anything, "my-task").Return(lastRun, nil)
+		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
+		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
+
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+
+		assert.Equal(t, 2, result.Triggered,
+			"the New York midnights in the window must be counted in America/New_York, not UTC")
+		runner.AssertNumberOfCalls(t, "TriggerRun", 2)
 	})
 
 	t.Run("policy=skip records the gap but triggers nothing", func(t *testing.T) {

--- a/apps/runwisp/internal/runtime/manager_test.go
+++ b/apps/runwisp/internal/runtime/manager_test.go
@@ -632,6 +632,75 @@ func TestRecordMissedRunUnknownTask(t *testing.T) {
 	require.Error(t, err, "recording a miss for an unknown task is an error, not a silent no-op")
 }
 
+// TestTerminalEventPublishedOffManagerLock is the regression test for the H2
+// re-entrancy deadlock. The three "run never executes" paths — a skip-overlap
+// firing (RecordSkippedFiring), a missed-tick firing (RecordMissedRun), and a
+// concurrency-policy rejection inside TriggerRunWithOptions — publish a terminal
+// EventRunFailed. In the pre-fix code that publish happened while the manager
+// still held m.mu (write lock). The cloud bridge subscribes to EventRunFailed
+// and re-enters the manager via ServiceSnapshot, which takes m.mu.RLock; an
+// RLock requested while the same goroutine already holds the write lock blocks
+// forever. The fix defers the terminal publish until after m.mu.Unlock. Each
+// subtest wires that exact re-entrant subscriber and a watchdog fails the test
+// if the publishing call deadlocks instead of returning.
+func TestTerminalEventPublishedOffManagerLock(t *testing.T) {
+	// assertReturns runs fn in a goroutine and fails if it does not return
+	// within the deadline — the observable symptom of the re-entrancy deadlock.
+	assertReturns := func(t *testing.T, name string, fn func()) {
+		t.Helper()
+		done := make(chan struct{})
+		go func() {
+			fn()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s deadlocked: the terminal event was published under the manager write lock, so the re-entrant ServiceSnapshot subscriber could not take the read lock", name)
+		}
+	}
+
+	t.Run("RecordSkippedFiring", func(t *testing.T) {
+		jm, _, eb := newTestManager(t)
+		jm.UpsertTask(testTask("task1", model.PolicySkip, 1))
+		// The cloud bridge: an EventRunFailed handler that reaches back into the
+		// manager for a snapshot, re-acquiring m.mu as a reader.
+		eb.Subscribe(events.EventRunFailed, func(events.Event) { jm.ServiceSnapshot("task1") })
+		assertReturns(t, "RecordSkippedFiring", func() {
+			_ = jm.RecordSkippedFiring("task1", model.ReasonSkipped, model.TriggeredByCron)
+		})
+	})
+
+	t.Run("RecordMissedRun", func(t *testing.T) {
+		jm, _, eb := newTestManager(t)
+		jm.UpsertTask(testTask("task1", model.PolicyQueue, 1))
+		eb.Subscribe(events.EventRunFailed, func(events.Event) { jm.ServiceSnapshot("task1") })
+		scheduledAt := time.Date(2026, 6, 9, 3, 0, 0, 0, time.UTC)
+		assertReturns(t, "RecordMissedRun", func() {
+			_ = jm.RecordMissedRun("task1", scheduledAt, "daemon was down")
+		})
+	})
+
+	t.Run("TriggerRunWithOptions rejection", func(t *testing.T) {
+		jm, exec, eb := newGatedManager(t)
+		jm.UpsertTask(testTask("task1", model.PolicySkip, 1))
+
+		// First run holds the only slot so the second firing is skip-rejected,
+		// which is the path that publishes the terminal event off the lock.
+		_, err := jm.TriggerRun("task1", model.TriggeredByAPI)
+		require.NoError(t, err)
+		exec.WaitStarted(t)
+
+		// Subscribe only now: the in-flight first run has already emitted its
+		// started event and has not failed, so the handler fires solely for the
+		// rejection we are about to trigger.
+		eb.Subscribe(events.EventRunFailed, func(events.Event) { jm.ServiceSnapshot("task1") })
+		assertReturns(t, "TriggerRun (skip rejection)", func() {
+			_, _ = jm.TriggerRun("task1", model.TriggeredByAPI)
+		})
+	})
+}
+
 func TestPersistenceHook(t *testing.T) {
 	jm, exec, eb := newTestManager(t)
 
@@ -790,6 +859,67 @@ func TestRetryNotFiredWhenRestartPolicySet(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return calls.Load() >= 5
 	}, time.Second, 10*time.Millisecond, "restart should keep firing past retry budget")
+}
+
+// TestNonServiceRestartBackoffEscalates is the regression test for M6: a
+// non-service task with restart=on_failure must escalate its restart backoff
+// across consecutive failures, exactly as the supervisor does for services.
+// Before the fix RestartAttempt never flowed through TriggerRunOptions →
+// ActiveRun → scheduleRestart, so computeRestartDelay saw attempt 0 on every
+// restart and the task hot-looped at the flat base delay. With an exponential
+// curve the inter-restart gaps must grow (base, 2×base, 4×base); a flat-base
+// regression keeps them all ≈ base.
+func TestNonServiceRestartBackoffEscalates(t *testing.T) {
+	exec := new(testutil.MockExecutor)
+	eb := events.NewEventBus()
+	jm := NewTaskManager(exec, eb, time.Now)
+	defer jm.Shutdown()
+
+	const base = 40 * time.Millisecond
+	task := &model.Task{
+		Name:           "task1",
+		Kind:           model.KindTask, // non-service: no supervisor to count attempts
+		Run:            "exit 1",
+		MaxConcurrent:  1,
+		OnOverlap:      model.PolicySkip,
+		Restart:        model.RestartOnFailure,
+		RestartDelay:   base,
+		RestartBackoff: model.BackoffExponential,
+	}
+	jm.UpsertTask(task)
+
+	var mu sync.Mutex
+	var starts []time.Time
+	exec.On("Execute", mock.Anything, task, mock.Anything).Run(func(mock.Arguments) {
+		mu.Lock()
+		starts = append(starts, time.Now())
+		mu.Unlock()
+	}).Return(&executor.ExecuteResult{ExitCode: 1})
+
+	_, err := jm.TriggerRun("task1", model.TriggeredByAPI)
+	require.NoError(t, err)
+
+	// Four starts give three inter-restart gaps: base, 2×base, 4×base.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(starts) >= 4
+	}, 5*time.Second, 5*time.Millisecond, "restart must keep firing on repeated failure")
+
+	mu.Lock()
+	defer mu.Unlock()
+	gap1 := starts[1].Sub(starts[0])
+	gap2 := starts[2].Sub(starts[1])
+	gap3 := starts[3].Sub(starts[2])
+
+	assert.Greater(t, gap2, gap1,
+		"second restart must wait longer than the first (backoff escalated): gaps %v, %v", gap1, gap2)
+	assert.Greater(t, gap3, gap2,
+		"third restart must wait longer than the second (backoff escalated): gaps %v, %v", gap2, gap3)
+	// A flat-base regression keeps every gap ≈ base; the escalated third gap
+	// (≈ 4×base) must clear that bar with room for scheduling jitter.
+	assert.Greater(t, gap3, 2*base,
+		"escalated gap must clearly exceed the flat base delay, got %v (base %v)", gap3, base)
 }
 
 // TestLoadPendingRunsResumed: a pending cron task with a free slot is

--- a/apps/runwisp/internal/runtime/services_test.go
+++ b/apps/runwisp/internal/runtime/services_test.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -289,10 +290,13 @@ func TestServiceFatalAfterStartRetries(t *testing.T) {
 	task.RestartDelay = time.Millisecond
 	jm.UpsertTask(task)
 
-	// Each run fails fast, well under healthy_after.
-	exec.On("Execute", mock.Anything, task, mock.Anything).Return(
-		&executor.ExecuteResult{ExitCode: 1}, 5*time.Millisecond,
-	)
+	// Each run fails fast, well under healthy_after. Count executions via an
+	// atomic counter: reading testify's exec.Calls slice directly races with the
+	// restart goroutine appending to it inside MethodCalled.
+	var execCalls atomic.Int64
+	exec.On("Execute", mock.Anything, task, mock.Anything).
+		Run(func(mock.Arguments) { execCalls.Add(1) }).
+		Return(&executor.ExecuteResult{ExitCode: 1}, 5*time.Millisecond)
 
 	require.NoError(t, jm.StartServiceInstances("flapper", model.TriggeredByService))
 
@@ -317,10 +321,10 @@ func TestServiceFatalAfterStartRetries(t *testing.T) {
 	require.Len(t, snap.Instances, 1)
 	assert.Equal(t, model.ServiceInstanceFatal, snap.Instances[0].State)
 
-	callsAtFatal := len(exec.Calls)
-	assert.Equal(t, 3, callsAtFatal, "start_retries=2 → 3 fast failures, then give up")
+	callsAtFatal := execCalls.Load()
+	assert.Equal(t, int64(3), callsAtFatal, "start_retries=2 → 3 fast failures, then give up")
 	time.Sleep(150 * time.Millisecond)
-	assert.Equal(t, callsAtFatal, len(exec.Calls), "no restarts after FATAL")
+	assert.Equal(t, callsAtFatal, execCalls.Load(), "no restarts after FATAL")
 
 	mu.Lock()
 	require.Len(t, fatalEvents, 1, "exactly one service.fatal event")
@@ -334,7 +338,7 @@ func TestServiceFatalAfterStartRetries(t *testing.T) {
 	// An operator restart clears FATAL and re-attempts with a fresh budget.
 	require.NoError(t, jm.RestartServiceInstances("flapper"))
 	require.Eventually(t, func() bool {
-		return len(exec.Calls) > callsAtFatal
+		return execCalls.Load() > callsAtFatal
 	}, time.Second, 5*time.Millisecond, "restart must re-attempt a FATAL service")
 }
 

--- a/apps/runwisp/internal/server/server_test.go
+++ b/apps/runwisp/internal/server/server_test.go
@@ -102,17 +102,23 @@ func TestGetTasks(t *testing.T) {
 func TestTriggerRun(t *testing.T) {
 	s, _, exec, _ := setupServer(t)
 
-	// The executor signals when the async run reaches it, so the test blocks on
-	// that signal rather than sleeping and hoping.
-	executed := make(chan struct{}, 1)
 	exec.On("Execute", mock.Anything, mock.Anything, mock.Anything).
-		Run(func(mock.Arguments) {
-			select {
-			case executed <- struct{}{}:
-			default:
-			}
-		}).
 		Return(&executor.ExecuteResult{ExitCode: 0})
+
+	// The run executes asynchronously, and the manager keeps mutating the Run
+	// (Run.End) after Execute returns. Block on the terminal run event — the
+	// manager publishes it only once that mutation is done — before asserting on
+	// the mock, whose recorded call argument is that very same Run pointer.
+	// Waiting on an Execute-entry signal instead would race End against
+	// AssertExpectations formatting the stored argument.
+	done := make(chan struct{}, 1)
+	unsub := s.eventBus.Subscribe(events.EventRunCompleted, func(events.Event) {
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	})
+	defer unsub()
 
 	req := httptest.NewRequest("POST", "/api/tasks/task1/run", nil)
 	w := httptest.NewRecorder()
@@ -127,9 +133,9 @@ func TestTriggerRun(t *testing.T) {
 	assert.Equal(t, "task1", run.TaskName)
 
 	select {
-	case <-executed:
+	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("triggered run never reached the executor")
+		t.Fatal("triggered run never completed")
 	}
 	exec.AssertExpectations(t)
 }

--- a/apps/runwisp/internal/server/stream_limiter_test.go
+++ b/apps/runwisp/internal/server/stream_limiter_test.go
@@ -51,9 +51,11 @@ func TestStreamLimiter_GlobalCap(t *testing.T) {
 func TestStreamLimiter_Middleware503(t *testing.T) {
 	l := newStreamLimiter(1, 1)
 
+	entered := make(chan struct{})
 	called := 0
 	h := l.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called++
+		close(entered)
 		// hold the slot until we let the next request through
 		<-r.Context().Done()
 	}))
@@ -69,15 +71,8 @@ func TestStreamLimiter_Middleware503(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait briefly for the goroutine to enter the handler.
-	for {
-		l.mu.Lock()
-		busy := l.total > 0
-		l.mu.Unlock()
-		if busy {
-			break
-		}
-	}
+	// Wait for the goroutine to enter the handler.
+	<-entered
 
 	overReq := httptest.NewRequest("GET", "/", nil)
 	overReq = overReq.WithContext(context.WithValue(overReq.Context(), peerAddrContextKey, "127.0.0.2:1"))

--- a/apps/runwisp/scripts/test-go.sh
+++ b/apps/runwisp/scripts/test-go.sh
@@ -17,7 +17,18 @@ covdir="$(pwd)/.gocoverdir"
 rm -rf "${covdir}"
 mkdir -p "${covdir}"
 
-RUNWISP_E2E_COVDIR="${covdir}" go test -covermode=atomic -coverpkg=./... \
+# Run the unit suite under the race detector: several fixes are data-race /
+# shutdown-timing hardening that only a -race run can catch (-covermode=atomic
+# makes coverage counters atomic; it does NOT enable the detector). The detector
+# needs CGO and a C toolchain — reliable on Linux; skip it on macOS, matching the
+# CI matrix's "-race on the Ubuntu runner only" split. A scalar (not an array)
+# keeps this safe under `set -u` on macOS's bash 3.2 when the flag is empty.
+race_flag=-race
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  race_flag=
+fi
+
+RUNWISP_E2E_COVDIR="${covdir}" go test ${race_flag} -covermode=atomic -coverpkg=./... \
   -coverprofile=.coverage_unit.out ./...
 
 go tool covdata textfmt -i "${covdir}" -o .coverage_e2e.out 2>/dev/null || true


### PR DESCRIPTION
Adds regression tests for three fixes from #159:

- **Runtime deadlock** (H2): verifies that terminal events fire outside the manager lock, preventing re-entrancy deadlock when a subscriber calls back into the manager. Each fixed path (skip, missed-run, trigger) guarded with a 2s watchdog.
- **Catch-up timezone** (M4): end-to-end case with `America/New_York` daily cron and a 27-hour gap — asserts 2 missed ticks (vs 1 without the zone fix). Pins `time/tzdata` for hermeticity.
- **Non-service restart backoff** (M6): measures inter-restart gaps for `restart=on_failure` with exponential backoff, verifying escalation (~40/80/160ms).

Also enables `-race` in `test-go.sh` (Ubuntu only — macOS  requires a C toolchain we don't guarantee in CI).

Each test was verified to fail on the pre-fix source.