### PR TITLE
fix(cron): stop empty run= on bare descriptors, restore cron on mask failure

### DIFF
--- a/apps/runwisp/internal/autostart/crontakeover.go
+++ b/apps/runwisp/internal/autostart/crontakeover.go
@@ -113,23 +113,29 @@ func (s *systemdInstaller) resolveMaskedCronUnit(ctx context.Context, opts Insta
 // masking first would leave a window where a running cron could still fire
 // a job on the old schedule before the stop takes effect. It reports
 // whether cron was active beforehand so a failed RunWisp start can roll
-// back to exactly that state.
-func (s *systemdInstaller) stopAndMaskCron(ctx context.Context, unit string, out io.Writer) (wasActive bool, err error) {
+// back to exactly that state, and separately whether `systemctl stop`
+// itself succeeded: a probe or stop failure means cron was never actually
+// stopped, so the caller must not roll back a take-over that never took —
+// unmasking a unit that was never masked, or starting one that was never
+// stopped, would just poke cron for no reason.
+func (s *systemdInstaller) stopAndMaskCron(ctx context.Context, unit string, out io.Writer) (wasActive bool, stopped bool, err error) {
 	_, activeState, _, err := s.probeCronUnit(ctx, unit)
 	if err != nil {
-		return false, fmt.Errorf("systemctl show %s: %w", unit, err)
+		return false, false, fmt.Errorf("systemctl show %s: %w", unit, err)
 	}
 	wasActive = activeState == "active"
 
 	fmt.Fprintf(out, "Stopping %s\n", unit)
 	if _, stderr, err := s.runSystemctlSystem(ctx, "stop", unit); err != nil {
-		return wasActive, fmt.Errorf("systemctl stop %s: %w: %s", unit, err, string(stderr))
+		return wasActive, false, fmt.Errorf("systemctl stop %s: %w: %s", unit, err, string(stderr))
 	}
+	stopped = true
+
 	fmt.Fprintf(out, "Masking %s\n", unit)
 	if _, stderr, err := s.runSystemctlSystem(ctx, "mask", unit); err != nil {
-		return wasActive, fmt.Errorf("systemctl mask %s: %w: %s", unit, err, string(stderr))
+		return wasActive, stopped, fmt.Errorf("systemctl mask %s: %w: %s", unit, err, string(stderr))
 	}
-	return wasActive, nil
+	return wasActive, stopped, nil
 }
 
 // unmaskCron reverses stopAndMaskCron. mask is self-inverting — it writes a
@@ -178,9 +184,11 @@ func (s *systemdInstaller) reassertCronTakeover(ctx context.Context, opts Instal
 		return nil
 	}
 	fmt.Fprintf(out, "%s is back since the take-over — it and RunWisp are both running your jobs.\n", plan.CronUnit)
-	cronWasActive, err := s.stopAndMaskCron(ctx, plan.CronUnit, out)
+	cronWasActive, stopped, err := s.stopAndMaskCron(ctx, plan.CronUnit, out)
 	if err != nil {
-		s.rollbackCronTakeover(ctx, opts, plan, cronWasActive, out)
+		if stopped {
+			s.rollbackCronTakeover(ctx, opts, plan, cronWasActive, out)
+		}
 		return fmt.Errorf("take over cron: %w", err)
 	}
 	// The unit was already on disk, but nothing so far proves the service is

--- a/apps/runwisp/internal/autostart/crontakeover.go
+++ b/apps/runwisp/internal/autostart/crontakeover.go
@@ -180,6 +180,7 @@ func (s *systemdInstaller) reassertCronTakeover(ctx context.Context, opts Instal
 	fmt.Fprintf(out, "%s is back since the take-over — it and RunWisp are both running your jobs.\n", plan.CronUnit)
 	cronWasActive, err := s.stopAndMaskCron(ctx, plan.CronUnit, out)
 	if err != nil {
+		s.rollbackCronTakeover(ctx, opts, plan, cronWasActive, out)
 		return fmt.Errorf("take over cron: %w", err)
 	}
 	// The unit was already on disk, but nothing so far proves the service is

--- a/apps/runwisp/internal/autostart/crontakeover.go
+++ b/apps/runwisp/internal/autostart/crontakeover.go
@@ -118,7 +118,7 @@ func (s *systemdInstaller) resolveMaskedCronUnit(ctx context.Context, opts Insta
 // stopped, so the caller must not roll back a take-over that never took —
 // unmasking a unit that was never masked, or starting one that was never
 // stopped, would just poke cron for no reason.
-func (s *systemdInstaller) stopAndMaskCron(ctx context.Context, unit string, out io.Writer) (wasActive bool, stopped bool, err error) {
+func (s *systemdInstaller) stopAndMaskCron(ctx context.Context, unit string, out io.Writer) (wasActive, stopped bool, err error) {
 	_, activeState, _, err := s.probeCronUnit(ctx, unit)
 	if err != nil {
 		return false, false, fmt.Errorf("systemctl show %s: %w", unit, err)

--- a/apps/runwisp/internal/autostart/crontakeover_test.go
+++ b/apps/runwisp/internal/autostart/crontakeover_test.go
@@ -253,6 +253,98 @@ func TestApplyInstall_TakeOverCron_NoRestartWhenCronWasAlreadyStopped(t *testing
 	assert.NotContains(t, out.String(), "Starting cron.service")
 }
 
+// TestApplyInstall_TakeOverCron_RollsBackOnMaskFailure is the regression for the
+// bug where a successful `stop` followed by a failed `mask` left the box with
+// cron stopped, unmasked, and never restarted — no scheduler running at all —
+// because the error from stopAndMaskCron short-circuited the install before any
+// rollback ran. It must restore cron the same way a failed `enable --now`
+// already does.
+func TestApplyInstall_TakeOverCron_RollsBackOnMaskFailure(t *testing.T) {
+	inst, fs, cmd, prompter, binary := newFakeInstaller(t, false)
+	inst.deps.Euid = 0
+	opts := systemInstallOpts(binary)
+	opts.TakeOverCron = true
+	prompter.YesNo = []bool{true}
+	require.NoError(t, fs.WriteFile(opts.Config, []byte("[scheduler]\n"), 0644))
+
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		[]byte("loaded\nactive\nenabled\n"), nil, nil)
+	cmd.Expect("systemctl", []string{"daemon-reload"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		[]byte("loaded\nactive\nenabled\n"), nil, nil)
+	cmd.Expect("systemctl", []string{"stop", "cron.service"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"mask", "cron.service"},
+		nil, []byte("Failed to mask unit: access denied"), assertErrFake("mask failed"))
+	// Rollback: cron was active before, so unmask AND start it again — `enable
+	// --now` for RunWisp is never reached.
+	cmd.Expect("systemctl", []string{"unmask", "cron.service"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"start", "cron.service"}, nil, nil, nil)
+
+	out := &bytes.Buffer{}
+	err := inst.Install(context.Background(), opts, out)
+	require.Error(t, err)
+	assert.Zero(t, cmd.Remaining(), "rollback must run every scripted call")
+	assert.Contains(t, out.String(), "Unmasking cron.service")
+	assert.Contains(t, out.String(), "Starting cron.service")
+}
+
+// TestApplyInstall_TakeOverCron_MaskFailureNoRestartWhenCronWasAlreadyStopped
+// is the other half: the rollback restores the prior scheduler state, which
+// means it must NOT start cron back up when cron was already inactive before
+// the take-over began.
+func TestApplyInstall_TakeOverCron_MaskFailureNoRestartWhenCronWasAlreadyStopped(t *testing.T) {
+	inst, fs, cmd, prompter, binary := newFakeInstaller(t, false)
+	inst.deps.Euid = 0
+	opts := systemInstallOpts(binary)
+	opts.TakeOverCron = true
+	prompter.YesNo = []bool{true}
+	require.NoError(t, fs.WriteFile(opts.Config, []byte("[scheduler]\n"), 0644))
+
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		[]byte("loaded\ninactive\nenabled\n"), nil, nil)
+	cmd.Expect("systemctl", []string{"daemon-reload"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		[]byte("loaded\ninactive\nenabled\n"), nil, nil)
+	cmd.Expect("systemctl", []string{"stop", "cron.service"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"mask", "cron.service"},
+		nil, []byte("Failed to mask unit: access denied"), assertErrFake("mask failed"))
+	cmd.Expect("systemctl", []string{"unmask", "cron.service"}, nil, nil, nil)
+
+	out := &bytes.Buffer{}
+	err := inst.Install(context.Background(), opts, out)
+	require.Error(t, err)
+	assert.Zero(t, cmd.Remaining(), "no start call scripted — must not be attempted for already-inactive cron")
+	assert.NotContains(t, out.String(), "Starting cron.service")
+}
+
+// TestInstall_NoopReassertRollsBackOnMaskFailure covers the other caller of the
+// same stopAndMaskCron helper: the reassert/no-op repair path taken when cron
+// has come back since a completed take-over. It must roll back on a mask
+// failure exactly like a fresh install does.
+func TestInstall_NoopReassertRollsBackOnMaskFailure(t *testing.T) {
+	inst, fs, cmd, _, binary := newFakeInstaller(t, false)
+	inst.deps.Euid = 0
+	opts := systemInstallOpts(binary)
+	opts.TakeOverCron = true
+	takenOverUnitOnDisk(t, inst, fs, opts)
+
+	for range 3 {
+		cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+			[]byte("loaded\nactive\nenabled\n"), nil, nil)
+	}
+	cmd.Expect("systemctl", []string{"stop", "cron.service"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"mask", "cron.service"},
+		nil, []byte("Failed to mask unit: access denied"), assertErrFake("mask failed"))
+	cmd.Expect("systemctl", []string{"unmask", "cron.service"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"start", "cron.service"}, nil, nil, nil)
+
+	out := &bytes.Buffer{}
+	require.Error(t, inst.Install(context.Background(), opts, out))
+	assert.Zero(t, cmd.Remaining(), "rollback must run every scripted call")
+	assert.Contains(t, out.String(), "Unmasking cron.service")
+	assert.Contains(t, out.String(), "Starting cron.service")
+}
+
 // takenOverUnitOnDisk writes the unit a completed take-over leaves behind, so
 // ComputePlan sees no drift and returns PlanNoop — the state `runwisp takeover`
 // finds on a box it has already been run on.

--- a/apps/runwisp/internal/autostart/crontakeover_test.go
+++ b/apps/runwisp/internal/autostart/crontakeover_test.go
@@ -253,6 +253,60 @@ func TestApplyInstall_TakeOverCron_NoRestartWhenCronWasAlreadyStopped(t *testing
 	assert.NotContains(t, out.String(), "Starting cron.service")
 }
 
+// TestApplyInstall_TakeOverCron_NoRollbackOnStopFailure is the B2 correction:
+// a failed `systemctl stop` means cron was never actually stopped or masked,
+// so there is nothing for the rollback to undo. Unmasking (or starting) a
+// unit that was never touched would just poke cron for no reason.
+func TestApplyInstall_TakeOverCron_NoRollbackOnStopFailure(t *testing.T) {
+	inst, fs, cmd, prompter, binary := newFakeInstaller(t, false)
+	inst.deps.Euid = 0
+	opts := systemInstallOpts(binary)
+	opts.TakeOverCron = true
+	prompter.YesNo = []bool{true}
+	require.NoError(t, fs.WriteFile(opts.Config, []byte("[scheduler]\n"), 0644))
+
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		[]byte("loaded\nactive\nenabled\n"), nil, nil)
+	cmd.Expect("systemctl", []string{"daemon-reload"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		[]byte("loaded\nactive\nenabled\n"), nil, nil)
+	cmd.Expect("systemctl", []string{"stop", "cron.service"},
+		nil, []byte("Failed to stop unit: access denied"), assertErrFake("stop failed"))
+
+	out := &bytes.Buffer{}
+	err := inst.Install(context.Background(), opts, out)
+	require.Error(t, err)
+	assert.Zero(t, cmd.Remaining(), "no mask, unmask, or start scripted — none must be attempted")
+	assert.NotContains(t, out.String(), "Masking")
+	assert.NotContains(t, out.String(), "Unmasking")
+	assert.NotContains(t, out.String(), "Starting cron.service")
+}
+
+// TestApplyInstall_TakeOverCron_NoRollbackOnProbeFailure is the other half:
+// the re-probe inside stopAndMaskCron fails before `stop` is ever attempted,
+// so cron was never touched at all.
+func TestApplyInstall_TakeOverCron_NoRollbackOnProbeFailure(t *testing.T) {
+	inst, fs, cmd, prompter, binary := newFakeInstaller(t, false)
+	inst.deps.Euid = 0
+	opts := systemInstallOpts(binary)
+	opts.TakeOverCron = true
+	prompter.YesNo = []bool{true}
+	require.NoError(t, fs.WriteFile(opts.Config, []byte("[scheduler]\n"), 0644))
+
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		[]byte("loaded\nactive\nenabled\n"), nil, nil)
+	cmd.Expect("systemctl", []string{"daemon-reload"}, nil, nil, nil)
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		nil, []byte("connection refused"), assertErrFake("probe failed"))
+
+	out := &bytes.Buffer{}
+	err := inst.Install(context.Background(), opts, out)
+	require.Error(t, err)
+	assert.Zero(t, cmd.Remaining(), "no stop, mask, unmask, or start scripted — none must be attempted")
+	assert.NotContains(t, out.String(), "Stopping")
+	assert.NotContains(t, out.String(), "Unmasking")
+}
+
 // TestApplyInstall_TakeOverCron_RollsBackOnMaskFailure is the regression for the
 // bug where a successful `stop` followed by a failed `mask` left the box with
 // cron stopped, unmasked, and never restarted — no scheduler running at all —
@@ -343,6 +397,53 @@ func TestInstall_NoopReassertRollsBackOnMaskFailure(t *testing.T) {
 	assert.Zero(t, cmd.Remaining(), "rollback must run every scripted call")
 	assert.Contains(t, out.String(), "Unmasking cron.service")
 	assert.Contains(t, out.String(), "Starting cron.service")
+}
+
+// TestInstall_NoopReassertNoRollbackOnStopFailure is the reassert-path half of
+// the same B2 correction: a failed `systemctl stop` during the repair means
+// cron was never actually stopped or masked, so there is nothing to roll back.
+func TestInstall_NoopReassertNoRollbackOnStopFailure(t *testing.T) {
+	inst, fs, cmd, _, binary := newFakeInstaller(t, false)
+	inst.deps.Euid = 0
+	opts := systemInstallOpts(binary)
+	opts.TakeOverCron = true
+	takenOverUnitOnDisk(t, inst, fs, opts)
+
+	for range 3 {
+		cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+			[]byte("loaded\nactive\nenabled\n"), nil, nil)
+	}
+	cmd.Expect("systemctl", []string{"stop", "cron.service"},
+		nil, []byte("Failed to stop unit: access denied"), assertErrFake("stop failed"))
+
+	out := &bytes.Buffer{}
+	require.Error(t, inst.Install(context.Background(), opts, out))
+	assert.Zero(t, cmd.Remaining(), "no mask, unmask, or start scripted — none must be attempted")
+	assert.NotContains(t, out.String(), "Unmasking")
+	assert.NotContains(t, out.String(), "Starting cron.service")
+}
+
+// TestInstall_NoopReassertNoRollbackOnProbeFailure covers the probe-failure
+// half: stopAndMaskCron's own re-probe fails before `stop` is ever attempted.
+func TestInstall_NoopReassertNoRollbackOnProbeFailure(t *testing.T) {
+	inst, fs, cmd, _, binary := newFakeInstaller(t, false)
+	inst.deps.Euid = 0
+	opts := systemInstallOpts(binary)
+	opts.TakeOverCron = true
+	takenOverUnitOnDisk(t, inst, fs, opts)
+
+	for range 2 {
+		cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+			[]byte("loaded\nactive\nenabled\n"), nil, nil)
+	}
+	cmd.Expect("systemctl", []string{"show", "-p", "LoadState,ActiveState,UnitFileState", "--value", "cron.service"},
+		nil, []byte("connection refused"), assertErrFake("probe failed"))
+
+	out := &bytes.Buffer{}
+	require.Error(t, inst.Install(context.Background(), opts, out))
+	assert.Zero(t, cmd.Remaining(), "no stop, mask, unmask, or start scripted — none must be attempted")
+	assert.NotContains(t, out.String(), "Stopping")
+	assert.NotContains(t, out.String(), "Unmasking")
 }
 
 // takenOverUnitOnDisk writes the unit a completed take-over leaves behind, so

--- a/apps/runwisp/internal/autostart/systemd_linux.go
+++ b/apps/runwisp/internal/autostart/systemd_linux.go
@@ -345,27 +345,32 @@ func (s *systemdInstaller) enableLingerIfNeeded(ctx context.Context, opts Instal
 }
 
 // takeOverCronIfRequested stops and masks the detected cron unit when the
-// caller asked for a take-over.
+// caller asked for a take-over. A stop that lands but a mask that fails would
+// otherwise leave the box with cron stopped, unmasked, and never restarted —
+// no scheduler at all — so a failure here rolls back the same way a failed
+// `enable --now` does, before the error reaches the caller.
 func (s *systemdInstaller) takeOverCronIfRequested(ctx context.Context, opts InstallOptions, plan Plan, out io.Writer) (bool, error) {
 	if !opts.TakeOverCron {
 		return false, nil
 	}
 	cronWasActive, err := s.stopAndMaskCron(ctx, plan.CronUnit, out)
 	if err != nil {
+		s.rollbackCronTakeover(ctx, opts, plan, cronWasActive, out)
 		return false, fmt.Errorf("take over cron: %w", err)
 	}
 	return cronWasActive, nil
 }
 
-// rollbackCronTakeover restores cron after `enable --now` fails. Best-effort:
-// the install has already failed, so a restore failure gets a warning rather
-// than masking the original error.
+// rollbackCronTakeover restores cron after a take-over step fails partway —
+// either stopAndMaskCron itself, or a later `enable --now`. Best-effort: the
+// install has already failed, so a restore failure gets a warning rather than
+// masking the original error.
 func (s *systemdInstaller) rollbackCronTakeover(ctx context.Context, opts InstallOptions, plan Plan, cronWasActive bool, out io.Writer) {
 	if !opts.TakeOverCron {
 		return
 	}
 	if rbErr := s.unmaskCron(ctx, plan.CronUnit, cronWasActive, out); rbErr != nil {
-		fmt.Fprintf(out, "Warning: RunWisp failed to start AND cron could not be restored: %v\n", rbErr)
+		fmt.Fprintf(out, "Warning: cron could not be restored: %v\n", rbErr)
 		fmt.Fprintf(out, "Warning: run 'sudo systemctl unmask %s' by hand to bring back a scheduler.\n", plan.CronUnit)
 	}
 }

--- a/apps/runwisp/internal/autostart/systemd_linux.go
+++ b/apps/runwisp/internal/autostart/systemd_linux.go
@@ -348,14 +348,19 @@ func (s *systemdInstaller) enableLingerIfNeeded(ctx context.Context, opts Instal
 // caller asked for a take-over. A stop that lands but a mask that fails would
 // otherwise leave the box with cron stopped, unmasked, and never restarted —
 // no scheduler at all — so a failure here rolls back the same way a failed
-// `enable --now` does, before the error reaches the caller.
+// `enable --now` does, before the error reaches the caller. A failure before
+// a successful stop (the initial probe, or the stop itself) means cron was
+// never touched, so there is nothing to roll back — doing so anyway would
+// unmask or start a unit RunWisp never masked or stopped.
 func (s *systemdInstaller) takeOverCronIfRequested(ctx context.Context, opts InstallOptions, plan Plan, out io.Writer) (bool, error) {
 	if !opts.TakeOverCron {
 		return false, nil
 	}
-	cronWasActive, err := s.stopAndMaskCron(ctx, plan.CronUnit, out)
+	cronWasActive, stopped, err := s.stopAndMaskCron(ctx, plan.CronUnit, out)
 	if err != nil {
-		s.rollbackCronTakeover(ctx, opts, plan, cronWasActive, out)
+		if stopped {
+			s.rollbackCronTakeover(ctx, opts, plan, cronWasActive, out)
+		}
 		return false, fmt.Errorf("take over cron: %w", err)
 	}
 	return cronWasActive, nil

--- a/apps/runwisp/internal/config/cronsource_test.go
+++ b/apps/runwisp/internal/config/cronsource_test.go
@@ -860,6 +860,35 @@ include_cron = ["crontabs/*"]
 	assert.Empty(t, cfg.CronFindings, "and nothing to warn about")
 }
 
+// TestIncludeCron_BareDescriptorNoCommandIsSkippedNotEmptyRun guards the live
+// include_cron path against a bare descriptor (`@daily` with nothing after it)
+// becoming a task with `run = ""`. crond never runs a descriptor with no
+// command — RunWisp must treat the line the same way it treats any other
+// unparseable line: skipped and reported, with the rest of the file still
+// loading.
+func TestIncludeCron_BareDescriptorNoCommandIsSkippedNotEmptyRun(t *testing.T) {
+	dir := writeFileTree(t, map[string]string{
+		"runwisp.toml": `
+[daemon]
+include_cron = ["crontabs/*"]
+`,
+		"crontabs/jobs": "@daily\n0 3 * * * /usr/local/bin/good.sh\n",
+	})
+
+	cfg := loadTree(t, dir)
+	assert.Equal(t, []string{"good"}, taskNames(cfg))
+	for _, task := range cfg.Tasks {
+		assert.NotEmpty(t, task.Run, "task %q must not have an empty run command", task.Name)
+	}
+
+	require.Len(t, cfg.CronFindings, 1)
+	skip := cfg.CronFindings[0]
+	assert.True(t, skip.Skipped)
+	assert.Empty(t, skip.Task, "a job that isn't running has no task name")
+	assert.Equal(t, 1, skip.Line)
+	assert.Equal(t, "@daily", skip.Source)
+}
+
 // stubCronServiceProbe replaces the systemctl-backed liveness probe for the
 // duration of one test, so a test can assert both branches (active/enabled
 // via the init system, and the pid-file fallback when it's unavailable)

--- a/apps/runwisp/internal/importer/cron.go
+++ b/apps/runwisp/internal/importer/cron.go
@@ -466,6 +466,8 @@ func splitCronJobLine(line string, system bool) (cronJobLine, bool) {
 				return cronJobLine{}, false // a user column with no command isn't a job
 			}
 			j.user, j.command = userTok[0], command
+		} else if rest == "" {
+			return cronJobLine{}, false // a descriptor with no command isn't a job
 		}
 		return j, true
 	}

--- a/apps/runwisp/internal/importer/cron_test.go
+++ b/apps/runwisp/internal/importer/cron_test.go
@@ -105,6 +105,31 @@ func TestCronReboot(t *testing.T) {
 	}
 }
 
