### PR TITLE
test: add regression guards for executor, notify, cloud, and container fixes

### DIFF
--- a/apps/runwisp/internal/cloud/client_test.go
+++ b/apps/runwisp/internal/cloud/client_test.go
@@ -367,6 +367,41 @@ func TestReconnectAfterSessionDrop(t *testing.T) {
 	cancel()
 }
 
+// TestRunConnectionAttempt_ShortSessionDoesNotResetBackoff pins the M8 fix:
+// runConnectionAttempt must only signal a backoff reset (its bool return) when
+// the session actually stayed up for minStableSessionDuration. A peer that
+// resets the connection immediately after sync used to reset backoff on every
+// attempt, turning the exponential curve into a tight reconnect loop. Here the
+// peer authenticates then closes at once, so the session lives far less than
+// the stability threshold and the reset must be withheld. (The stable==true
+// branch depends on a real ≥30s session, so it isn't unit-testable without an
+// injected clock; this guards the flap side, which is where the bug lived.)
+func TestRunConnectionAttempt_ShortSessionDoesNotResetBackoff(t *testing.T) {
+	env := newTestEnv(t, func(conn *websocket.Conn) {
+		_ = sendJSON(conn, protocol.AuthResultMessage{
+			Type:         "auth:result",
+			Success:      true,
+			ConnectionID: "conn-flap",
+		})
+		// Close immediately after auth to mimic a control plane that flaps right
+		// after task sync — the session lasts only milliseconds.
+		conn.Close(websocket.StatusGoingAway, "flap")
+	})
+	defer env.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	resetBackoff, _ := env.client.runConnectionAttempt(ctx)
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, minStableSessionDuration,
+		"test premise: the session must end well before the stability threshold")
+	assert.False(t, resetBackoff,
+		"a session shorter than minStableSessionDuration must not signal a backoff reset")
+}
+
 // ---------- State machine tests ----------
 
 func TestStateTransitions(t *testing.T) {

--- a/apps/runwisp/internal/cloud/execution_tracker_test.go
+++ b/apps/runwisp/internal/cloud/execution_tracker_test.go
@@ -277,6 +277,45 @@ func TestBufferUpdateDropsOldestAtCap(t *testing.T) {
 		"newest update must be at the tail after the drop-oldest shift")
 }
 
