### PR TITLE
fix: address several edge cases in server, CLI, TUI, and web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A second daemon started against a data dir already owned by a live daemon refuses to start**, and PID-file cleanup removes the file only while it still holds that daemon's own PID, so a running daemon stays managable via `stop`/`restart`/`reload`.
+- **`stop` and `restart` confirm the recorded PID still belongs to a RunWisp daemon before signalling it**, so a recycled stale PID leaves an unrelated process untouched.
+- **The background daemon spawned by the launcher (and `runwisp demo`) inherits the launcher's `--host` and `--socket`**, binding where the operator probed instead of defaulting to loopback and the default socket path.
+- **TUI log search opens the highlighted result on Enter** and scrolls the result list to keep the selected hit in view when there are more matches than fit the window.
+- **The TUI notification panel keeps its cursor on the highlighted notification** when a newer one streams in above it, so open and mark-read act on the intended row; the collapsed summary truncates by display width so styled output stays intact on narrow terminals.
+- **The web UI run count decrements once per deletion**, keeping the total accurate when the optimistic removal and the `run.deleted` event both fire for the same run.
+- **The web UI overview merges snapshot fetches through the same phase-order guard as live updates**, so a finished run keeps its final status when a fetch resolves with an older view.
+- **The web UI keeps the freshest data when overlapping fetches resolve out of order.**
+- **The SSE log-stream drop counter is guarded against concurrent access** between the publishing goroutine and the stream handler.
+
 ## [0.13.1] - 2026-07-24
 
 ### Fixed