+// TestCronBareDescriptorNoCommandIsUnparseable: a per-user crontab line that is
+// just a descriptor with no trailing command (`@daily` with nothing after it) is
+// not a job crond would ever run — it must become an unparseable-line note, not
+// a task with an empty `run`. A valid job elsewhere in the file must still
+// import.
+func TestCronBareDescriptorNoCommandIsUnparseable(t *testing.T) {
+	res := parseCron(t, "@daily\n0 3 * * * /bin/good\n", CronOptions{})
+	out := res.TOML()
+	mustNotContain(t, out, `run = ""`)
+	mustContain(t, out, "[tasks.good]")
+	mustContain(t, out, `run = "/bin/good"`)
+
+	items := res.Items()
+	if len(items) != 2 {
+		t.Fatalf("expected two report rows, got %+v", items)
+	}
+	if got := items[0].Status(); got != StatusBlocked {
+		t.Errorf("status of the bare descriptor = %v, want blocked", got)
+	}
+	if got := items[0].Source; got != "@daily" {
+		t.Errorf("Source = %q, want the line verbatim", got)
+	}
+	findNote(t, res, NoteLineUnparseable)
+}
+
 func TestCronDescriptors(t *testing.T) {
 	res := parseCron(t, "@daily /bin/rotate\n@midnight /bin/nightly\n@annually /bin/yearly\n", CronOptions{})
 	out := res.TOML()


### PR DESCRIPTION
## Summary

Two fixes in the crond-takeover path:

- **Importer**: a per-user crontab line that is only a schedule descriptor with no trailing command (e.g. a bare `@daily`) was accepted by `splitCronJobLine` and emitted as a task with `run = ""`, instead of being treated as an unparseable line like any other malformed entry. The system-crontab form already guarded against this (empty command after the user column); the per-user form did not.
- **Cron takeover**: `stopAndMaskCron` stops the cron unit, then masks it. If `stop` succeeds but `mask` fails, both callers (`takeOverCronIfRequested` for a fresh install, and `reassertCronTakeover` for the reassert/no-op repair path) returned the error immediately without restoring cron — leaving the box with cron stopped, unmasked, and never restarted. Both now roll back through the existing unmask+restart path already used when a later `enable --now` fails, restoring whatever state cron was in before the takeover began (and correctly not restarting it if it was already inactive).

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go test ./internal/importer ./internal/config ./internal/autostart` (from `apps/runwisp`) — pass
- [x] `go build ./...` and `go vet ./...` (from `apps/runwisp`) — clean
- [x] `go test ./...` (from `apps/runwisp`) — all packages pass except a pre-existing flaky e2e test (`TestCLIImportThenPromote`) that fails identically on `origin/main` before this change, unrelated to this diff
- [x] Verified each new test fails against the pre-fix code and passes against the fix