### PR TITLE
fix(docs): correct mutually-exclusive claim in services.mdx, fix storage.mdx list rendering

### DIFF
--- a/apps/docs/src/content/docs/configuration/services.mdx
+++ b/apps/docs/src/content/docs/configuration/services.mdx
@@ -284,7 +284,9 @@ environment base, as the same OS user (`user` needs the daemon running as root).
 `docker-compose.yml` instead of a raw shell command. Set
 `compose_file = "./docker-compose.yml"` and (optionally)
 `compose_service = "<name>"` — when omitted, the service name defaults
-to the table key. `run` and `compose_file` are mutually exclusive.
+to the table key. `compose_file` alone starts the service with its own
+command; add a `run` command and it's exec'd inside the running container
+instead. Override that default with [`compose_mode`](/configuration/compose/#running-a-command-in-a-service-compose_mode).
 
 For importing the whole compose file at once, see [`[compose.*]`](/configuration/compose/).
 

--- a/apps/docs/src/content/docs/configuration/storage.mdx
+++ b/apps/docs/src/content/docs/configuration/storage.mdx
@@ -69,12 +69,14 @@ required`. The daemon itself keeps running; only that run fails.
   log writer stops accepting new lines and the daemon raises a
   `log.disk_pressure` notification (severity `warn`) so you find out
   about the output you're no longer seeing. What happens to
-  the process itself comes down to the task's `log_on_full`: - `drop_new` / `drop_old`: a system line `"Log output stopped:
-disk space critically low"` goes into the log and the process
-  keeps running. - `kill_task`: the run is cancelled (`end_reason = "log_overflow"`)
-  with a system line `"Process killed: disk space critically low
-…; log_on_full=\"kill_task\""`. You asked for loud failure over
-  disk safety, and RunWisp honours that.
+  the process itself comes down to the task's `log_on_full`:
+
+    - `drop_new` / `drop_old`: a system line `"Log output stopped: disk space critically low"`
+      goes into the log and the process keeps running.
+    - `kill_task`: the run is cancelled (`end_reason = "log_overflow"`) with a system line
+      `"Process killed: disk space critically low …; log_on_full=\"kill_task\""`.
+
+    You asked for loud failure over disk safety, and RunWisp honours that.
 
 That notification fires once per run, not once per check, and it carries
 `free_bytes`, `min_free_bytes`, and `killed_task` — so a dashboard can


### PR DESCRIPTION
Two docs fixes from proofreading:

- services.mdx: replace false 'run and compose_file are mutually exclusive' with accurate compose_mode='exec' explanation (matches tasks.mdx fix from #171)
- storage.mdx: break bullet list onto separate lines so it renders as proper markdown instead of a wall of text