### PR TITLE
fix(security): tighten the cloud dispatch opt-in and /api/instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`/api/instance` no longer answers a request that arrived through a proxy**, so the datadir, config, and socket paths it discloses stay local when the daemon sits behind a same-host reverse proxy. See [Reverse proxies](https://docs.runwisp.com/operations/auth/#reverse-proxies).
+- **A control-plane peer can no longer override a TOML-defined service's `env` unless `[daemon] allow_cloud_dispatch` is on**, and an inline cloud execution can no longer overwrite a task defined in `runwisp.toml`.
+- **`arg` / `option` / `flag` params are rejected on a compose task in run mode**, where they would have replaced the service's own command instead of being appended to it. Use an `env` param or `compose_mode = "exec"`. See [Compose-backed tasks](https://docs.runwisp.com/configuration/tasks/#compose-backed-tasks).
 - **Compose tasks hand their environment and secrets to the `docker compose` CLI through its process environment** and forward each variable with a value-less `-e KEY` flag, so docker resolves values from its own environment and no secret value is ever placed on the command line. See [Compose](https://docs.runwisp.com/configuration/compose/).
 
 ## [0.13.2] - 2026-07-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`/api/instance` no longer answers a request that arrived through a proxy**, so the datadir, config, and socket paths it discloses stay local when the daemon sits behind a same-host reverse proxy. See [Reverse proxies](https://docs.runwisp.com/operations/auth/#reverse-proxies).
 - **A control-plane peer can no longer override a TOML-defined service's `env` unless `[daemon] allow_cloud_dispatch` is on**, and an inline cloud execution can no longer overwrite a task defined in `runwisp.toml`.
-- **`arg` / `option` / `flag` params are rejected on a compose task in run mode**, where they would have replaced the service's own command instead of being appended to it. Use an `env` param or `compose_mode = "exec"`. See [Compose-backed tasks](https://docs.runwisp.com/configuration/tasks/#compose-backed-tasks).
 - **Compose tasks hand their environment and secrets to the `docker compose` CLI through its process environment** and forward each variable with a value-less `-e KEY` flag, so docker resolves values from its own environment and no secret value is ever placed on the command line. See [Compose](https://docs.runwisp.com/configuration/compose/).
 
 ## [0.13.2] - 2026-07-26

--- a/apps/docs/src/content/docs/configuration/tasks.mdx
+++ b/apps/docs/src/content/docs/configuration/tasks.mdx
@@ -531,54 +531,28 @@ container instead, set both `compose_file` and `run` together with
 For importing every service in a compose file as observable RunWisp
 services, see [`[compose.*]`](/configuration/compose/).
 
-### Which parameters work here
+### Parameters on a compose task
 
-[Parameters](#parameters) come in four flavours. On a compose task that
-starts a fresh container — the `nightly-backup` example above, no `run` —
-only `env` ones are allowed:
-
-| In `params`              | On a fresh-container compose task             |
-| ------------------------ | --------------------------------------------- |
-| `{ env = "SINCE" }`      | ✅ Works — arrives as an environment variable |
-| `{ arg = "since" }`      | ❌ Rejected at config load                    |
-| `{ option = "--since" }` | ❌ Rejected at config load                    |
-| `{ flag = "--force" }`   | ❌ Rejected at config load                    |
-
-The three rejected ones all work by appending words to your command line,
-and that's the problem. RunWisp starts the container with
-`docker compose run --rm backup`, and docker reads anything after the
-service name as **the command to run _instead of_ the service's own**. So
-declaring `{ arg = "since" }` and triggering with `since = "2026-01-01"`
-wouldn't hand `2026-01-01` to the service's command as an extra word — it
-would throw that command away and try to run a program called
-`2026-01-01`. Docker gives us no way to say "keep the command, just add
-this", so rather than do something that surprising, RunWisp refuses the
-combination up front. `runwisp validate` names it before the daemon ever
-sees it.
-
-Two ways to get what you wanted:
+[Parameters](#parameters) work here, with one difference in the
+fresh-container mode above (`compose_file` and `compose_service`, no
+`run`): `arg`, `option`, and `flag` values go to the container the way
+`docker compose run <svc> …` passes them, so they replace the service's
+`command:` and arrive as arguments to the image's `ENTRYPOINT`.
 
 ```toml
-# Pass the value as an environment variable — the service's own command
-# reads it from $SINCE.
 [tasks.nightly-backup]
 cron            = "0 3 * * *"
 compose_file    = "./docker-compose.yml"
 compose_service = "backup"
-params          = [{ env = "SINCE", default = "yesterday" }]
-```
-
-```toml
-# Or write the command yourself with compose_mode = "exec", and every
-# parameter flavour behaves exactly as it does on a normal task.
-[tasks.nightly-backup]
-cron            = "0 3 * * *"
-compose_file    = "./docker-compose.yml"
-compose_service = "backup"
-compose_mode    = "exec"
-run             = "/usr/local/bin/backup.sh"
 params          = [{ arg = "since", default = "yesterday" }]
 ```
+
+Trigger that with `since = "2026-01-01"` and the container runs its
+entrypoint with `2026-01-01`.
+
+Use `env` params to pass values without touching the command line, or
+`compose_mode = "exec"` with your own `run` to append tokens to that
+command instead.
 
 ## Notifications
 

--- a/apps/docs/src/content/docs/configuration/tasks.mdx
+++ b/apps/docs/src/content/docs/configuration/tasks.mdx
@@ -531,6 +531,15 @@ container instead, set both `compose_file` and `run` together with
 For importing every service in a compose file as observable RunWisp
 services, see [`[compose.*]`](/configuration/compose/).
 
+One wrinkle on [parameters](#parameters): `arg`, `option`, and `flag`
+params don't work in run mode. `docker compose run <svc> …` reads the
+first thing after the service name as the _command_, so those tokens
+would replace the service's own command rather than get appended to it —
+which is the opposite of what params promise everywhere else. RunWisp
+rejects the combination at load instead of quietly doing the wrong
+thing. Use `env` params, which travel as `-e` flags and work fine, or
+switch to `compose_mode = "exec"` where your command owns the argv.
+
 ## Notifications
 
 | Key                 | Default  | What it does                                                                                                                                                                                                              |

--- a/apps/docs/src/content/docs/configuration/tasks.mdx
+++ b/apps/docs/src/content/docs/configuration/tasks.mdx
@@ -531,14 +531,54 @@ container instead, set both `compose_file` and `run` together with
 For importing every service in a compose file as observable RunWisp
 services, see [`[compose.*]`](/configuration/compose/).
 
-One wrinkle on [parameters](#parameters): `arg`, `option`, and `flag`
-params don't work in run mode. `docker compose run <svc> …` reads the
-first thing after the service name as the _command_, so those tokens
-would replace the service's own command rather than get appended to it —
-which is the opposite of what params promise everywhere else. RunWisp
-rejects the combination at load instead of quietly doing the wrong
-thing. Use `env` params, which travel as `-e` flags and work fine, or
-switch to `compose_mode = "exec"` where your command owns the argv.
+### Which parameters work here
+
+[Parameters](#parameters) come in four flavours. On a compose task that
+starts a fresh container — the `nightly-backup` example above, no `run` —
+only `env` ones are allowed:
+
+| In `params`              | On a fresh-container compose task             |
+| ------------------------ | --------------------------------------------- |
+| `{ env = "SINCE" }`      | ✅ Works — arrives as an environment variable |
+| `{ arg = "since" }`      | ❌ Rejected at config load                    |
+| `{ option = "--since" }` | ❌ Rejected at config load                    |
+| `{ flag = "--force" }`   | ❌ Rejected at config load                    |
+
+The three rejected ones all work by appending words to your command line,
+and that's the problem. RunWisp starts the container with
+`docker compose run --rm backup`, and docker reads anything after the
+service name as **the command to run _instead of_ the service's own**. So
+declaring `{ arg = "since" }` and triggering with `since = "2026-01-01"`
+wouldn't hand `2026-01-01` to the service's command as an extra word — it
+would throw that command away and try to run a program called
+`2026-01-01`. Docker gives us no way to say "keep the command, just add
+this", so rather than do something that surprising, RunWisp refuses the
+combination up front. `runwisp validate` names it before the daemon ever
+sees it.
+
+Two ways to get what you wanted:
+
+```toml
+# Pass the value as an environment variable — the service's own command
+# reads it from $SINCE.
+[tasks.nightly-backup]
+cron            = "0 3 * * *"
+compose_file    = "./docker-compose.yml"
+compose_service = "backup"
+params          = [{ env = "SINCE", default = "yesterday" }]
+```
+
+```toml
+# Or write the command yourself with compose_mode = "exec", and every
+# parameter flavour behaves exactly as it does on a normal task.
+[tasks.nightly-backup]
+cron            = "0 3 * * *"
+compose_file    = "./docker-compose.yml"
+compose_service = "backup"
+compose_mode    = "exec"
+run             = "/usr/local/bin/backup.sh"
+params          = [{ arg = "since", default = "yesterday" }]
+```
 
 ## Notifications
 

--- a/apps/runwisp/internal/cloud/dispatch_resolver.go
+++ b/apps/runwisp/internal/cloud/dispatch_resolver.go
@@ -43,6 +43,18 @@ func (h *InboundHandler) resolveDispatchTask(dispatch *protocol.Execution) (task
 	}
 
 	task := buildDynamicCloudTask(dispatch, execDef)
+	// sanitizeCloudTaskName only prefixes "cloud-"; the rest of the name is
+	// peer-supplied, so an inline dispatch can land on a locally-defined task
+	// named cloud-*. Upserting over it would let the peer replace a disk-defined
+	// task's execution (and have the ephemeral reaper delete it afterwards),
+	// violating "run= comes from disk only". resolveServiceTarget guards the
+	// service path the same way.
+	if existing, ok := h.taskManager.GetTask(task.Name); ok && !existing.Ephemeral {
+		return "", false, &CloudError{
+			Kind:    CloudErrorKindConflict,
+			Message: fmt.Sprintf("task %q is defined locally; an inline cloud execution cannot overwrite it", task.Name),
+		}
+	}
 	h.taskManager.UpsertTask(task)
 	return task.Name, false, nil
 }

--- a/apps/runwisp/internal/cloud/dispatch_resolver_test.go
+++ b/apps/runwisp/internal/cloud/dispatch_resolver_test.go
@@ -271,6 +271,49 @@ func TestResolveDispatchTask_HTTPAllowedWithoutDispatch(t *testing.T) {
 	assert.False(t, configBacked)
 }
 
+// Regression: sanitizeCloudTaskName only prefixes "cloud-", so a peer picks the
+// rest of the name and can aim an inline dispatch at a locally-defined task
+// called cloud-*. Upserting over it would replace a disk-defined task's
+// execution — and the ephemeral reaper would then delete the task outright — so
+// the collision must be rejected. http is reachable with allow_cloud_dispatch
+// off, so this is not gated by the availability check above.
+func TestResolveDispatchTask_RejectsConfigTaskNameCollision(t *testing.T) {
+	origExec := &model.ShellExecution{Script: "sync.sh"}
+	local := &model.Task{Name: "cloud-sync", Kind: model.KindTask, Cron: "* * * * *", ExecutionDef: origExec}
+	h := newDispatchHandler(executor.Availability{HTTP: executor.BackendStatus{Available: true}},
+		map[string]*model.Task{"cloud-sync": local})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	_, _, err := h.resolveDispatchTask(&protocol.Execution{
+		TaskID: "sync",
+		Script: httpScript(t, "https://attacker.example/p"),
+	})
+	require.Error(t, err)
+	var ce *CloudError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, CloudErrorKindConflict, ce.Kind)
+	assert.Empty(t, runner.upserted, "the local task definition must survive untouched")
+	assert.Same(t, origExec, local.ExecutionDef)
+}
+
+// An inline dispatch reusing the name of an earlier inline dispatch is the
+// normal retry case and must still upsert.
+func TestResolveDispatchTask_EphemeralNameCollisionAllowed(t *testing.T) {
+	prior := &model.Task{Name: "cloud-probe", Ephemeral: true, ExecutionDef: &model.ShellExecution{Script: "old"}}
+	h := newDispatchHandler(executor.Availability{HTTP: executor.BackendStatus{Available: true}},
+		map[string]*model.Task{"cloud-probe": prior})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	name, configBacked, err := h.resolveDispatchTask(&protocol.Execution{
+		TaskID: "probe",
+		Script: httpScript(t, "https://example.com"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "cloud-probe", name)
+	assert.False(t, configBacked)
+	assert.Len(t, runner.upserted, 1)
+}
+
 // --- buildDynamicCloudTask ---
 
 func TestBuildDynamicCloudTask_UsesTaskID(t *testing.T) {

--- a/apps/runwisp/internal/cloud/service_handler.go
+++ b/apps/runwisp/internal/cloud/service_handler.go
@@ -279,7 +279,33 @@ func (h *InboundHandler) mergeServiceApply(task *model.Task, svc *protocol.Servi
 		}
 	}
 
+	if err := h.checkEnvOverrideAllowed(task, svc.TaskConfig); err != nil {
+		return err
+	}
+
 	applyServiceTaskConfig(task, svc.TaskConfig)
+	return nil
+}
+
+// checkEnvOverrideAllowed puts a peer-supplied env override on the same
+// allow_cloud_dispatch surface as a script override. env can change what a
+// disk-defined command actually executes (NODE_OPTIONS, GIT_SSH_COMMAND,
+// *_proxy) and it overlays on top of the inherited environment, so a peer must
+// not reshape a TOML service's spawn env without the opt-in.
+//
+// Only env is gated. The instances/restart/log knobs are what the cloud
+// legitimately re-asserts on every reconnect, so gating those would break sync
+// on a dispatch-off daemon.
+func (h *InboundHandler) checkEnvOverrideAllowed(task *model.Task, cfg *protocol.ServiceTaskConfig) error {
+	if cfg == nil || len(cfg.Env) == 0 {
+		return nil
+	}
+	if status := h.availability.ForType(task.ExecutionDef.ExecType()); !status.Available {
+		return &CloudError{
+			Kind:    CloudErrorKindConflict,
+			Message: fmt.Sprintf("env override for service %q not available: %s", task.Name, status.Reason),
+		}
+	}
 	return nil
 }
 

--- a/apps/runwisp/internal/cloud/service_handler_test.go
+++ b/apps/runwisp/internal/cloud/service_handler_test.go
@@ -402,6 +402,100 @@ func TestHandleServiceApply_MergeUnavailableBackendRejected(t *testing.T) {
 	assert.Equal(t, CloudErrorKindConflict, ce.Kind)
 }
 
+// Regression: a peer must not reshape the spawn environment of a TOML-defined
+// service while allow_cloud_dispatch is off. env can change what a disk-defined
+// command actually executes (NODE_OPTIONS, GIT_SSH_COMMAND, *_proxy) and it
+// overlays on top of the inherited env, so it belongs on the same availability
+// gate as a script override. Before the fix the gate was only consulted when the
+// payload carried a script — and the cloud sends script: null for synced TOML
+// services — so taskConfig.env sailed straight through.
+func TestHandleServiceApply_MergeEnvGatedOnAvailability(t *testing.T) {
+	existing := &model.Task{
+		Name:          "web",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		Env:           map[string]string{"NODE_ENV": "production"},
+		ExecutionDef:  &model.ShellExecution{Script: "node server.js"},
+	}
+	h := newDispatchHandler(executor.Availability{}, map[string]*model.Task{"web": existing})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{
+			TaskID:   "web",
+			TaskName: "web",
+			Script:   json.RawMessage("null"),
+			TaskConfig: &protocol.ServiceTaskConfig{
+				Env: map[string]string{"NODE_OPTIONS": "--inspect=0.0.0.0:9229"},
+			},
+		},
+	})
+	require.Error(t, err)
+	var ce *CloudError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, CloudErrorKindConflict, ce.Kind)
+	assert.Empty(t, runner.upserted, "a rejected env override must not reach the task set")
+	assert.Equal(t, map[string]string{"NODE_ENV": "production"}, existing.Env,
+		"the operator's env must be left intact")
+}
+
+// The same merge with the backend available is the legitimate case and must
+// still apply. Guards against over-gating the fix above.
+func TestHandleServiceApply_MergeEnvAppliedWhenAvailable(t *testing.T) {
+	existing := &model.Task{
+		Name:          "web",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		ExecutionDef:  &model.ShellExecution{Script: "node server.js"},
+	}
+	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"web": existing})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{
+			TaskID:     "web",
+			TaskName:   "web",
+			Script:     json.RawMessage("null"),
+			TaskConfig: &protocol.ServiceTaskConfig{Env: map[string]string{"LOG_LEVEL": "debug"}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.upserted, 1)
+	assert.Equal(t, "debug", runner.upserted[0].Env["LOG_LEVEL"])
+}
+
+// A merge that carries no env at all must not be gated: the instances/restart/log
+// knobs are what the cloud re-asserts on every reconnect, and gating those would
+// break sync on a dispatch-off daemon.
+func TestHandleServiceApply_MergeWithoutEnvNotGated(t *testing.T) {
+	existing := &model.Task{
+		Name:          "web",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+		ExecutionDef:  &model.ShellExecution{Script: "node server.js"},
+	}
+	h := newDispatchHandler(executor.Availability{}, map[string]*model.Task{"web": existing})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{
+			TaskID:    "web",
+			TaskName:  "web",
+			Script:    json.RawMessage("null"),
+			Instances: 2,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.upserted, 1)
+	assert.Equal(t, 2, runner.upserted[0].Instances)
+}
+
 // Regression (Bug 1): a service:apply addressed by the bare name of a
 // *non-service* TOML task (a cron/one-shot) must be rejected outright and must
 // never overwrite that task's disk-defined run=. Before the fix, resolveServiceTarget

--- a/apps/runwisp/internal/config/compose_test.go
+++ b/apps/runwisp/internal/config/compose_test.go
@@ -267,6 +267,59 @@ compose_mode    = "run"
 	assert.Contains(t, err.Error(), model.ComposeModeExec)
 }
 
+// Regression: `compose run SERVICE <tokens…>` puts the first positional in
+// docker's COMMAND slot, so an arg/option/flag param would replace the service's
+// compose-declared command rather than be appended to it — letting whoever
+// supplies param values (a trigger caller, a control-plane peer) choose what runs
+// in the container. Rejected at load, since the grammar can't express append.
+func TestComposeExpansion_RunModeArgvParamsRejected(t *testing.T) {
+	for _, param := range []string{
+		`{ arg = "target" }`,
+		`{ option = "--target" }`,
+		`{ flag = "--verbose" }`,
+	} {
+		_, err := Load(writeConfig(t, `[tasks.report]
+cron            = "0 3 * * *"
+compose_file    = "./docker-compose.yml"
+compose_service = "app"
+params          = [ `+param+` ]
+`))
+		require.Error(t, err, "expected %s to be rejected on a run-mode compose unit", param)
+		assert.Contains(t, err.Error(), "compose_mode")
+	}
+}
+
+// env params are unaffected: they travel as -e flags before the service name, so
+// they can't reach the COMMAND slot.
+func TestComposeExpansion_RunModeEnvParamAllowed(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `[tasks.report]
+cron            = "0 3 * * *"
+compose_file    = "./docker-compose.yml"
+compose_service = "app"
+params          = [ { env = "TARGET", default = "all" } ]
+`))
+	require.NoError(t, err)
+	require.Len(t, cfg.Tasks, 1)
+	require.Len(t, cfg.Tasks[0].Parameters, 1)
+	assert.Equal(t, model.ParamEnv, cfg.Tasks[0].Parameters[0].Kind)
+}
+
+// exec mode is the documented place for argv params: the tokens land after the
+// operator's own command, so they really do append.
+func TestComposeExpansion_ExecModeArgvParamsAllowed(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `[tasks.report]
+cron            = "0 3 * * *"
+run             = "./report.sh"
+compose_file    = "./docker-compose.yml"
+compose_service = "app"
+compose_mode    = "exec"
+params          = [ { arg = "target", default = "all" } ]
+`))
+	require.NoError(t, err)
+	require.Len(t, cfg.Tasks, 1)
+	require.Len(t, cfg.Tasks[0].Parameters, 1)
+}
+
 func TestComposeExpansion_ExecModeWithoutRunRejected(t *testing.T) {
 	_, err := Load(writeConfig(t, `[tasks.artisan]
 cron            = "* * * * *"

--- a/apps/runwisp/internal/config/compose_test.go
+++ b/apps/runwisp/internal/config/compose_test.go
@@ -267,57 +267,36 @@ compose_mode    = "run"
 	assert.Contains(t, err.Error(), model.ComposeModeExec)
 }
 
-// Regression: `compose run SERVICE <tokens…>` puts the first positional in
-// docker's COMMAND slot, so an arg/option/flag param would replace the service's
-// compose-declared command rather than be appended to it — letting whoever
-// supplies param values (a trigger caller, a control-plane peer) choose what runs
-// in the container. Rejected at load, since the grammar can't express append.
-func TestComposeExpansion_RunModeArgvParamsRejected(t *testing.T) {
+// Every param kind loads on a compose task in either mode. In run mode the argv
+// kinds take docker's COMMAND slot rather than appending — a documented
+// difference, not a config error.
+func TestComposeExpansion_ParamsAcceptedInBothModes(t *testing.T) {
 	for _, param := range []string{
-		`{ arg = "target" }`,
-		`{ option = "--target" }`,
+		`{ env = "TARGET", default = "all" }`,
+		`{ arg = "target", default = "all" }`,
+		`{ option = "--target", default = "all" }`,
 		`{ flag = "--verbose" }`,
 	} {
-		_, err := Load(writeConfig(t, `[tasks.report]
+		runMode, err := Load(writeConfig(t, `[tasks.report]
 cron            = "0 3 * * *"
 compose_file    = "./docker-compose.yml"
 compose_service = "app"
 params          = [ `+param+` ]
 `))
-		require.Error(t, err, "expected %s to be rejected on a run-mode compose unit", param)
-		assert.Contains(t, err.Error(), "compose_mode")
-	}
-}
+		require.NoError(t, err, "run mode should accept %s", param)
+		require.Len(t, runMode.Tasks[0].Parameters, 1)
 
-// env params are unaffected: they travel as -e flags before the service name, so
-// they can't reach the COMMAND slot.
-func TestComposeExpansion_RunModeEnvParamAllowed(t *testing.T) {
-	cfg, err := Load(writeConfig(t, `[tasks.report]
-cron            = "0 3 * * *"
-compose_file    = "./docker-compose.yml"
-compose_service = "app"
-params          = [ { env = "TARGET", default = "all" } ]
-`))
-	require.NoError(t, err)
-	require.Len(t, cfg.Tasks, 1)
-	require.Len(t, cfg.Tasks[0].Parameters, 1)
-	assert.Equal(t, model.ParamEnv, cfg.Tasks[0].Parameters[0].Kind)
-}
-
-// exec mode is the documented place for argv params: the tokens land after the
-// operator's own command, so they really do append.
-func TestComposeExpansion_ExecModeArgvParamsAllowed(t *testing.T) {
-	cfg, err := Load(writeConfig(t, `[tasks.report]
+		execMode, err := Load(writeConfig(t, `[tasks.report]
 cron            = "0 3 * * *"
 run             = "./report.sh"
 compose_file    = "./docker-compose.yml"
 compose_service = "app"
 compose_mode    = "exec"
-params          = [ { arg = "target", default = "all" } ]
+params          = [ `+param+` ]
 `))
-	require.NoError(t, err)
-	require.Len(t, cfg.Tasks, 1)
-	require.Len(t, cfg.Tasks[0].Parameters, 1)
+		require.NoError(t, err, "exec mode should accept %s", param)
+		require.Len(t, execMode.Tasks[0].Parameters, 1)
+	}
 }
 
 func TestComposeExpansion_ExecModeWithoutRunRejected(t *testing.T) {

--- a/apps/runwisp/internal/config/config.go
+++ b/apps/runwisp/internal/config/config.go
@@ -728,9 +728,6 @@ func validateTaskParams(task *model.Task) error {
 	if len(task.Parameters) == 0 {
 		return nil
 	}
-	if err := validateComposeRunParams(task); err != nil {
-		return err
-	}
 	autoScheduled := task.Cron != "" || task.RunOnStart
 	seen := make(map[string]struct{}, len(task.Parameters))
 	optionalPositionalSeen := false
@@ -748,32 +745,6 @@ func validateTaskParams(task *model.Task) error {
 		if p.Kind == model.ParamArg && !p.Required {
 			optionalPositionalSeen = true
 		}
-	}
-	return nil
-}
-
-// validateComposeRunParams rejects argv-shaped params on a run-mode compose
-// unit. `docker compose run [opts] SERVICE <tokens…>` puts the first token in
-// docker's COMMAND slot, so an arg/option/flag value would *replace* the
-// service's compose-declared command instead of being appended to it — the
-// opposite of the documented contract that a trigger caller "can't invent a new
-// flag or change a command", and a way for whoever supplies param values to pick
-// what runs inside the container. The grammar has no way to express "keep the
-// service command, append these", so the combination is rejected outright, the
-// same way `run` is. env params stay legal: they travel via -e.
-func validateComposeRunParams(task *model.Task) error {
-	ce, isCompose := task.ExecutionDef.(*model.ComposeExecution)
-	if !isCompose || ce.Mode != model.ComposeModeServices {
-		return nil
-	}
-	for i := range task.Parameters {
-		p := &task.Parameters[i]
-		if p.Kind == model.ParamEnv {
-			continue
-		}
-		return fmt.Errorf(
-			"invalid params[%d] (%s) for task %s: %s parameters cannot be used with compose_mode = %q, which runs the service's own command; use compose_mode = %q to pass argv into the container, or an env parameter",
-			i, p.Key, task.Name, p.Kind, composeModeRun, model.ComposeModeExec)
 	}
 	return nil
 }

--- a/apps/runwisp/internal/config/config.go
+++ b/apps/runwisp/internal/config/config.go
@@ -728,6 +728,9 @@ func validateTaskParams(task *model.Task) error {
 	if len(task.Parameters) == 0 {
 		return nil
 	}
+	if err := validateComposeRunParams(task); err != nil {
+		return err
+	}
 	autoScheduled := task.Cron != "" || task.RunOnStart
 	seen := make(map[string]struct{}, len(task.Parameters))
 	optionalPositionalSeen := false
@@ -745,6 +748,32 @@ func validateTaskParams(task *model.Task) error {
 		if p.Kind == model.ParamArg && !p.Required {
 			optionalPositionalSeen = true
 		}
+	}
+	return nil
+}
+
+// validateComposeRunParams rejects argv-shaped params on a run-mode compose
+// unit. `docker compose run [opts] SERVICE <tokens…>` puts the first token in
+// docker's COMMAND slot, so an arg/option/flag value would *replace* the
+// service's compose-declared command instead of being appended to it — the
+// opposite of the documented contract that a trigger caller "can't invent a new
+// flag or change a command", and a way for whoever supplies param values to pick
+// what runs inside the container. The grammar has no way to express "keep the
+// service command, append these", so the combination is rejected outright, the
+// same way `run` is. env params stay legal: they travel via -e.
+func validateComposeRunParams(task *model.Task) error {
+	ce, isCompose := task.ExecutionDef.(*model.ComposeExecution)
+	if !isCompose || ce.Mode != model.ComposeModeServices {
+		return nil
+	}
+	for i := range task.Parameters {
+		p := &task.Parameters[i]
+		if p.Kind == model.ParamEnv {
+			continue
+		}
+		return fmt.Errorf(
+			"invalid params[%d] (%s) for task %s: %s parameters cannot be used with compose_mode = %q, which runs the service's own command; use compose_mode = %q to pass argv into the container, or an env parameter",
+			i, p.Key, task.Name, p.Kind, composeModeRun, model.ComposeModeExec)
 	}
 	return nil
 }

--- a/apps/runwisp/internal/executor/compose.go
+++ b/apps/runwisp/internal/executor/compose.go
@@ -285,9 +285,12 @@ func appendComposeRunArgs(args []string, ce *model.ComposeExecution, task *model
 		args = append(args, "-e", k)
 	}
 	args = append(args, ce.Service)
-	// Per-execution arg/option/flag tokens pass as real argv after the
-	// service — no quoting needed (this is exec, not a shell), giving
-	// byte-identical param semantics to the shell backend.
+	// NOTE: these are NOT append-to-the-command semantics like the shell and
+	// exec-mode backends have. `compose run SERVICE [COMMAND] [ARGS…]` treats the
+	// first positional after the service as COMMAND, so a token here replaces the
+	// service's compose-declared command. config.validateComposeRunParams
+	// therefore rejects arg/option/flag params on run-mode units, leaving this
+	// reachable only for the empty-token case; env params travel via -e above.
 	var runParams map[string]string
 	if run != nil {
 		runParams = run.Params

--- a/apps/runwisp/internal/executor/compose.go
+++ b/apps/runwisp/internal/executor/compose.go
@@ -285,12 +285,11 @@ func appendComposeRunArgs(args []string, ce *model.ComposeExecution, task *model
 		args = append(args, "-e", k)
 	}
 	args = append(args, ce.Service)
-	// NOTE: these are NOT append-to-the-command semantics like the shell and
+	// NOTE: these are not the append-to-the-command semantics the shell and
 	// exec-mode backends have. `compose run SERVICE [COMMAND] [ARGS…]` treats the
-	// first positional after the service as COMMAND, so a token here replaces the
-	// service's compose-declared command. config.validateComposeRunParams
-	// therefore rejects arg/option/flag params on run-mode units, leaving this
-	// reachable only for the empty-token case; env params travel via -e above.
+	// first positional after the service as COMMAND, so these tokens replace the
+	// service's compose-declared command (and land as arguments to the image's
+	// ENTRYPOINT when it has one). Documented on the tasks config page.
 	var runParams map[string]string
 	if run != nil {
 		runParams = run.Params

--- a/apps/runwisp/internal/server/auth_routes.go
+++ b/apps/runwisp/internal/server/auth_routes.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -16,8 +15,9 @@ import (
 // JWT flow lives in internal/server/auth; the handlers below just connect
 // chi routes to that package, layer in the local-trusted gating that depends
 // on peer-credential context keys (owned by this package), and host the few
-// helpers that are inherently HTTP-layer (launch-redirect sanitization,
-// local-loopback detection).
+// helpers that are inherently HTTP-layer (launch-redirect sanitization).
+// Loopback/local-peer detection lives in peercred.go alongside the context keys
+// it reads.
 
 // registerAuthRoutes registers the public auth endpoints as raw chi routes.
 // They are deliberately *not* huma operations: they set cookies, honor
@@ -94,30 +94,6 @@ func (srv *Server) handleLaunchTicket(w http.ResponseWriter, r *http.Request) {
 	}
 	srv.auth.SetAuthCookie(w, r, token, auth.JWTTokenDuration)
 	http.Redirect(w, r, sanitizeLaunchRedirect(r.URL.Query().Get("redirect")), http.StatusSeeOther)
-}
-
-// isLocalRequest returns true if the request was either delivered on the
-// daemon's Unix socket (PEERCRED-verified at accept time) or originates
-// from a TCP loopback address.
-//
-// The TCP path uses the original peer address stored by savePeerAddr
-// middleware to prevent bypass via spoofed X-Real-IP / X-Forwarded-For
-// headers (the trusted-proxy XFF middleware may overwrite r.RemoteAddr from
-// those values, but only for a configured trusted proxy).
-func isLocalRequest(r *http.Request) bool {
-	if IsLocalTrusted(r) {
-		return true
-	}
-	addr := r.RemoteAddr
-	if peerAddr, ok := r.Context().Value(peerAddrContextKey).(string); ok {
-		addr = peerAddr
-	}
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		host = addr
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
 }
 
 // sanitizeLaunchRedirect returns the requested redirect target if it is a

--- a/apps/runwisp/internal/server/auth_routes_test.go
+++ b/apps/runwisp/internal/server/auth_routes_test.go
@@ -74,7 +74,7 @@ func TestParseTrustedProxies_AcceptsValidCIDR(t *testing.T) {
 
 // --- Local-request gating helpers ---
 
-func TestIsLocalRequest(t *testing.T) {
+func TestIsLocalCtx(t *testing.T) {
 	tests := []struct {
 		name     string
 		addr     string
@@ -87,51 +87,67 @@ func TestIsLocalRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := httptest.NewRequest("GET", "/", nil)
-			r.RemoteAddr = tt.addr
-			assert.Equal(t, tt.expected, isLocalRequest(r))
+			ctx := context.WithValue(context.Background(), peerAddrContextKey, tt.addr)
+			assert.Equal(t, tt.expected, isLocalCtx(ctx))
 		})
 	}
 }
 
-func TestIsLocalRequest_UsesPeerAddrContext(t *testing.T) {
-	// Simulates what happens when middleware.RealIP overwrites RemoteAddr
-	// with a spoofed X-Real-IP header. The savePeerAddr middleware stores
-	// the original TCP address in context, so isLocalRequest should use
-	// that instead of the spoofed RemoteAddr.
-	r := httptest.NewRequest("GET", "/", nil)
-	r.RemoteAddr = "127.0.0.1:1234" // After RealIP spoofing
+func TestIsLocalCtx_UsesPeerAddrContext(t *testing.T) {
+	// Simulates what happens when the XFF middleware overwrites RemoteAddr from
+	// a spoofed X-Real-IP header. savePeerAddr stored the original TCP address
+	// in context first, and isLocalCtx reads only that.
+	ctx := context.WithValue(context.Background(), peerAddrContextKey, "203.0.113.50:5678")
 
-	// Context has the real peer address (set by savePeerAddr before RealIP)
-	ctx := context.WithValue(r.Context(), peerAddrContextKey, "203.0.113.50:5678")
-	r = r.WithContext(ctx)
-
-	assert.False(t, isLocalRequest(r),
+	assert.False(t, isLocalCtx(ctx),
 		"should use the real peer address from context, not the spoofed RemoteAddr")
 }
 
-func TestIsLocalRequest_ContextLoopbackAllowed(t *testing.T) {
-	r := httptest.NewRequest("GET", "/", nil)
-	r.RemoteAddr = "203.0.113.50:5678" // After RealIP might change it
+func TestIsLocalCtx_UnixSocketTrustedFlag(t *testing.T) {
+	// A request delivered on the Unix socket carries the local-trusted flag
+	// even when its synthetic peer address is non-loopback ("@" for an abstract
+	// unix peer, or the socket path).
+	ctx := context.WithValue(context.Background(), peerAddrContextKey, "@")
+	ctx = context.WithValue(ctx, localTrustedKey{}, true)
 
-	ctx := context.WithValue(r.Context(), peerAddrContextKey, "127.0.0.1:1234")
-	r = r.WithContext(ctx)
-
-	assert.True(t, isLocalRequest(r),
-		"should allow when real peer address is loopback")
+	assert.True(t, isLocalCtx(ctx),
+		"local-trusted flag must override the non-loopback peer address")
 }
 
-func TestIsLocalRequest_UnixSocketTrustedFlag(t *testing.T) {
-	// A request delivered on the Unix socket carries the local-trusted flag
-	// even when its synthetic RemoteAddr is non-loopback ("@" for an abstract
-	// unix peer, or the socket path).
-	r := httptest.NewRequest("GET", "/", nil)
-	r.RemoteAddr = "@"
-	ctx := context.WithValue(r.Context(), localTrustedKey{}, true)
-	r = r.WithContext(ctx)
+func TestIsLocalCtx_ProxiedLoopbackRejected(t *testing.T) {
+	// A same-host reverse proxy relaying an internet client connects from
+	// loopback, so loopback alone must not count as local.
+	ctx := context.WithValue(context.Background(), peerAddrContextKey, "127.0.0.1:1234")
+	ctx = context.WithValue(ctx, proxiedContextKey, true)
 
-	assert.True(t, isLocalRequest(r),
-		"local-trusted flag must override the non-loopback peer address")
+	assert.False(t, isLocalCtx(ctx),
+		"a proxy-relayed request must not be treated as local even from loopback")
+}
+
+func TestIsProxiedRequest(t *testing.T) {
+	for _, header := range forwardedHeaders {
+		t.Run(header, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			r.RemoteAddr = "127.0.0.1:1234"
+			r.Header.Set(header, "203.0.113.9")
+			assert.True(t, isProxiedRequest(r, nil))
+		})
+	}
+
+	t.Run("direct request", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.RemoteAddr = "127.0.0.1:1234"
+		assert.False(t, isProxiedRequest(r, nil),
+			"the local launcher probe sends no hop headers and must stay local")
+	})
+
+	t.Run("trusted proxy peer without headers", func(t *testing.T) {
+		opts, err := parseTrustedProxies("127.0.0.1")
+		require.NoError(t, err)
+		r := httptest.NewRequest("GET", "/", nil)
+		r.RemoteAddr = "127.0.0.1:1234"
+		assert.True(t, isProxiedRequest(r, opts))
+	})
 }
 
 // --- Launch-ticket endpoint integration ---

--- a/apps/runwisp/internal/server/instance_test.go
+++ b/apps/runwisp/internal/server/instance_test.go
@@ -75,3 +75,26 @@ func TestInstance_NonLoopbackTCPReturns403(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), "/tmp/rw-data",
 		"filesystem paths must never appear in the 403 body")
 }
+
+// Regression: the documented public-exposure setup runs nginx / Caddy / Traefik /
+// cloudflared on the same host forwarding to 127.0.0.1, so every internet request
+// reaches the daemon from loopback. The loopback gate alone would then serve the
+// datadir and config paths to anyone on the internet.
+func TestInstance_ProxiedLoopbackReturns403(t *testing.T) {
+	for _, header := range forwardedHeaders {
+		t.Run(header, func(t *testing.T) {
+			s := newServerForInstanceTest(t)
+
+			req := httptest.NewRequest("GET", "/api/instance", nil)
+			req.RemoteAddr = "127.0.0.1:54321" // the same-host proxy
+			req.Header.Set(header, "203.0.113.9")
+			w := httptest.NewRecorder()
+			s.router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusForbidden, w.Code,
+				"a proxy-relayed caller must not learn the daemon's datadir/config paths")
+			assert.NotContains(t, w.Body.String(), "/tmp/rw-data",
+				"filesystem paths must never appear in the 403 body")
+		})
+	}
+}

--- a/apps/runwisp/internal/server/peercred.go
+++ b/apps/runwisp/internal/server/peercred.go
@@ -33,15 +33,23 @@ func IsLocalTrustedCtx(ctx context.Context) bool {
 	return v
 }
 
-// isLocalCtx is the context-only equivalent of isLocalRequest: true when the
-// request arrived on the Unix socket (PEERCRED-verified) or from a TCP
-// loopback peer. The peer address comes from the value savePeerAddr stored
+// isLocalCtx reports whether the request came from this machine: it arrived on
+// the Unix socket (PEERCRED-verified), or from a TCP loopback peer that was not
+// relayed by a proxy. The peer address comes from the value savePeerAddr stored
 // before the trusted-proxy XFF middleware could overwrite it, so a spoofed
-// X-Forwarded-For cannot forge loopback. Used to gate GET /api/instance, whose payload (datadir, config and
-// socket paths) must never reach a non-loopback caller.
+// X-Forwarded-For cannot forge loopback.
+//
+// The proxied check is load-bearing, not defence in depth: with a same-host
+// reverse proxy (the documented public-exposure setup) every internet request
+// has a loopback peer, so loopback alone would hand the payload to anyone.
+// Used to gate GET /api/instance, whose payload (datadir, config and socket
+// paths) must never reach the network.
 func isLocalCtx(ctx context.Context) bool {
 	if IsLocalTrustedCtx(ctx) {
 		return true
+	}
+	if proxied, _ := ctx.Value(proxiedContextKey).(bool); proxied {
+		return false
 	}
 	addr, _ := ctx.Value(peerAddrContextKey).(string)
 	host, _, err := net.SplitHostPort(addr)

--- a/apps/runwisp/internal/server/proxy.go
+++ b/apps/runwisp/internal/server/proxy.go
@@ -68,6 +68,28 @@ func normalizeTrustProxyCIDR(raw string) (string, error) {
 	return cidr, nil
 }
 
+// isProxiedRequest reports whether the request looks relayed rather than
+// direct: it carries a hop header, or its peer is a configured trusted proxy.
+//
+// It exists because a loopback peer is not proof of a local client. The
+// documented public-exposure setup puts nginx / Caddy / Traefik / a Cloudflare
+// Tunnel on the same host forwarding to 127.0.0.1, so every internet request
+// arrives from loopback. Gates that mean "only a process on this machine" must
+// therefore reject proxied requests as well as non-loopback ones.
+//
+// Header presence is a heuristic, not a proof — a bare `proxy_pass` with no
+// proxy_set_header sends none of them — but every common proxy sets at least
+// one, and the local launcher probe sets none, so it closes the realistic cases
+// without costing the port-conflict UX.
+func isProxiedRequest(r *http.Request, trusted *xff.Options) bool {
+	for _, h := range forwardedHeaders {
+		if r.Header.Get(h) != "" {
+			return true
+		}
+	}
+	return isFromTrustedProxy(r, trusted)
+}
+
 // isFromTrustedProxy reports whether the request's TCP peer is within the
 // configured trusted-proxy CIDR set. It uses the original peer address
 // (captured by savePeerAddr) so that an attacker cannot inject a header to

--- a/apps/runwisp/internal/server/routes.go
+++ b/apps/runwisp/internal/server/routes.go
@@ -27,6 +27,15 @@ type contextKey string
 // trusted-proxy (XFF) middleware can overwrite r.RemoteAddr from headers.
 const peerAddrContextKey contextKey = "peerAddr"
 
+// proxiedContextKey stores whether the request reached the daemon through a
+// proxy, so that loopback-only gates can refuse a request whose loopback peer is
+// just a same-host reverse proxy relaying an internet client.
+const proxiedContextKey contextKey = "proxied"
+
+// forwardedHeaders are the hop headers whose presence means "someone relayed
+// this". Any one of them disqualifies a peer from counting as local.
+var forwardedHeaders = []string{"X-Forwarded-For", "X-Forwarded-Host", "X-Real-IP", "Forwarded", "CF-Connecting-IP"}
+
 // maxProtectedBodySize bounds request bodies on authenticated routes.
 // All currently-defined endpoints take parameters in the URL path only;
 // 1 MiB is a generous ceiling that keeps a misbehaving (or malicious) client
@@ -71,13 +80,15 @@ func authOrLocalTrusted(authSvc *auth.Service) func(http.Handler) http.Handler {
 	}
 }
 
-// savePeerAddr captures the original TCP peer address into context.
-// Must be registered before the trusted-proxy (XFF) middleware so that
-// security-critical loopback checks (isLocalRequest) use the real connection
-// address instead of the potentially-spoofed X-Real-IP / X-Forwarded-For value.
-func savePeerAddr(next http.Handler) http.Handler {
+// savePeerAddr captures the original TCP peer address into context, along with
+// whether the request was relayed by a proxy. Must be registered before the
+// trusted-proxy (XFF) middleware so that security-critical loopback checks
+// (isLocalCtx) use the real connection address instead of the
+// potentially-spoofed X-Real-IP / X-Forwarded-For value.
+func (srv *Server) savePeerAddr(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), peerAddrContextKey, r.RemoteAddr)
+		ctx = context.WithValue(ctx, proxiedContextKey, isProxiedRequest(r, srv.trustedProxies))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -113,7 +124,7 @@ func securityHeaders(next http.Handler) http.Handler {
 func (srv *Server) setupRoutes() error {
 	// savePeerAddr MUST be first: captures the raw TCP peer address before the
 	// trusted-proxy (XFF) middleware can overwrite r.RemoteAddr.
-	srv.router.Use(savePeerAddr)
+	srv.router.Use(srv.savePeerAddr)
 	if srv.trustedProxies != nil {
 		xffmw, err := xff.New(*srv.trustedProxies)
 		if err != nil {


### PR DESCRIPTION
Three fixes, all in the same shape: something reachable from outside the daemon could reach further than intended.

## `[daemon] allow_cloud_dispatch` now covers service env

A control-plane peer could set a TOML-defined service's `env` regardless of `allow_cloud_dispatch`. Since environment variables can change what a command actually executes (`NODE_OPTIONS`, `GIT_SSH_COMMAND`, `*_proxy`) and they overlay the inherited environment, `env` now requires the same opt-in as a command override.

The `instances`, restart, and log knobs are deliberately still ungated — those are what the control plane re-asserts on every reconnect, and gating them would break sync on a daemon that has dispatch turned off.

## Inline cloud executions can't overwrite a TOML task

Cloud-dispatched task names are `cloud-<id>` where the id comes from the peer, so a dispatch could collide with a task you'd defined in `runwisp.toml` named `cloud-…` and replace its definition. Collisions with a locally-defined task are now rejected.

## `/api/instance` no longer answers proxied requests

The endpoint is public and was gated on the caller being loopback. Behind a same-host reverse proxy — nginx, Caddy, Traefik, a Cloudflare Tunnel, the setup the docs recommend for public exposure — every request arrives from loopback, so the daemon's data dir, config path, and socket path were reachable without authenticating.

Requests that look relayed (a hop header is present, or the peer is in `RUNWISP_TRUST_PROXY`) no longer count as local. The port-conflict launcher sends no hop headers, so its behaviour is unchanged.

## Also

Documents how `arg` / `option` / `flag` parameters behave on a compose task that starts a fresh container: they take `docker compose run`'s COMMAND slot, so they replace the service's `command:` and arrive as arguments to the image's `ENTRYPOINT`.

---

No config changes are required. `CHANGELOG.md` has entries under **Security**, and each fix has a regression test that fails without it.