### PR TITLE
compose: harden secret passing via docker CLI env injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The daemon and web UI (`apps/`) are now licensed GPL-3.0-or-later**, up from Apache-2.0. The shared libraries under `packages/` remain Apache-2.0. See [LICENSE](LICENSE) and [LICENSE-APACHE](LICENSE-APACHE).
 
+### Security
+
+- **Compose tasks hand their environment and secrets to the `docker compose` CLI through its process environment** and forward each variable with a value-less `-e KEY` flag, so docker resolves values from its own environment and no secret value is ever placed on the command line. See [Compose](https://docs.runwisp.com/configuration/compose/).
+
 ## [0.13.2] - 2026-07-26
 
 ### Fixed

--- a/apps/runwisp/internal/executor/compose.go
+++ b/apps/runwisp/internal/executor/compose.go
@@ -97,10 +97,15 @@ func (b *ComposeBackend) Start(ctx context.Context, task *model.Task, run *model
 		cmd.Dir = ce.WorkingDir
 	}
 
-	// Compose CLI inherits the daemon's env so users' DOCKER_HOST etc. work;
-	// task env is passed to the container itself via -e flags (see
-	// buildComposeArgs).
+	// Compose CLI inherits the daemon's env so users' DOCKER_HOST etc. work.
+	// Task env/secrets/params are then appended so the value-less `-e KEY`
+	// flags (see buildComposeArgs) resolve their values from the CLI's own
+	// environment — keeping secret values off argv (and out of `ps` output).
+	// Stack mode forwards env via compose itself, not `-e`, so it's exempt.
 	cmd.Env = os.Environ()
+	if ce.Mode != model.ComposeModeStack {
+		cmd.Env = append(cmd.Env, composeEnv(task, run, instanceIndex)...)
+	}
 
 	proc, err := startCmd(cmd, task.GracefulStop, signalFromName(task.StopSignal), nil, "start docker compose")
 	if err != nil {
@@ -178,7 +183,9 @@ func parseContainerIDs(out []byte) []string {
 // buildComposeArgs assembles the argv tail (after the docker binary) for
 // either per-service (`run --rm`) or stack-mode (`up --abort-on-container-exit`)
 // invocations. RUNWISP_INSTANCE_INDEX + task.Env + task.Secrets flow into
-// the target container via repeated -e flags, deterministically ordered.
+// the target container via repeated value-less `-e KEY` flags, deterministically
+// ordered; docker resolves each value from the CLI's environment (injected in
+// Start), so no value ever appears on argv.
 // fingerprint scopes the ownership labels stamped on the container.
 func buildComposeArgs(ce *model.ComposeExecution, task *model.Task, run *model.Run, fingerprint string) []string {
 	args := []string{"compose", "-f", ce.File}
@@ -221,8 +228,8 @@ func appendComposeRunArgs(args []string, ce *model.ComposeExecution, task *model
 	for _, l := range composeManagedLabels(task.Name, instanceIndex, fingerprint) {
 		args = append(args, "--label", l)
 	}
-	for _, kv := range composeEnvFlags(task, run, instanceIndex) {
-		args = append(args, "-e", kv)
+	for _, k := range composeEnvFlags(task, run, instanceIndex) {
+		args = append(args, "-e", k)
 	}
 	args = append(args, ce.Service)
 	// Per-execution arg/option/flag tokens pass as real argv after the
@@ -265,13 +272,13 @@ func composeContainerName(project, service string, idx int) string {
 	}
 }
 
-// composeEnvFlags returns deterministically ordered KEY=VALUE strings suitable
-// for passing as -e arguments to `docker compose run`. RUNWISP_INSTANCE_INDEX
-// is always injected; task.Env wins over the daemon's environment because we
-// only forward the user's declared variables, not os.Environ(). The per-run
+// composeMergedEnv builds the deterministic variable set forwarded into the
+// target container. RUNWISP_INSTANCE_INDEX is always injected; task.Env wins
+// over the daemon's environment because we only forward the user's declared
+// variables, not os.Environ(). Secrets override plain env, and the per-run
 // param env layer is applied last so manual intent wins (collisions are
 // rejected at config load, so order is immaterial in valid configs).
-func composeEnvFlags(task *model.Task, run *model.Run, instanceIndex int) []string {
+func composeMergedEnv(task *model.Task, run *model.Run, instanceIndex int) map[string]string {
 	merged := map[string]string{
 		"RUNWISP_INSTANCE_INDEX": strconv.Itoa(instanceIndex),
 	}
@@ -288,11 +295,36 @@ func composeEnvFlags(task *model.Task, run *model.Run, instanceIndex int) []stri
 	for k, v := range model.ParamEnvLayer(task.Parameters, runParams) {
 		merged[k] = v
 	}
-	keys := make([]string, 0, len(merged))
-	for k := range merged {
+	return merged
+}
+
+// sortedKeys returns the map's keys in ascending order — the single source of
+// the deterministic ordering shared by composeEnvFlags and composeEnv.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+	return keys
+}
+
+// composeEnvFlags returns the deterministically ordered variable NAMES to
+// forward into the container as value-less `-e KEY` flags. Docker's `-e KEY`
+// form reads each value from the calling process's environment — which Start
+// populates via composeEnv — so secret values never appear on argv (and thus
+// never in `ps` output).
+func composeEnvFlags(task *model.Task, run *model.Run, instanceIndex int) []string {
+	return sortedKeys(composeMergedEnv(task, run, instanceIndex))
+}
+
+// composeEnv returns the forwarded variables as deterministically ordered
+// KEY=VALUE pairs, for appending to the docker CLI child process's environment
+// in Start. Pairing with composeEnvFlags' value-less `-e KEY` flags, this is
+// how the actual values reach the container without ever touching argv.
+func composeEnv(task *model.Task, run *model.Run, instanceIndex int) []string {
+	merged := composeMergedEnv(task, run, instanceIndex)
+	keys := sortedKeys(merged)
 	out := make([]string, len(keys))
 	for i, k := range keys {
 		out[i] = k + "=" + merged[k]

--- a/apps/runwisp/internal/executor/compose_test.go
+++ b/apps/runwisp/internal/executor/compose_test.go
@@ -55,8 +55,11 @@ func TestComposeBackend_BuildArgs_ServicesMode(t *testing.T) {
 	assert.Contains(t, joined, "--label com.runwisp.task=boxes.web")
 	assert.Contains(t, joined, "--label com.runwisp.instance=2")
 	assert.Contains(t, joined, "--label com.runwisp.instance-fp=fp-123")
-	assert.Contains(t, joined, "-e RUNWISP_INSTANCE_INDEX=2")
-	assert.Contains(t, joined, "-e LOG_LEVEL=info")
+	// Values are injected into the docker CLI's own environment, not argv, so
+	// only the value-less `-e KEY` flags appear here.
+	assert.Contains(t, joined, "-e RUNWISP_INSTANCE_INDEX")
+	assert.Contains(t, joined, "-e LOG_LEVEL")
+	assert.NotContains(t, joined, "LOG_LEVEL=info", "env values must never appear on argv")
 	// service name is the final positional argument
 	assert.Equal(t, "web", args[len(args)-1])
 }
@@ -103,12 +106,13 @@ func TestComposeBackend_EnvFlags_DeterministicOrder(t *testing.T) {
 		Secrets: map[string]string{"ZED": "secret"},
 	}
 	flags := composeEnvFlags(task, nil, 0)
-	// alphabetical ordering keeps test assertions stable
+	// composeEnvFlags returns NAMES only (values go into the CLI env, not argv);
+	// alphabetical ordering keeps test assertions stable.
 	assert.Equal(t, []string{
-		"BAR=2",
-		"FOO=1",
-		"RUNWISP_INSTANCE_INDEX=0",
-		"ZED=secret",
+		"BAR",
+		"FOO",
+		"RUNWISP_INSTANCE_INDEX",
+		"ZED",
 	}, flags)
 }
 
@@ -117,9 +121,13 @@ func TestComposeBackend_EnvFlags_SecretOverridesEnv(t *testing.T) {
 		Env:     map[string]string{"PASSWORD": "plain"},
 		Secrets: map[string]string{"PASSWORD": "from-secret"},
 	}
-	flags := composeEnvFlags(task, nil, 0)
-	assert.Contains(t, flags, "PASSWORD=from-secret")
-	assert.NotContains(t, flags, "PASSWORD=plain")
+	// composeEnv carries the resolved KEY=VALUE pairs (injected into the CLI
+	// env); it's where the secret-over-env precedence is observable.
+	env := composeEnv(task, nil, 0)
+	assert.Contains(t, env, "PASSWORD=from-secret")
+	assert.NotContains(t, env, "PASSWORD=plain")
+	// The value-less flags carry only the name.
+	assert.Equal(t, []string{"PASSWORD", "RUNWISP_INSTANCE_INDEX"}, composeEnvFlags(task, nil, 0))
 }
 
 func TestComposeContainerName(t *testing.T) {
@@ -175,8 +183,50 @@ func TestComposeBackend_Start_RecordsArgs(t *testing.T) {
 	assert.Contains(t, rec, "-f /tmp/dc.yml")
 	assert.Contains(t, rec, "-p demo")
 	assert.Contains(t, rec, "--name demo_web_1")
-	assert.Contains(t, rec, "RUNWISP_INSTANCE_INDEX=1")
-	assert.Contains(t, rec, "FOO=bar")
+	// Only the value-less `-e KEY` flags reach argv; the values are injected
+	// into the docker CLI's environment instead (see the env-injection test).
+	assert.Contains(t, rec, "-e RUNWISP_INSTANCE_INDEX")
+	assert.Contains(t, rec, "-e FOO")
+	assert.NotContains(t, rec, "FOO=bar", "env values must never appear on argv")
+	assert.NotContains(t, rec, "RUNWISP_INSTANCE_INDEX=1", "env values must never appear on argv")
+}
+
+// TestComposeBackend_Start_InjectsEnvIntoChildProcess pins the hardening: the
+// actual env/secret values are delivered to docker through the CLI child's
+// environment (so `-e KEY` can resolve them), never through argv. The shim
+// dumps its own environment and the test asserts the secret value is present
+// there.
+func TestComposeBackend_Start_InjectsEnvIntoChildProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-shim depends on POSIX shell")
+	}
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "env.txt")
+	body := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"compose\" ] && [ \"$2\" = \"version\" ]; then\n" +
+		"  echo 'Docker Compose v2.test'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"env > '" + envFile + "'\n" +
+		"exit 0\n"
+	installDockerShimScript(t, dir, body)
+
+	b := &ComposeBackend{dockerCmd: "docker"}
+	ce := &model.ComposeExecution{File: "/tmp/dc.yml", ProjectName: "demo", Service: "web", Mode: model.ComposeModeServices}
+	task := &model.Task{Secrets: map[string]string{"API_TOKEN": "s3cr3t"}}
+
+	proc, err := b.Start(context.Background(), task, &model.Run{InstanceIndex: 0}, ce)
+	require.NoError(t, err)
+	go drain(proc.Stdout)
+	go drain(proc.Stderr)
+	proc.Wait()
+
+	recorded, err := os.ReadFile(envFile)
+	require.NoError(t, err)
+	env := string(recorded)
+	assert.Contains(t, env, "API_TOKEN=s3cr3t",
+		"secret value must reach the docker CLI via its environment, not argv")
+	assert.Contains(t, env, "RUNWISP_INSTANCE_INDEX=0")
 }
 
 // TestComposeBackend_Start_ReclaimsStaleInstance verifies that, before


### PR DESCRIPTION
Compose tasks now pass env vars and secrets to `docker compose` through the child process environment rather than as `-e KEY=VALUE` CLI arguments. Docker resolves each `-e KEY` flag from its own environment, so secret values never appear on the command line and are no longer visible via `ps aux` on the host.

**Changes:**
- `composeEnvFlags` now returns only sorted key names (used for `-e KEY` without value)
- New `composeEnv` returns sorted `KEY=VALUE` pairs injected into `cmd.Env`
- `Start()` appends merged task env/secrets/params to `cmd.Env` before `startCmd` runs
- New integration test verifies secrets arrive in the container without touching argv

All tests pass (`go test ./internal/executor/`), `go vet` clean, `gofmt` clean.