### PR TITLE
ci: submit accurate dependency graph snapshot from bun.lock

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,36 @@
+# Copyright (c) PoppyCake, s.r.o. SPDX-License-Identifier: GPL-3.0-or-later
+
+# GitHub's static dependency graph doesn't parse bun.lock, so every npm
+# manifest in this repo shows up with its raw package.json semver range
+# instead of a resolved version — Dependabot alerts then can't tell whether
+# an installed version is actually vulnerable. This job submits an accurate
+# snapshot, built from bun.lock's own resolved versions, via the Dependency
+# Submission API instead.
+name: Dependency Submission
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  submit:
+    name: Submit npm dependency snapshot
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: package.json
+
+      - name: Generate SPDX SBOM from bun.lock
+        run: bun scripts/bun-lock-to-spdx.ts bun.lock.spdx.json
+
+      - name: Submit dependency snapshot
+        uses: advanced-security/spdx-dependency-submission-action@169d22427d74f3faf93504e70b03eede8dab272a # v0.2.0
+        with:
+          filePath: "."
+          filePattern: "bun.lock.spdx.json"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "apps/*",
     "packages/*"
   ],
+  "overrides": {
+    "sharp": "^0.35.0"
+  },
   "scripts": {
     "dev": "moon run runwisp:dev",
     "demo": "moon run runwisp:demo",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "apps/*",
     "packages/*"
   ],
-  "overrides": {
-    "sharp": "^0.35.0"
-  },
   "scripts": {
     "dev": "moon run runwisp:dev",
     "demo": "moon run runwisp:demo",

--- a/scripts/bun-lock-to-spdx.ts
+++ b/scripts/bun-lock-to-spdx.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Converts bun.lock into a minimal SPDX 2.2 SBOM so CI can submit an accurate
+// dependency snapshot via GitHub's Dependency Submission API. GitHub's static
+// dependency graph doesn't parse bun.lock (only package-lock.json/yarn.lock/
+// pnpm-lock.yaml) and npm's own CLI can't read this repo's manifests either
+// (workspace:* is a bun/pnpm/yarn protocol npm doesn't understand), so this
+// reads bun.lock's own resolved versions directly instead of routing through
+// foreign tooling.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const lockPath = resolve(repoRoot, "bun.lock");
+const outPath = resolve(repoRoot, process.argv[2] ?? "bun.lock.spdx.json");
+
+interface BunLock {
+    packages: Record<string, [string, ...unknown[]]>;
+}
+
+// bun.lock is JSONC (trailing commas allowed); strip them before JSON.parse.
+function parseJsonc(text: string): unknown {
+    const withoutTrailingCommas = text.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(withoutTrailingCommas);
+}
+
+function toPurl(name: string, version: string): string {
+    const encoded = name.startsWith("@")
+        ? `%40${encodeURIComponent(name.slice(1))}`
+        : encodeURIComponent(name);
+    return `pkg:npm/${encoded}@${encodeURIComponent(version)}`;
+}
+
+function toSpdxId(name: string, version: string): string {
+    const safe = `${name}-${version}`.replace(/[^A-Za-z0-9.-]/g, "-");
+    return `SPDXRef-Package-${safe}`;
+}
+
+const lock = parseJsonc(readFileSync(lockPath, "utf8")) as BunLock;
+
+const seen = new Map<string, { name: string; version: string }>();
+for (const entry of Object.values(lock.packages)) {
+    const spec = entry[0];
+    const at = spec.lastIndexOf("@");
+    if (at <= 0) continue; // skip malformed/unversioned entries
+    const name = spec.slice(0, at);
+    const version = spec.slice(at + 1);
+    if (version.startsWith("workspace:")) continue; // internal package, not a real published dependency
+    seen.set(`${name}@${version}`, { name, version });
+}
+
+const packages = [...seen.values()]
+    .sort((a, b) =>
+        a.name === b.name
+            ? a.version.localeCompare(b.version)
+            : a.name.localeCompare(b.name),
+    )
+    .map(({ name, version }) => ({
+        SPDXID: toSpdxId(name, version),
+        name,
+        versionInfo: version,
+        downloadLocation: "NOASSERTION",
+        licenseConcluded: "NOASSERTION",
+        licenseDeclared: "NOASSERTION",
+        copyrightText: "NOASSERTION",
+        externalRefs: [
+            {
+                referenceCategory: "PACKAGE-MANAGER",
+                referenceType: "purl",
+                referenceLocator: toPurl(name, version),
+            },
+        ],
+    }));
+
+const documentId = "SPDXRef-DOCUMENT";
+const sbom = {
+    spdxVersion: "SPDX-2.2",
+    dataLicense: "CC0-1.0",
+    SPDXID: documentId,
+    name: "runwisp-bun-dependencies",
+    documentNamespace: `https://runwisp.com/spdx/${process.env.GITHUB_SHA ?? "local"}-${crypto.randomUUID()}`,
+    creationInfo: {
+        created: new Date().toISOString(),
+        creators: ["Tool: bun-lock-to-spdx"],
+    },
+    packages,
+    relationships: packages.map((pkg) => ({
+        spdxElementId: documentId,
+        relatedSpdxElement: pkg.SPDXID,
+        relationshipType: "DEPENDS_ON",
+    })),
+};
+
+writeFileSync(outPath, JSON.stringify(sbom, null, 2));
+console.log(`Wrote ${packages.length} packages to ${outPath}`);


### PR DESCRIPTION
## Summary

GitHub's dependency graph doesn't parse `bun.lock`, so every npm manifest in this repo shows up with its raw `package.json` semver range instead of a resolved version — which is why [Dependabot alert #24](https://github.com/runwisp/runwisp/security/dependabot/24) couldn't determine an installed version for `sharp` even though `bun.lock` correctly pinned a patched one. (The `sharp` vulnerability itself is already fixed on `main` via #173.)

This adds a CI job that submits an accurate dependency snapshot to GitHub via the Dependency Submission API, built directly from `bun.lock`'s own resolved versions (`scripts/bun-lock-to-spdx.ts` → SPDX → `advanced-security/spdx-dependency-submission-action`). No existing tool (npm's own CLI, `component-detection`, `cyclonedx-node-npm`) can read this repo's manifests, since they all use the `workspace:*` protocol that only bun/pnpm/yarn support — hence the small converter script.

## Test plan

- [x] `scripts/bun-lock-to-spdx.ts` verified locally against the repo's actual `bun.lock` — resolves real versions correctly (e.g. `sharp@0.35.3`), skips internal workspace-link entries
- [x] `bun run check` and `bun run test` pass
- [ ] Confirm the new `dependency-submission` workflow succeeds on `main` and the dependency graph shows resolved versions