+// TestFlushPendingDoesNotAliasBufferDuringSend pins the M3 fix: FlushPending
+// used to build its outbound slice with `append(t.pendingExecutionUpdates, …)`
+// and reset the field to `[:0]`, keeping the backing array live. A bufferUpdate
+// arriving after the unlock (while FlushPending still iterates the slice) would
+// then overwrite slots the flush had not sent yet, so a queued update got sent
+// as a *different* update's payload. The fix copies into a fresh slice and nils
+// the source. We reproduce the aliasing deterministically by buffering new
+// updates from inside the send callback (which runs after the unlock) and
+// asserting the still-unsent entries are delivered with their original IDs.
+func TestFlushPendingDoesNotAliasBufferDuringSend(t *testing.T) {
+	tracker := NewExecutionTracker()
+	// No active executions → runningSnapshots is empty, so the pre-fix
+	// `append(pending, nothing...)` returned the same backing array — the exact
+	// aliasing condition. Buffer three updates directly into that array.
+	tracker.bufferUpdate(NewExecutionUpdateMessage("a", protocol.ExecutionStatusOk, nil, nil, nil))
+	tracker.bufferUpdate(NewExecutionUpdateMessage("b", protocol.ExecutionStatusOk, nil, nil, nil))
+	tracker.bufferUpdate(NewExecutionUpdateMessage("c", protocol.ExecutionStatusOk, nil, nil, nil))
+
+	var delivered []string
+	first := true
+	tracker.FlushPending(func(msg any) error {
+		upd, ok := msg.(protocol.ExecutionUpdateMessage)
+		require.True(t, ok)
+		delivered = append(delivered, upd.ExecutionID)
+		if first {
+			first = false
+			// A concurrent-style write during the flush: on the pre-fix code these
+			// append into the shared backing array (len 0 after the [:0] reset),
+			// clobbering the not-yet-sent "b" and "c" slots the flush still holds.
+			tracker.bufferUpdate(NewExecutionUpdateMessage("X", protocol.ExecutionStatusErr, nil, nil, nil))
+			tracker.bufferUpdate(NewExecutionUpdateMessage("Y", protocol.ExecutionStatusErr, nil, nil, nil))
+		}
+		return nil
+	})
+
+	assert.Equal(t, []string{"a", "b", "c"}, delivered,
+		"buffering during the flush must not overwrite entries the flush has not sent yet")
+}
+
 // FlushPending must re-queue any updates that haven't been delivered yet when
 // send returns an error part-way through the slice.
 func TestFlushPendingPartialFailureRequeuesRemainder(t *testing.T) {

--- a/apps/runwisp/internal/executor/compose_test.go
+++ b/apps/runwisp/internal/executor/compose_test.go
@@ -438,6 +438,45 @@ func TestComposeBackend_Start_ContextCancelledBeforeStart(t *testing.T) {
 	assert.Contains(t, err.Error(), "start docker compose")
 }
 
+// TestLazyComposeBackend_ReprobesAfterTransientFailure pins the H5 fix: a
+// transient first-probe failure (docker still coming up) must not disable
+// compose for the daemon's whole lifetime. The old code latched probed=true on
+// the first failure and never retried. The shim fails `compose version` once,
+// then succeeds — so the second ensureProbed must report available.
+func TestLazyComposeBackend_ReprobesAfterTransientFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-shim depends on POSIX shell")
+	}
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "probe.count")
+	body := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"compose\" ] && [ \"$2\" = \"version\" ]; then\n" +
+		"  n=$(cat '" + counter + "' 2>/dev/null || echo 0)\n" +
+		"  n=$((n+1))\n" +
+		"  echo $n > '" + counter + "'\n" +
+		"  if [ \"$n\" = \"1\" ]; then\n" +
+		"    exit 1\n" + // first probe: docker not up yet
+		"  fi\n" +
+		"  echo 'Docker Compose v2.test'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	installDockerShimScript(t, dir, body)
+
+	l := NewLazyComposeBackend("fp-test")
+
+	_, availFirst := l.ensureProbed(context.Background())
+	assert.False(t, availFirst, "the transient first-probe failure must report unavailable")
+
+	_, availSecond := l.ensureProbed(context.Background())
+	assert.True(t, availSecond, "compose must be re-probed and become available once docker is up")
+
+	data, err := os.ReadFile(counter)
+	require.NoError(t, err)
+	assert.Equal(t, "2", strings.TrimSpace(string(data)),
+		"ensureProbed must actually re-run the probe after a failure, not latch the failed result")
+}
+
 func TestLazyComposeBackend_ReturnsErrorWhenUnavailable(t *testing.T) {
 	t.Setenv("PATH", "")
 	l := NewLazyComposeBackend("fp-test")

--- a/apps/runwisp/internal/executor/container_test.go
+++ b/apps/runwisp/internal/executor/container_test.go
@@ -548,6 +548,104 @@ func TestStartGracefulStopUsesSignalAndTimeout(t *testing.T) {
 	}
 }
 
