### PR TITLE
ci: deploy docs only on published stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,6 +382,23 @@ jobs:
         working-directory: npm/runwisp
         run: npm publish --access public --tag "${NPM_TAG}" --provenance
 
+  deploy-docs:
+    # Cloudflare Pages builds/deploys the docs site from its Git integration.
+    # Its production branch is `docs-release` (not `main`), so the docs only go
+    # live when we fast-forward that branch to a freshly published stable
+    # release — never on an ordinary main push or a prerelease.
+    if: github.event_name == 'release' && github.event.release.prerelease == false
+    name: Point docs-release at the release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Move docs-release to the released commit
+        run: git push origin "HEAD:refs/heads/docs-release" --force
+
   docker-publish:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     name: Publish Docker image (${{ matrix.base }})


### PR DESCRIPTION
Cloudflare Pages was rebuilding and redeploying the docs site on every push to `main`. This changes it so the live docs only update when a version is released.

## What changed
- New `deploy-docs` job in the release workflow. When a **stable** release is published (prereleases are skipped), it fast-forwards a dedicated `docs-release` branch to that release's tag commit.

## One-time setup required
Cloudflare Pages' **production branch** for the docs project must be changed from `main` → `docs-release`. Until then nothing about the current deploy behaviour changes.

The `docs-release` branch has already been created from the latest tag (`v0.13.2`), so the first CF build after the switch reflects the shipped release.