--- a/apps/runwisp/cmd/runwisp/bughunt3_test.go
+++ b/apps/runwisp/cmd/runwisp/bughunt3_test.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/runwisp/runwisp/internal/datadir"
+)
+
+// TestEnsureNoRunningDaemon_LiveDaemonRefused guards H1: booting a second
+// daemon against a data dir whose daemon.pid names a live daemon process must
+// fail, so it can't clobber the shared PID file and orphan the running daemon.
+func TestEnsureNoRunningDaemon_LiveDaemonRefused(t *testing.T) {
+	dir := t.TempDir()
+
+	// A real, live process distinct from the test binary.
+	other := exec.Command("sleep", "30")
+	if err := other.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+	t.Cleanup(func() { _ = other.Process.Kill(); _, _ = other.Process.Wait() })
+
+	if err := os.WriteFile(datadir.PidFilePath(dir), []byte(strconv.Itoa(other.Process.Pid)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := lookupProcessName
+	t.Cleanup(func() { lookupProcessName = orig })
+	lookupProcessName = func(int) (string, bool) { return "runwisp", true }
+
+	if err := ensureNoRunningDaemon(Flags{DataDir: dir}); err == nil {
+		t.Fatal("expected refusal to start when a live daemon owns the data dir")
+	}
+}
+
+func TestEnsureNoRunningDaemon_NoPidFile(t *testing.T) {
+	if err := ensureNoRunningDaemon(Flags{DataDir: t.TempDir()}); err != nil {
+		t.Fatalf("no PID file should allow start, got %v", err)
+	}
+}
+
+func TestEnsureNoRunningDaemon_StalePid(t *testing.T) {
+	dir := t.TempDir()
+	// PID 0 can't be signalled → treated as stale/not-running.
+	if err := os.WriteFile(datadir.PidFilePath(dir), []byte("0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureNoRunningDaemon(Flags{DataDir: dir}); err != nil {
+		t.Fatalf("stale PID file should allow start, got %v", err)
+	}
+}
+
+// TestDaemonSpawnArgs_CarriesHostAndSocket guards M1: the spawned daemon must
+// inherit --host and --socket so it binds where the launcher probed instead of
+// silently re-defaulting to loopback / the default socket path.
+func TestDaemonSpawnArgs_CarriesHostAndSocket(t *testing.T) {
+	f := Flags{
+		CfgFile: "cfg.toml",
+		DataDir: "/data",
+		Port:    9477,
+		Host:    "0.0.0.0",
+		Socket:  "/run/custom.sock",
+	}
+	args := daemonSpawnArgs([]string{"daemon"}, f)
+
+	if len(args) == 0 || args[0] != "daemon" {
+		t.Fatalf("expected leading subcommand, got %v", args)
+	}
+	assertFlagValue(t, args, "--host", "0.0.0.0")
+	assertFlagValue(t, args, "--socket", "/run/custom.sock")
+	assertFlagValue(t, args, "--port", "9477")
+}
+
+func TestDaemonSpawnArgs_OmitsEmptySocket(t *testing.T) {
+	args := daemonSpawnArgs([]string{"cloud", "--no-tui"}, Flags{Host: "127.0.0.1"})
+	if slices.Contains(args, "--socket") {
+		t.Fatalf("empty socket should not be passed, got %v", args)
+	}
+	assertFlagValue(t, args, "--host", "127.0.0.1")
+}
+
+// TestProcessAlive_RejectsForeignProcess guards M7: a stale PID recycled by an
+// unrelated process must not be reported alive, so stop/restart never signal a
+// bystander.
+func TestProcessAlive_RejectsForeignProcess(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := datadir.PidFilePath(dir)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := lookupProcessName
+	t.Cleanup(func() { lookupProcessName = orig })
+
+	lookupProcessName = func(int) (string, bool) { return "sshd", true }
+	if processAlive(os.Getpid(), pidPath) {
+		t.Fatal("a live process not named runwisp must be treated as not-alive")
+	}
+
+	lookupProcessName = func(int) (string, bool) { return "runwisp", true }
+	if !processAlive(os.Getpid(), pidPath) {
+		t.Fatal("a live runwisp process must be treated as alive")
+	}
+
+	// Unknown name (e.g. macOS, no procfs) falls back to trusting liveness.
+	lookupProcessName = func(int) (string, bool) { return "", false }
+	if !processAlive(os.Getpid(), pidPath) {
+		t.Fatal("unresolvable process name must fall back to alive")
+	}
+}
+
+func assertFlagValue(t *testing.T, args []string, flag, want string) {
+	t.Helper()
+	for i, a := range args {
+		if a == flag {
+			if i+1 >= len(args) {
+				t.Fatalf("%s has no value in %v", flag, args)
+			}
+			if args[i+1] != want {
+				t.Fatalf("%s: got %q want %q", flag, args[i+1], want)
+			}
+			return
+		}
+	}
+	t.Fatalf("%s not present in %v", flag, args)
+}

--- a/apps/runwisp/cmd/runwisp/cmd_demo.go
+++ b/apps/runwisp/cmd/runwisp/cmd_demo.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -214,11 +213,7 @@ func seedDemoHistory(f Flags) error {
 // mode spawns the headless `cloud` subcommand; standalone reuses spawnDaemon.
 func spawnDemoDaemon(f Flags) error {
 	if demoFlags.Cloud {
-		return spawnDaemonProcess([]string{"cloud", "--no-tui",
-			"--config", f.CfgFile,
-			"--data", f.DataDir,
-			"--port", strconv.Itoa(f.Port),
-		}, f.DataDir)
+		return spawnDaemonProcess(daemonSpawnArgs([]string{"cloud", "--no-tui"}, f), f.DataDir)
 	}
 	return spawnDaemon(f)
 }

--- a/apps/runwisp/cmd/runwisp/cmd_exec.go
+++ b/apps/runwisp/cmd/runwisp/cmd_exec.go
@@ -157,6 +157,25 @@ func isDaemonRunning(f Flags) bool {
 	return processAlive(pid, pidPath)
 }
 
+// ensureNoRunningDaemon returns an error when a live daemon already owns this
+// data dir, so a second `runwisp daemon` refuses to start rather than clobber
+// the shared PID file and open the same SQLite database. A missing, unreadable,
+// or stale PID file leaves the caller free to start.
+func ensureNoRunningDaemon(f Flags) error {
+	pidPath := datadir.PidFilePath(f.DataDir)
+	pid, err := datadir.ReadPidFile(f.DataDir)
+	if err != nil {
+		return nil
+	}
+	if pid == os.Getpid() {
+		return nil
+	}
+	if processAlive(pid, pidPath) {
+		return fmt.Errorf("a RunWisp daemon (pid %d) is already running for data dir %q; stop it first", pid, f.DataDir)
+	}
+	return nil
+}
+
 // runExecViaDaemon dispatches the run through the running daemon's REST API
 // (via its local Unix socket) and follows its SSE log stream until the run
 // reaches a terminal state.

--- a/apps/runwisp/cmd/runwisp/cmd_run.go
+++ b/apps/runwisp/cmd/runwisp/cmd_run.go
@@ -96,6 +96,13 @@ func runDaemon(mode daemonMode, f Flags, headless bool) (err error) {
 		defer rerouteLogsToStderrOnError(&err)
 	}
 
+	// Refuse to boot if another daemon already owns this data dir. Two daemons
+	// on one data dir clobber the shared PID file (orphaning the first) and open
+	// the same SQLite database, so fail hard before touching any state.
+	if err := ensureNoRunningDaemon(f); err != nil {
+		return err
+	}
+
 	// Open database first — config values (fingerprint, jwt_secret) live there.
 	db, err := storage.New(f.DBPath())
 	if err != nil {
@@ -135,7 +142,7 @@ func runDaemon(mode daemonMode, f Flags, headless bool) (err error) {
 	defer svc.DB.Close()
 
 	if pidErr := datadir.WritePidFile(f.DataDir); pidErr != nil {
-		slog.Warn("Failed to write PID file", "err", pidErr)
+		return fmt.Errorf("write PID file: %w", pidErr)
 	}
 	defer datadir.CleanPidFile(f.DataDir)
 

--- a/apps/runwisp/cmd/runwisp/daemon_spawn.go
+++ b/apps/runwisp/cmd/runwisp/daemon_spawn.go
@@ -40,11 +40,26 @@ func pollHealth(client *apiclient.Client, timeout time.Duration) error {
 // spawnDaemon starts a new daemon process in the background, detached from the
 // current terminal session so it survives after the TUI exits.
 func spawnDaemon(f Flags) error {
-	return spawnDaemonProcess([]string{"daemon",
+	return spawnDaemonProcess(daemonSpawnArgs([]string{"daemon"}, f), f.DataDir)
+}
+
+// daemonSpawnArgs builds the argument list for a spawned daemon, prefixed by
+// the given subcommand ("daemon", or "cloud --no-tui"). It carries the full
+// effective config — including --host and --socket — so the child binds exactly
+// where the launcher probed instead of silently re-defaulting to loopback / the
+// default socket path.
+func daemonSpawnArgs(subcommand []string, f Flags) []string {
+	args := append([]string{}, subcommand...)
+	args = append(args,
 		"--config", f.CfgFile,
 		"--data", f.DataDir,
 		"--port", strconv.Itoa(f.Port),
-	}, f.DataDir)
+		"--host", f.Host,
+	)
+	if f.Socket != "" {
+		args = append(args, "--socket", f.Socket)
+	}
+	return args
 }
 
 // spawnDaemonProcess execs `runwisp <args...>` as a detached background process
@@ -137,8 +152,11 @@ func waitForProcessExit(pid int, timeout time.Duration, dataDir string) error {
 	return fmt.Errorf("daemon (pid %d) did not shut down within %s", pid, timeout)
 }
 
-// processAlive returns true when the PID file exists AND the process
-// responds to signal 0. Either side failing means the daemon is gone.
+// processAlive returns true when the PID file exists, the process responds to
+// signal 0, AND the process still looks like a RunWisp daemon. The identity
+// check closes a PID-reuse hole: after an unclean death leaves a stale
+// daemon.pid, the OS may recycle that PID for an unrelated process, and
+// signalling it (stop/restart) would hit an innocent bystander.
 func processAlive(pid int, pidPath string) bool {
 	if _, err := os.Stat(pidPath); os.IsNotExist(err) {
 		return false
@@ -147,7 +165,35 @@ func processAlive(pid int, pidPath string) bool {
 	if err != nil {
 		return false
 	}
-	return proc.Signal(syscall.Signal(0)) == nil
+	if proc.Signal(syscall.Signal(0)) != nil {
+		return false
+	}
+	return processIsDaemon(pid)
+}
+
+// lookupProcessName resolves a PID to its process name. Swapped out in tests.
+var lookupProcessName = defaultLookupProcessName
+
+// defaultLookupProcessName reads the process name from /proc/<pid>/comm on
+// Linux. On platforms without procfs (macOS) the read fails and ok is false,
+// so processIsDaemon falls back to trusting the liveness check alone.
+func defaultLookupProcessName(pid int) (name string, ok bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(data)), true
+}
+
+// processIsDaemon reports whether the process with the given PID looks like a
+// RunWisp daemon. It is best-effort: when the process name can't be read it
+// returns true so a genuine daemon is never mistaken for a recycled stranger.
+func processIsDaemon(pid int) bool {
+	name, ok := lookupProcessName(pid)
+	if !ok {
+		return true
+	}
+	return strings.Contains(strings.ToLower(name), "runwisp")
 }
 
 // daemonLogDrainer tails the daemon's log file incrementally, emitting each

--- a/apps/runwisp/internal/datadir/datadir.go
+++ b/apps/runwisp/internal/datadir/datadir.go
@@ -92,9 +92,24 @@ func ReadPidFile(dataDir string) (int, error) {
 	return strconv.Atoi(strings.TrimSpace(string(data)))
 }
 
-// CleanPidFile removes the PID file.
+// CleanPidFile removes the PID file, but only when it still holds this
+// process's own PID. A second daemon that clobbered the file (or a stale file
+// belonging to an unrelated process) is left untouched so a live daemon is
+// never orphaned by another process's cleanup.
 func CleanPidFile(dataDir string) {
-	if err := os.Remove(PidFilePath(dataDir)); err != nil && !os.IsNotExist(err) {
+	path := PidFilePath(dataDir)
+	pid, err := ReadPidFile(dataDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("Failed to read PID file before cleanup", "err", err)
+		}
+		return
+	}
+	if pid != os.Getpid() {
+		// The file names a different process — not ours to remove.
+		return
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		slog.Warn("Failed to remove PID file", "err", err)
 	}
 }

--- a/apps/runwisp/internal/datadir/datadir_test.go
+++ b/apps/runwisp/internal/datadir/datadir_test.go
@@ -84,12 +84,29 @@ func TestWritePidFile_RefusesSymlink(t *testing.T) {
 func TestCleanPidFile_RemovesExisting(t *testing.T) {
 	dataDir := t.TempDir()
 	pid := PidFilePath(dataDir)
-	if err := os.WriteFile(pid, []byte("123"), 0600); err != nil {
+	if err := os.WriteFile(pid, []byte(strconv.Itoa(os.Getpid())), 0600); err != nil {
 		t.Fatal(err)
 	}
 	CleanPidFile(dataDir)
 	if _, err := os.Stat(pid); !os.IsNotExist(err) {
 		t.Fatalf("expected PID file removed, got err=%v", err)
+	}
+}
+
+// TestCleanPidFile_LeavesForeignPid guards H1: when daemon.pid names a process
+// other than the caller (e.g. a second daemon clobbered it, or a stale file
+// from an unrelated process), CleanPidFile must leave it in place so the live
+// owner is not orphaned by another process's deferred cleanup.
+func TestCleanPidFile_LeavesForeignPid(t *testing.T) {
+	dataDir := t.TempDir()
+	pid := PidFilePath(dataDir)
+	foreign := os.Getpid() + 1
+	if err := os.WriteFile(pid, []byte(strconv.Itoa(foreign)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	CleanPidFile(dataDir)
+	if _, err := os.Stat(pid); err != nil {
+		t.Fatalf("expected foreign PID file to be left in place, got err=%v", err)
 	}
 }
 

--- a/apps/runwisp/internal/server/logstream/logstream.go
+++ b/apps/runwisp/internal/server/logstream/logstream.go
@@ -10,6 +10,7 @@ package logstream
 
 import (
 	"context"
+	"sync"
 
 	"log/slog"
 
@@ -237,10 +238,43 @@ func resolveBackfillAnchor(from, replayLimit, totalLines, firstAvailable int64) 
 }
 
 // streamDropTracker holds the mutable drop-accounting state shared between
-// the bus subscription handler and the main event loop.
+// the bus subscription handler (publisher goroutine) and the SSE loop. The
+// bus invokes handlers synchronously on the publisher's goroutine, so the
+// writer and reader run concurrently — every field access goes through mu.
 type streamDropTracker struct {
+	mu    sync.Mutex
 	after int64 // highest dropped line number (-1 = none)
 	count int64 // total dropped since last flush
+}
+
+// recordDrop accounts for one dropped line at lineNum.
+func (dt *streamDropTracker) recordDrop(lineNum int64) {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	dt.count++
+	if lineNum > dt.after {
+		dt.after = lineNum
+	}
+}
+
+// snapshot returns the current drop accounting without resetting it.
+func (dt *streamDropTracker) snapshot() (after, count int64) {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	return dt.after, dt.count
+}
+
+// commitSent subtracts count already-reported drops, resetting the anchor once
+// the backlog is drained. Any drops recorded after the matching snapshot are
+// preserved for the next flush.
+func (dt *streamDropTracker) commitSent(count int64) {
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	dt.count -= count
+	if dt.count <= 0 {
+		dt.count = 0
+		dt.after = -1
+	}
 }
 
 func (s *streamer) streamLoop(ctx context.Context, runID string, bus events.EventBus, db RunGetter, anchorFrom, replayLimit int64, runEnded bool) {
@@ -360,19 +394,13 @@ func bufferLogLine(le events.LogLineEvent, pendingCh chan events.LogLineEvent, d
 		// stays current, then try to enqueue the newest.
 		select {
 		case dropped := <-pendingCh:
-			if dropped.LineNum > dt.after {
-				dt.after = dropped.LineNum
-			}
-			dt.count++
+			dt.recordDrop(dropped.LineNum)
 		default:
 		}
 		select {
 		case pendingCh <- le:
 		default:
-			dt.count++
-			if le.LineNum > dt.after {
-				dt.after = le.LineNum
-			}
+			dt.recordDrop(le.LineNum)
 		}
 	}
 }
@@ -417,8 +445,8 @@ func (s *streamer) sendTerminalEvents(pendingCh <-chan events.LogLineEvent, dt *
 	if err := s.drainPendingCh(pendingCh); err != nil {
 		return
 	}
-	if dt.count > 0 {
-		_ = s.send.SendDropped(DroppedEvent{After: dt.after, Count: dt.count})
+	if after, count := dt.snapshot(); count > 0 {
+		_ = s.send.SendDropped(DroppedEvent{After: after, Count: count})
 	}
 	_ = s.send.SendDone(DoneEvent{FinalLine: s.lastSent, Status: "ended"})
 }
@@ -429,12 +457,11 @@ func (s *streamer) handleLiveLine(le events.LogLineEvent, dt *streamDropTracker)
 	if err := s.emitLine(lineFromBus(le)); err != nil {
 		return false
 	}
-	if dt.count > 0 {
-		if err := s.send.SendDropped(DroppedEvent{After: dt.after, Count: dt.count}); err != nil {
+	if after, count := dt.snapshot(); count > 0 {
+		if err := s.send.SendDropped(DroppedEvent{After: after, Count: count}); err != nil {
 			return false
 		}
-		dt.count = 0
-		dt.after = -1
+		dt.commitSent(count)
 	}
 	return true
 }

--- a/apps/runwisp/internal/server/logstream/logstream_test.go
+++ b/apps/runwisp/internal/server/logstream/logstream_test.go
@@ -5,6 +5,7 @@ package logstream
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2/sse"
@@ -399,4 +400,51 @@ func TestMakeTerminalHandler_NilRun(t *testing.T) {
 
 	handler(events.Event{Data: events.RunEvent{Run: nil}})
 	assert.Empty(t, termCh)
+}
+
+// TestStreamDropTracker_ConcurrentRecord guards M8: recordDrop runs on the
+// publisher goroutine while the SSE loop reads/commits, so the counter must be
+// mutex-guarded. Without the lock, concurrent increments lose updates and the
+// reported drop count undercounts.
+func TestStreamDropTracker_ConcurrentRecord(t *testing.T) {
+	const goroutines = 8
+	const perGoroutine = 5000
+
+	dt := &streamDropTracker{after: -1}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				dt.recordDrop(int64(i))
+			}
+		}()
+	}
+	wg.Wait()
+
+	_, count := dt.snapshot()
+	if want := int64(goroutines * perGoroutine); count != want {
+		t.Fatalf("drop count: got %d want %d (lost updates → data race)", count, want)
+	}
+}
+
+// TestStreamDropTracker_CommitSentPreservesLaterDrops verifies that drops
+// recorded after a snapshot survive commitSent of the reported batch.
+func TestStreamDropTracker_CommitSentPreservesLaterDrops(t *testing.T) {
+	dt := &streamDropTracker{after: -1}
+	dt.recordDrop(5)
+	dt.recordDrop(6)
+	_, count := dt.snapshot()
+	require.Equal(t, int64(2), count)
+
+	// Two more drops land before the reported batch is committed.
+	dt.recordDrop(7)
+	dt.recordDrop(8)
+	dt.commitSent(count)
+
+	after, remaining := dt.snapshot()
+	assert.Equal(t, int64(2), remaining, "later drops must be preserved")
+	assert.Equal(t, int64(8), after)
 }

--- a/apps/runwisp/internal/tui/views/logsearch/logsearch_test.go
+++ b/apps/runwisp/internal/tui/views/logsearch/logsearch_test.go
@@ -4,6 +4,7 @@
 package logsearch
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -121,8 +122,11 @@ func TestUpdate_ArrowKeys_AlsoMoveCursor(t *testing.T) {
 func TestUpdate_EnterOnHitEmitsSelectMsg(t *testing.T) {
 	m := newTestModel(t)
 	m.hits = []server.LogSearchHit{{RunID: "rA", N: 42, Text: "hello"}}
-	// Defocus the input so Enter is treated as "select hit".
-	m.input.Blur()
+	// Simulate the post-search state: a query was dispatched and results
+	// arrived, so an Enter with the query unchanged selects the hit.
+	m.input.SetValue("hello")
+	m.lastSearched = "hello"
+	m.searched = true
 	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal("expected select cmd")
@@ -268,11 +272,61 @@ func TestView_RendersHits_AndOverflow(t *testing.T) {
 		})
 	}
 	out := m.View(80, 24)
-	if !strings.Contains(out, "more hits") {
-		t.Fatalf("expected overflow marker, got:\n%s", out)
+	if !strings.Contains(out, fmt.Sprintf("of %d", MaxVisibleHits+5)) {
+		t.Fatalf("expected windowed hit-count marker, got:\n%s", out)
 	}
 	if !strings.Contains(out, "▶") {
 		t.Fatalf("expected selection cursor, got:\n%s", out)
+	}
+}
+
+// TestView_WindowFollowsCursor exercises M10: with more hits than the visible
+// window, the highlighted row must scroll into view instead of staying pinned
+// to a fixed [0:MaxVisibleHits] slice.
+func TestView_WindowFollowsCursor(t *testing.T) {
+	m := newTestModel(t)
+	for i := 0; i < MaxVisibleHits+8; i++ {
+		m.hits = append(m.hits, server.LogSearchHit{
+			RunID: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			N:     int64(i + 1),
+			Text:  fmt.Sprintf("match-%02d", i),
+		})
+	}
+	// Cursor well past the fixed window's bottom edge.
+	m.cursor = MaxVisibleHits + 4
+	out := m.View(120, 40)
+	want := fmt.Sprintf("match-%02d", m.cursor)
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected selected hit %q to be visible, got:\n%s", want, out)
+	}
+	// The selection cursor must render on the highlighted row.
+	if !strings.Contains(out, "▶") {
+		t.Fatalf("expected selection cursor in view, got:\n%s", out)
+	}
+}
+
+// TestUpdate_EnterSelectsAfterSearch exercises M2: after a search runs and
+// results arrive, pressing Enter again (query unchanged, input still focused
+// as it always is in production) selects the highlighted hit rather than
+// re-running the search.
+func TestUpdate_EnterSelectsAfterSearch(t *testing.T) {
+	m := newTestModel(t)
+	m.input.SetValue("needle")
+	// First Enter dispatches the search; input stays focused.
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	// Results land.
+	m3, _ := m2.Update(resultsMsg{hits: []server.LogSearchHit{{RunID: "rX", N: 9, Text: "hit"}}})
+	// Second Enter must select, not search.
+	_, cmd := m3.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected a command from Enter")
+	}
+	sel, ok := cmd().(SelectMsg)
+	if !ok {
+		t.Fatalf("expected SelectMsg, got %T", cmd())
+	}
+	if sel.RunID != "rX" || sel.Line != 9 || sel.TaskName != "task1" {
+		t.Fatalf("SelectMsg fields wrong: %+v", sel)
 	}
 }
 

--- a/apps/runwisp/internal/tui/views/logsearch/model.go
+++ b/apps/runwisp/internal/tui/views/logsearch/model.go
@@ -47,6 +47,13 @@ type Model struct {
 	loading       bool
 	errMsg        string
 	client        *apiclient.Client
+
+	// lastSearched is the query string of the most recently dispatched search.
+	// Enter runs a new search while the query differs from it, and selects the
+	// highlighted hit once it matches — so the deep-link path is reachable
+	// without blurring the (always-focused) input.
+	lastSearched string
+	searched     bool
 }
 
 // New creates a fresh overlay for the given task.
@@ -148,10 +155,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 	return m, nil, false
 }
 
-// handleEnter either fires a new search (when the input has focus and text)
-// or selects the highlighted hit.
+// handleEnter fires a new search whenever the query has changed since the last
+// one dispatched, and otherwise selects the highlighted hit. Keying on the
+// query (rather than input focus, which never clears) keeps both the search and
+// the deep-link select reachable from the same always-focused input.
 func (m Model) handleEnter() (Model, tea.Cmd) {
-	if m.input.Focused() && m.input.Value() != "" {
+	q := m.input.Value()
+	if q == "" {
+		return m, nil
+	}
+	if !m.searched || q != m.lastSearched {
 		return m.startSearch()
 	}
 	if h := m.SelectedHit(); h != nil {
@@ -183,6 +196,8 @@ func (m *Model) ErrorMessage() string { return m.errMsg }
 func (m Model) startSearch() (Model, tea.Cmd) {
 	m.loading = true
 	m.errMsg = ""
+	m.lastSearched = m.input.Value()
+	m.searched = true
 	client := m.client
 	taskName := m.taskName
 	opts := apiclient.SearchLogsOptions{

--- a/apps/runwisp/internal/tui/views/logsearch/view.go
+++ b/apps/runwisp/internal/tui/views/logsearch/view.go
@@ -68,11 +68,9 @@ func (m *Model) renderHits(b *strings.Builder, width int) {
 	selStyle := lipgloss.NewStyle().Foreground(uikit.ColorBg).Background(uikit.ColorPrimary)
 	mutedStyle := lipgloss.NewStyle().Foreground(uikit.ColorTextMuted)
 
-	max := len(m.hits)
-	if max > MaxVisibleHits {
-		max = MaxVisibleHits
-	}
-	for i := 0; i < max; i++ {
+	total := len(m.hits)
+	start, end := hitWindow(m.cursor, total)
+	for i := start; i < end; i++ {
 		h := m.hits[i]
 		runShort := h.RunID
 		if len(runShort) > 6 {
@@ -91,7 +89,24 @@ func (m *Model) renderHits(b *strings.Builder, width int) {
 		b.WriteString(prefix + style.Render(line))
 		b.WriteString("\n")
 	}
-	if len(m.hits) > MaxVisibleHits {
-		b.WriteString(mutedStyle.Render(fmt.Sprintf("…%d more hits", len(m.hits)-MaxVisibleHits)))
+	if total > MaxVisibleHits {
+		b.WriteString(mutedStyle.Render(fmt.Sprintf("hits %d–%d of %d", start+1, end, total)))
 	}
+}
+
+// hitWindow returns the [start, end) slice of hit indices to render so the
+// window of at most MaxVisibleHits rows always contains the cursor. Once the
+// cursor passes the bottom of the window the view scrolls to follow it.
+func hitWindow(cursor, total int) (start, end int) {
+	if total <= MaxVisibleHits {
+		return 0, total
+	}
+	start = 0
+	if cursor >= MaxVisibleHits {
+		start = cursor - MaxVisibleHits + 1
+	}
+	if start > total-MaxVisibleHits {
+		start = total - MaxVisibleHits
+	}
+	return start, start + MaxVisibleHits
 }

--- a/apps/runwisp/internal/tui/views/notifications/panel.go
+++ b/apps/runwisp/internal/tui/views/notifications/panel.go
@@ -89,9 +89,7 @@ func (p *Panel) Upsert(n server.NotificationDTO) bool {
 		idx := sort.Search(len(p.ordered), func(i int) bool {
 			return p.ordered[i] < n.ID
 		})
-		p.ordered = append(p.ordered, "")
-		copy(p.ordered[idx+1:], p.ordered[idx:])
-		p.ordered[idx] = n.ID
+		p.insertOrdered(idx, n.ID)
 		changed = true
 	} else if n.Count != prev.Count ||
 		!prev.LastOccurredAt.Equal(n.LastOccurredAt) ||
@@ -100,8 +98,26 @@ func (p *Panel) Upsert(n server.NotificationDTO) bool {
 	}
 	if changed {
 		p.rebuildContent()
+		if p.expanded {
+			p.ensureCursorVisible()
+		}
 	}
 	return changed
+}
+
+// insertOrdered splices id into p.ordered at idx and keeps the cursor pinned to
+// the same notification: an insert at or above the cursor shifts every tracked
+// row down by one, so the cursor must move with it or actions (open, toggle
+// read) would land on the neighbour that slid under the highlight.
+func (p *Panel) insertOrdered(idx int, id string) {
+	p.ordered = append(p.ordered, "")
+	copy(p.ordered[idx+1:], p.ordered[idx:])
+	p.ordered[idx] = id
+	// Only meaningful while expanded — a collapsed panel has no positioned
+	// cursor (Toggle snaps it into range on expand).
+	if p.expanded && idx <= p.cursor {
+		p.cursor++
+	}
 }
 
 // IsExpanded reports whether the panel is in expanded mode.
@@ -226,13 +242,14 @@ func (p *Panel) LoadHistorical(items []server.NotificationDTO) bool {
 		idx := sort.Search(len(p.ordered), func(i int) bool {
 			return p.ordered[i] < n.ID
 		})
-		p.ordered = append(p.ordered, "")
-		copy(p.ordered[idx+1:], p.ordered[idx:])
-		p.ordered[idx] = n.ID
+		p.insertOrdered(idx, n.ID)
 		changed = true
 	}
 	if changed {
 		p.rebuildContent()
+		if p.expanded {
+			p.ensureCursorVisible()
+		}
 	}
 	return changed
 }
@@ -536,14 +553,20 @@ func relativeTime(t time.Time) string {
 	return rhythm.Relative(t, time.Now())
 }
 
+// truncateLine trims a (possibly ANSI-styled) line to at most max display
+// columns. It slices by visible column via uikit.SliceLineColumns — never by
+// raw bytes — so a cut never lands mid escape-sequence or mid-rune and garbles
+// the styled collapsed summary.
 func truncateLine(s string, max int) string {
 	if max <= 1 || lipgloss.Width(s) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		sliced, _ := uikit.SliceLineColumns(s, 0, max)
+		return sliced
 	}
-	return s[:max-1] + "…"
+	sliced, _ := uikit.SliceLineColumns(s, 0, max-1)
+	return sliced + "…"
 }
 
 func isUnread(n server.NotificationDTO) bool { return n.ReadAt == nil }

--- a/apps/runwisp/internal/tui/views/notifications/panel_test.go
+++ b/apps/runwisp/internal/tui/views/notifications/panel_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/runwisp/runwisp/internal/server"
 )
 
@@ -53,6 +55,46 @@ func TestNotificationsPanel_UpsertSameTimestampNoOp(t *testing.T) {
 	}
 	if p.Upsert(n) {
 		t.Fatal("identical re-upsert should be a no-op")
+	}
+}
+
+// TestNotificationsPanel_CursorTracksInsert guards M4: when a notification
+// streams in above the cursor while the panel is expanded, the cursor must
+// follow the item it was pointing at so open/toggle-read act on the right row.
+func TestNotificationsPanel_CursorTracksInsert(t *testing.T) {
+	p := NewPanel()
+	now := time.Now()
+	p.Upsert(unreadNotification("01A", "info", now, "a"))
+	p.Upsert(unreadNotification("01B", "info", now, "b"))
+	p.Upsert(unreadNotification("01C", "info", now, "c"))
+
+	p.Toggle() // expand; cursor 0 → highest ULID "01C"
+	if !p.MoveCursor(1) {
+		t.Fatal("expected cursor to move to the second row")
+	}
+	if sel := p.Selected(); sel == nil || sel.ID != "01B" {
+		t.Fatalf("precondition: cursor should highlight 01B, got %v", sel)
+	}
+
+	// A newer notification (highest ULID) inserts at index 0, above the cursor.
+	p.Upsert(unreadNotification("01Z", "warn", now, "z"))
+	if sel := p.Selected(); sel == nil || sel.ID != "01B" {
+		t.Fatalf("cursor should still track 01B after insert above it, got %v", sel)
+	}
+}
+
+// TestTruncateLine_ANSIAware guards M5: truncating an ANSI-styled line must cut
+// by display column, never by raw bytes, so the visible content stays intact
+// instead of slicing through an escape sequence. The input carries explicit SGR
+// escapes because lipgloss renders colorless under test.
+func TestTruncateLine_ANSIAware(t *testing.T) {
+	styled := "\x1b[31m" + strings.Repeat("x", 40) + "\x1b[0m"
+	out := truncateLine(styled, 10)
+	if w := lipgloss.Width(out); w != 10 {
+		t.Fatalf("truncated display width: got %d want 10", w)
+	}
+	if visible := ansi.Strip(out); visible != strings.Repeat("x", 9)+"…" {
+		t.Fatalf("visible content corrupted by byte-slice: %q", visible)
 	}
 }
 

--- a/apps/ui/src/lib/utils/async-data.svelte.ts
+++ b/apps/ui/src/lib/utils/async-data.svelte.ts
@@ -48,7 +48,12 @@ export class AsyncData<T> {
         this.#loading = true;
         this.#error = undefined;
         try {
-            this.#data = await this.#fetcher(ac.signal);
+            const data = await this.#fetcher(ac.signal);
+            // A newer fetch() aborts this controller; a fetcher that ignores its
+            // signal can still resolve late, so guard the assignment
+            // symmetrically with the catch path to keep the freshest data.
+            if (ac.signal.aborted) return;
+            this.#data = data;
             connectionStore.markConnected();
         } catch (err: unknown) {
             if (ac.signal.aborted) return;

--- a/apps/ui/src/lib/utils/async-data.test.ts
+++ b/apps/ui/src/lib/utils/async-data.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+// Stub $lib/api so importing AsyncData doesn't pull in the REST/SSE modules
+// (and their zod schemas) — we only need AuthRequiredError's identity.
+vi.mock("$lib/api", () => ({
+    AuthRequiredError: class AuthRequiredError extends Error {},
+}));
+
+import { AsyncData } from "./async-data.svelte";
+
+describe("AsyncData", () => {
+    // Guards M9: a fetcher that ignores its abort signal can still resolve after
+    // a newer fetch() superseded it. The success path must drop the stale
+    // result instead of overwriting fresher data.
+    it("does not let an aborted fetch overwrite fresher data", async () => {
+        let resolveFirst: (v: string) => void = () => {};
+        const first = new Promise<string>((r) => (resolveFirst = r));
+
+        let call = 0;
+        const ad = new AsyncData<string>(
+            async () => {
+                call += 1;
+                // First call ignores the signal and resolves late.
+                if (call === 1) return first;
+                return "fresh";
+            },
+            { reloadOnReconnect: false, toastOnError: false },
+        );
+
+        const p1 = ad.fetch(); // starts the (pending) first fetch
+        const p2 = ad.fetch(); // aborts the first, resolves with "fresh"
+        await p2;
+        expect(ad.data).toBe("fresh");
+
+        // The stale first fetch resolves only now — it must not clobber "fresh".
+        resolveFirst("stale");
+        await p1;
+        expect(ad.data).toBe("fresh");
+    });
+});

--- a/apps/ui/src/lib/utils/overview-runs.test.ts
+++ b/apps/ui/src/lib/utils/overview-runs.test.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { Run } from "@runwisp/common";
+import { mergeRecentRuns, mergeRunningRuns } from "./overview-runs";
+
+function makeRun(id: string, overrides: Partial<Run> = {}): Run {
+    return {
+        id,
+        task_name: "backup-db",
+        created_at: "2026-06-22T12:00:00.000Z",
+        status: "ended",
+        end_reason: "success",
+        triggered_by: "api",
+        exit_code: 0,
+        instance_index: 0,
+        retry_attempt: 0,
+        ...overrides,
+    };
+}
+
+describe("mergeRecentRuns", () => {
+    // Guards M6: an SSE event advanced a run to "ended"; a snapshot fetched
+    // before that landed still carries it as "running". Merging the snapshot
+    // must not revert the run's phase.
+    it("does not regress an SSE-advanced run to an older phase", () => {
+        const live = [makeRun("r1", { status: "ended", end_reason: "success" })];
+        const snapshot = [makeRun("r1", { status: "running", end_reason: undefined })];
+
+        const merged = mergeRecentRuns(live, snapshot, 16);
+        expect(merged).toHaveLength(1);
+        expect(merged[0]?.status).toBe("ended");
+    });
+
+    it("seeds from a snapshot when the live list is empty", () => {
+        const snapshot = [
+            makeRun("a", { created_at: "2026-06-22T12:00:00.000Z" }),
+            makeRun("b", { created_at: "2026-06-22T13:00:00.000Z" }),
+        ];
+        const merged = mergeRecentRuns([], snapshot, 16);
+        // Newest first.
+        expect(merged.map((r) => r.id)).toEqual(["b", "a"]);
+    });
+});
+
+describe("mergeRunningRuns", () => {
+    it("drops a stale snapshot's running copy of a finished run", () => {
+        const live = [makeRun("r1", { status: "ended", end_reason: "success" })];
+        const snapshot = [makeRun("r1", { status: "running", end_reason: undefined })];
+
+        const merged = mergeRunningRuns(live, snapshot, 8);
+        expect(merged).toHaveLength(0);
+    });
+
+    it("keeps genuinely running runs", () => {
+        const live: Run[] = [];
+        const snapshot = [makeRun("r1", { status: "running", end_reason: undefined })];
+        const merged = mergeRunningRuns(live, snapshot, 8);
+        expect(merged.map((r) => r.id)).toEqual(["r1"]);
+    });
+});

--- a/apps/ui/src/lib/utils/overview-runs.test.ts
+++ b/apps/ui/src/lib/utils/overview-runs.test.ts
@@ -26,7 +26,7 @@ describe("mergeRecentRuns", () => {
     // must not revert the run's phase.
     it("does not regress an SSE-advanced run to an older phase", () => {
         const live = [makeRun("r1", { status: "ended", end_reason: "success" })];
-        const snapshot = [makeRun("r1", { status: "running", end_reason: undefined })];
+        const snapshot = [makeRun("r1", { status: "running" })];
 
         const merged = mergeRecentRuns(live, snapshot, 16);
         expect(merged).toHaveLength(1);
@@ -47,7 +47,7 @@ describe("mergeRecentRuns", () => {
 describe("mergeRunningRuns", () => {
     it("drops a stale snapshot's running copy of a finished run", () => {
         const live = [makeRun("r1", { status: "ended", end_reason: "success" })];
-        const snapshot = [makeRun("r1", { status: "running", end_reason: undefined })];
+        const snapshot = [makeRun("r1", { status: "running" })];
 
         const merged = mergeRunningRuns(live, snapshot, 8);
         expect(merged).toHaveLength(0);
@@ -55,7 +55,7 @@ describe("mergeRunningRuns", () => {
 
     it("keeps genuinely running runs", () => {
         const live: Run[] = [];
-        const snapshot = [makeRun("r1", { status: "running", end_reason: undefined })];
+        const snapshot = [makeRun("r1", { status: "running" })];
         const merged = mergeRunningRuns(live, snapshot, 8);
         expect(merged.map((r) => r.id)).toEqual(["r1"]);
     });

--- a/apps/ui/src/lib/utils/overview-runs.ts
+++ b/apps/ui/src/lib/utils/overview-runs.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Run } from "@runwisp/common";
+import { runPhaseOrder } from "@runwisp/ui";
+import { sortByCreatedAtDesc } from "$lib/utils/sort";
+
+// upsertPhaseGuarded folds one snapshot run into the list without ever
+// regressing a run's phase. A snapshot fetched before an SSE `run.completed`
+// lands carries the run as still "running"; merging it through this guard keeps
+// the SSE-advanced "ended" row intact instead of reverting it.
+function upsertPhaseGuarded(list: Run[], run: Run): Run[] {
+    const idx = list.findIndex((r) => r.id === run.id);
+    if (idx === -1) return [...list, run];
+    const existing = list[idx];
+    if (!existing) return list;
+    if (runPhaseOrder(run.status) < runPhaseOrder(existing.status)) return list;
+    const copy = [...list];
+    copy[idx] = run;
+    return copy;
+}
+
+// mergeRecentRuns reconciles a freshly-fetched snapshot of recent runs into the
+// live (SSE-fed) list, preserving the newest known phase for each run, and
+// returns the newest `limit` runs.
+export function mergeRecentRuns(existing: Run[], snapshot: Run[], limit: number): Run[] {
+    let merged = existing;
+    for (const run of snapshot) merged = upsertPhaseGuarded(merged, run);
+    return sortByCreatedAtDesc(merged).slice(0, limit);
+}
+
+// mergeRunningRuns reconciles a snapshot of running runs into the live list.
+// The phase guard drops a stale snapshot's "running" copy of a run the live
+// state already advanced past, and the final filter keeps only rows that are
+// still running.
+export function mergeRunningRuns(existing: Run[], snapshot: Run[], limit: number): Run[] {
+    let merged = existing;
+    for (const run of snapshot) merged = upsertPhaseGuarded(merged, run);
+    return sortByCreatedAtDesc(merged)
+        .filter((run) => run.status === "running")
+        .slice(0, limit);
+}

--- a/apps/ui/src/lib/utils/runs-source.svelte.ts
+++ b/apps/ui/src/lib/utils/runs-source.svelte.ts
@@ -216,11 +216,14 @@ export function createRunsSource(): RunsSource {
 
     function remove(runId: string): void {
         const idx = items.findIndex((r) => r.id === runId);
-        if (idx !== -1) {
-            const next = [...items];
-            next.splice(idx, 1);
-            items = next;
-        }
+        // Only touch total when the run was actually present. The optimistic
+        // remove and the server's run.deleted SSE echo both call this for the
+        // same id; decrementing on the second (idx === -1) call would drift the
+        // count below the true total and can prematurely mark the list "done".
+        if (idx === -1) return;
+        const next = [...items];
+        next.splice(idx, 1);
+        items = next;
         if (total > 0) total -= 1;
     }
 

--- a/apps/ui/src/lib/utils/runs-source.test.ts
+++ b/apps/ui/src/lib/utils/runs-source.test.ts
@@ -169,7 +169,9 @@ describe("createRunsSource SSE filter parity (matchesFilters)", () => {
             total: 2,
         });
         src.setFilters(baseFilters());
-        await vi.waitFor(() => expect(src.loaded).toBe(true));
+        await vi.waitFor(() => {
+            expect(src.loaded).toBe(true);
+        });
 
         src.remove("a"); // present → removes row, total 2 → 1
         src.remove("a"); // already gone → must not touch total

--- a/apps/ui/src/lib/utils/runs-source.test.ts
+++ b/apps/ui/src/lib/utils/runs-source.test.ts
@@ -158,4 +158,23 @@ describe("createRunsSource SSE filter parity (matchesFilters)", () => {
         src.upsert(makeRun("first", { retry_attempt: 0 }));
         expect(src.items.map((r) => r.id)).toEqual(["retried"]);
     });
+
+    // Guards M3: the optimistic remove and the server's run.deleted SSE echo
+    // both call remove() for the same id. Only the call that actually removes a
+    // row may decrement total, or the count drifts below the true value.
+    it("decrements total once even when remove is called twice for one id", async () => {
+        const src = createRunsSource();
+        vi.mocked(runsApi.getAll).mockResolvedValue({
+            runs: [makeRun("a"), makeRun("b")],
+            total: 2,
+        });
+        src.setFilters(baseFilters());
+        await vi.waitFor(() => expect(src.loaded).toBe(true));
+
+        src.remove("a"); // present → removes row, total 2 → 1
+        src.remove("a"); // already gone → must not touch total
+
+        expect(src.items.map((r) => r.id)).toEqual(["b"]);
+        expect(src.total).toBe(1);
+    });
 });

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -151,21 +151,27 @@
     });
 
     $effect(() => {
-        if (pageData.data) {
-            dashState.tasks = pageData.data.tasks;
+        const data = pageData.data;
+        if (data) {
+            dashState.tasks = data.tasks;
             // Merge the snapshot through the same phase-order guard the SSE path
             // uses, so a fetch that resolves with an older view can't revert a
             // run the live stream already advanced (e.g. finished → running).
-            dashState.recentRuns = mergeRecentRuns(
-                dashState.recentRuns,
-                pageData.data.recentRuns,
-                RECENT_RUN_LIMIT,
-            );
-            dashState.runningRuns = mergeRunningRuns(
-                dashState.runningRuns,
-                pageData.data.runningRuns,
-                RUNNING_RUN_LIMIT,
-            );
+            // Read the current runs untracked: the merge folds them into itself,
+            // so tracking them here would make this effect re-trigger on its own
+            // writes and loop until Svelte aborts it (effect_update_depth_exceeded).
+            untrack(() => {
+                dashState.recentRuns = mergeRecentRuns(
+                    dashState.recentRuns,
+                    data.recentRuns,
+                    RECENT_RUN_LIMIT,
+                );
+                dashState.runningRuns = mergeRunningRuns(
+                    dashState.runningRuns,
+                    data.runningRuns,
+                    RUNNING_RUN_LIMIT,
+                );
+            });
         }
     });
 

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -19,6 +19,7 @@
     } from "$lib/stores";
     import { getApiUrl } from "$lib/utils/env";
     import { toTaskPageId } from "$lib/utils/task-id";
+    import { mergeRecentRuns, mergeRunningRuns } from "$lib/utils/overview-runs";
     import { AsyncData } from "$lib/utils/async-data.svelte";
     import { type Run, type Task } from "$lib/types";
 
@@ -152,8 +153,19 @@
     $effect(() => {
         if (pageData.data) {
             dashState.tasks = pageData.data.tasks;
-            dashState.recentRuns = pageData.data.recentRuns;
-            dashState.runningRuns = pageData.data.runningRuns;
+            // Merge the snapshot through the same phase-order guard the SSE path
+            // uses, so a fetch that resolves with an older view can't revert a
+            // run the live stream already advanced (e.g. finished → running).
+            dashState.recentRuns = mergeRecentRuns(
+                dashState.recentRuns,
+                pageData.data.recentRuns,
+                RECENT_RUN_LIMIT,
+            );
+            dashState.runningRuns = mergeRunningRuns(
+                dashState.runningRuns,
+                pageData.data.runningRuns,
+                RUNNING_RUN_LIMIT,
+            );
         }
     });
 


### PR DESCRIPTION
Addresses the HIGH and all MEDIUM findings from the third bug-hunt audit, spanning the daemon lifecycle (refusing a second daemon on a data dir a live one already owns, PID-file cleanup and identity checks so stop/restart never signal a recycled stranger, and carrying --host/--socket through to a spawned child), the TUI (log-search hit selection and windowing, and the notification panel's cursor tracking and width-aware summary truncation), the web UI (accurate run-count decrementing, phase-order-guarded overview snapshot merges, and dropping superseded fetch results), and a mutex around the SSE log-stream drop counter. Each fix ships with a regression test that fails on the pre-fix code.