+// TestImageBuilder_Build_MalformedStreamFailsPromptly pins the H4 fix: when the
+// build response body is not valid JSON, json.Decoder returns a non-EOF error
+// without advancing past the offending bytes. The old loop did `continue`,
+// busy-looping forever on the same bytes. Build must instead bail out with an
+// error — and do so promptly. The timeout catches a regression of the busy-loop.
+func TestImageBuilder_Build_MalformedStreamFailsPromptly(t *testing.T) {
+	bodyClosed := false
+	mock := &mockDockerClient{
+		imageBuildFunc: func(ctx context.Context, _ io.Reader, _ client.ImageBuildOptions) (client.ImageBuildResult, error) {
+			return client.ImageBuildResult{
+				Body: &trackingCloser{
+					Reader:  strings.NewReader("this is not valid docker build json {{{"),
+					onClose: func() { bodyClosed = true },
+				},
+			}, nil
+		},
+	}
+	builder := &ImageBuilder{docker: mock}
+
+	type result struct {
+		tag string
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		tag, err := builder.Build(context.Background(), &model.ContainerExecution{
+			Script:    "echo test",
+			BaseImage: "alpine",
+		})
+		done <- result{tag, err}
+	}()
+
+	select {
+	case r := <-done:
+		require.Error(t, r.err, "a malformed build stream must surface as an error, not spin forever")
+		assert.Contains(t, r.err.Error(), "decode response stream")
+		assert.Empty(t, r.tag, "no image tag must be returned on a decode failure")
+		assert.True(t, bodyClosed, "the build response body must be closed on the decode-error path")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Build did not return on a malformed stream — the busy-loop regressed")
+	}
+}
+
+// TestStartCleanupUsesDetachedContextOnCtxCancel pins the M7 fix: when a start
+// fails *because* the run ctx was cancelled (a timeout or manager stop), the
+// cleanup must still run — ContainerRemove and ImageRemove must receive a
+// context that is NOT cancelled (context.WithoutCancel), or Docker rejects the
+// calls immediately and the container + image leak. We cancel the run ctx, fail
+// ContainerStart, and assert both cleanup calls fired on a live context.
+func TestStartCleanupUsesDetachedContextOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var (
+		containerRemoveCalled bool
+		containerRemoveCtxErr error
+		imageRemoveCalled     bool
+		imageRemoveCtxErr     error
+	)
+	mock := &mockDockerClient{
+		imageBuildFunc: func(_ context.Context, _ io.Reader, _ client.ImageBuildOptions) (client.ImageBuildResult, error) {
+			return client.ImageBuildResult{Body: io.NopCloser(strings.NewReader(`{"stream":"ok"}`))}, nil
+		},
+		containerAttachFunc: func(_ context.Context, _ string, _ client.ContainerAttachOptions) (client.ContainerAttachResult, error) {
+			return newHijackedResponse(""), nil
+		},
+		containerStartFunc: func(_ context.Context, _ string, _ client.ContainerStartOptions) (client.ContainerStartResult, error) {
+			// The run ctx was cancelled (timeout / manager stop); the start fails.
+			cancel()
+			return client.ContainerStartResult{}, fmt.Errorf("start failed: %w", context.Canceled)
+		},
+		containerRemoveFunc: func(rmCtx context.Context, _ string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
+			containerRemoveCalled = true
+			containerRemoveCtxErr = rmCtx.Err()
+			return client.ContainerRemoveResult{}, nil
+		},
+		imageRemoveFunc: func(rmCtx context.Context, _ string, _ client.ImageRemoveOptions) (client.ImageRemoveResult, error) {
+			imageRemoveCalled = true
+			imageRemoveCtxErr = rmCtx.Err()
+			return client.ImageRemoveResult{}, nil
+		},
+	}
+	b := NewContainerBackendFromClient(mock)
+
+	_, err := b.Start(ctx, &model.Task{}, nil, &model.ContainerExecution{
+		Script:    "echo test",
+		BaseImage: "alpine",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "container start")
+
+	require.True(t, containerRemoveCalled, "the orphaned container must still be removed")
+	require.True(t, imageRemoveCalled, "the built image must still be removed")
+	assert.NoError(t, containerRemoveCtxErr,
+		"ContainerRemove must run on a detached (non-cancelled) context, else the container leaks")
+	assert.NoError(t, imageRemoveCtxErr,
+		"ImageRemove must run on a detached (non-cancelled) context, else the image leaks")
+}
+
 func TestStartWaitError(t *testing.T) {
 	buildBody := `{"stream":"ok"}` + "\n"
 	mock := &mockDockerClient{

--- a/apps/runwisp/internal/executor/executor_test.go
+++ b/apps/runwisp/internal/executor/executor_test.go
@@ -422,6 +422,51 @@ func TestRoutingExecutor_SetRunUpdateCallback_ReceivesUpdates(t *testing.T) {
 	assert.True(t, called)
 }
 
+// TestRoutingExecutor_notifyRunUpdated_PublishesCopy pins the H3 fix: the run
+// pointer handed to notifyRunUpdated is still being mutated by the execute
+// goroutine (recordRunOutcome → run.End()) while SSE/cloud subscribers marshal
+// the event on their own goroutines. notifyRunUpdated must publish a copy, not
+// the shared pointer, so a subscriber never races the mutation. We assert the
+// published Run is a distinct pointer and that a later mutation of the original
+// does not leak into the already-published event.
+func TestRoutingExecutor_notifyRunUpdated_PublishesCopy(t *testing.T) {
+	eb := events.NewEventBus()
+	e := newTestExecutor(t, Options{EventBus: eb})
+
+	var (
+		mu        sync.Mutex
+		published *model.Run
+	)
+	unsub := eb.Subscribe(events.EventRunUpdated, func(ev events.Event) {
+		re, ok := ev.Data.(events.RunEvent)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		published = re.Run
+		mu.Unlock()
+	})
+	defer unsub()
+
+	original := &model.Run{ID: "r-copy", Status: model.PhaseRunning}
+	e.notifyRunUpdated(original, "")
+
+	mu.Lock()
+	got := published
+	mu.Unlock()
+
+	require.NotNil(t, got, "run.updated must carry a Run payload")
+	assert.NotSame(t, original, got, "notifyRunUpdated must publish a copy, not the shared pointer")
+	assert.Equal(t, original.ID, got.ID, "the copy must preserve the run's fields")
+
+	// The execute goroutine keeps mutating the original after publish; that
+	// must not be observable through the already-published (copied) event.
+	reason := model.ReasonSuccess
+	original.End(reason, 0, time.Now())
+	assert.Equal(t, model.PhaseRunning, got.Status,
+		"post-publish mutation of the original must not leak into the published copy")
+}
+
 func TestRoutingExecutor_SetOnProcessStarted_ReceivesCall(t *testing.T) {
 	e := newTestExecutor(t, Options{})
 

--- a/apps/runwisp/internal/notify/coalesce/coalesce_test.go
+++ b/apps/runwisp/internal/notify/coalesce/coalesce_test.go
@@ -6,6 +6,7 @@ package coalesce
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -217,6 +218,60 @@ func TestCoalesce_WindowCloseFailureReportsInApp(t *testing.T) {
 
 	require.Len(t, sink.captured, 1, "a permanent window-close summary failure must surface in-app")
 	assert.Equal(t, notify.KindNotifyDeliveryFailed, sink.captured[0].Kind)
+}
+
+// TestTimerFlush_ConcurrentWithCloseNoPanic pins the M2 fix: a window-close
+// timer that fires just as Close begins used to call wg.Add(1) concurrently
+// with Close's wg.Wait, panicking with "WaitGroup is reused before previous
+// Wait has returned". The fix checks timerDone under c.mu before the wg.Add, so
+// once Close has run timerCancel() (which it does before taking the lock) a
+// racing timerFlush skips the Add. This is fundamentally a data-race guard: its
+// only observable symptom is the panic under concurrency, so we stress the
+// interleaving over many iterations and fail on any panic. It is most powerful
+// under `go test -race`; without it the panic is timing-dependent, so this is a
+// best-effort regression guard rather than a deterministic reproduction.
+func TestTimerFlush_ConcurrentWithCloseNoPanic(t *testing.T) {
+	const iterations = 300
+	fp := notify.FingerprintKey(failEvent("etl"))
+	panics := make(chan any, 2*iterations)
+
+	for i := 0; i < iterations; i++ {
+		inner := testutil.NewFakeChannel("slack-ops")
+		c := New(inner, Config{Window: time.Hour, EveryN: 1000}, testutil.NewFakeClock(time.Unix(0, 0)), nil, nil)
+		withManualTimers(c)
+
+		// Two events arm a window-close timer with a non-empty pending state, so
+		// timerFlush reaches the wg.Add path (rather than the empty-state return).
+		require.NoError(t, c.Execute(context.Background(), failEvent("etl")))
+		require.NoError(t, c.Execute(context.Background(), failEvent("etl")))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panics <- r
+				}
+			}()
+			c.timerFlush(fp)
+		}()
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panics <- r
+				}
+			}()
+			_ = c.Close(context.Background())
+		}()
+		wg.Wait()
+	}
+
+	close(panics)
+	for r := range panics {
+		t.Fatalf("timerFlush racing Close must not panic (WaitGroup reuse regression): %v", r)
+	}
 }
 
 func TestSummarize_NonNilExtra(t *testing.T) {

--- a/apps/runwisp/internal/notify/notify_test.go
+++ b/apps/runwisp/internal/notify/notify_test.go
@@ -208,6 +208,44 @@ func TestOnBusEvent_IgnoresUnknownEvents(t *testing.T) {
 	assert.Empty(t, svc.ingressCh)
 }
 
+// TestOnBusEvent_AfterStopDropsWithoutPanic pins the M1 fix: Stop closes
+// ingressCh, but an onBusEvent that captured the subscriber list just before
+// unsubscribe may still be mid-send. The old code did a bare close, so that
+// late send panicked ("send on closed channel"). The fix guards the close and
+// the send with ingressMu + an ingressClosed flag: a post-Stop onBusEvent must
+// observe the closed state and drop, never panic. We drive the send path
+// directly after Stop — with an empty (drained) channel the send branch, not
+// the backpressure default, is what would have panicked pre-fix.
+func TestOnBusEvent_AfterStopDropsWithoutPanic(t *testing.T) {
+	svc := New(Config{Bus: events.NewEventBus()})
+	require.NoError(t, svc.Start(context.Background()))
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, svc.Stop(stopCtx))
+
+	before := svc.droppedIngress.Load()
+
+	// Simulate the in-flight publish that raced Stop: onBusEvent runs after the
+	// channel was closed. Wrap in a goroutine with recover so a regression
+	// (bare send on the closed channel) fails the test instead of crashing it.
+	panicked := make(chan any, 1)
+	go func() {
+		defer func() { panicked <- recover() }()
+		svc.onBusEvent(failedRunEvent())
+	}()
+
+	select {
+	case r := <-panicked:
+		require.Nil(t, r, "onBusEvent after Stop must not panic on the closed ingress channel")
+	case <-time.After(2 * time.Second):
+		t.Fatal("onBusEvent did not return after Stop")
+	}
+
+	assert.Equal(t, before+1, svc.droppedIngress.Load(),
+		"an event arriving after Stop must be counted as a drop, not sent on the closed channel")
+}
+
 // TestServiceStop_RetentionTickerExits ensures the retention goroutine actually
 // returns rather than leaking. We invoke Stop with a generous deadline and
 // verify it doesn't hit the timeout branch (where ctx is cancelled).


### PR DESCRIPTION
Adds regression tests for seven fixes from #159:

- **H3** (`TestRoutingExecutor_notifyRunUpdated_PublishesCopy`): catches run mutation leak in event publishing
- **H4** (`TestImageBuilder_Build_MalformedStreamFailsPromptly`): catches busy-loop on malformed Docker build stream
- **H5** (`TestLazyComposeBackend_ReprobesAfterTransientFailure`): catches latched probe failure
- **M1** (`TestOnBusEvent_AfterStopDropsWithoutPanic`): catches send-on-closed panic in notify shutdown
- **M2** (`TestTimerFlush_ConcurrentWithCloseNoPanic`): stress-guards coalescer WaitGroup race
- **M3** (`TestFlushPendingDoesNotAliasBufferDuringSend`): catches slice aliasing in cloud execution tracker
- **M7** (`TestStartCleanupUsesDetachedContextOnCtxCancel`): catches orphaned container/image on cancelled start
- **M8** (`TestRunConnectionAttempt_ShortSessionDoesNotResetBackoff`): catches false backoff reset

Each test was verified to fail on the pre-fix source.