### PR TITLE
Default [daemon] tls to "off" instead of "auto"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`runwisp import cron` now scopes a crontab's settings to that crontab's own tasks**, instead of applying them globally. See [How cron maps to TOML](https://docs.runwisp.com/replacing-cron/cron-mapping/#the-mapping-table).
 - **Imported jobs skip catch-up runs, like cron did** — a missed run is still recorded, just not re-fired. See [How cron maps to TOML](https://docs.runwisp.com/replacing-cron/cron-mapping/#the-mapping-table).
 - **`runwisp import --quiet` now only silences clean imports** — jobs that need a fix are still listed. See [CLI](https://docs.runwisp.com/operations/cli/#migrate-an-existing-setup).
+- **`[daemon] tls` now defaults to `"off"`.** A non-loopback bind used to self-sign a certificate and serve HTTPS automatically; it now serves plain HTTP unless you opt in with `tls = "auto"` (self-signed HTTPS) or supply `tls_cert`/`tls_key`. See [`[daemon]`](https://docs.runwisp.com/configuration/daemon/#tls-tls_cert-tls_key).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Full configuration reference, REST API docs, and operational guides live at **[d
 **Operations**
 
 - Single Go binary, zero runtime dependencies. No Python, no Node.js, no external database.
-- HTTPS by default off loopback — bind beyond `127.0.0.1` and RunWisp self-signs a cert and serves TLS with no setup; bring your own cert (`tls_cert`/`tls_key`) or front it with a reverse proxy ([`[daemon]`](https://docs.runwisp.com/configuration/daemon/#tls-tls_cert-tls_key))
+- Optional self-signed HTTPS with one setting — `tls = "auto"` and RunWisp self-signs a cert and serves TLS the moment you bind beyond `127.0.0.1`, no setup; bring your own cert (`tls_cert`/`tls_key`) or front it with a reverse proxy ([`[daemon]`](https://docs.runwisp.com/configuration/daemon/#tls-tls_cert-tls_key))
 - ~25 MB RAM idle, happy on a $5 VPS, a Raspberry Pi, or alongside your real workload
 - Crash-safe: `kill -9` and power loss are recoverable; in-flight runs are marked **interrupted** on restart, never silently lost
 - Local-first, offline-complete. No signup, no telemetry, no account required.

--- a/apps/docs/src/agents/reference.md
+++ b/apps/docs/src/agents/reference.md
@@ -258,9 +258,9 @@ opt out         `set +e` as the script's first line; no TOML key exists for this
 
 Persistent flags: `-c/--config` (=`runwisp.toml`, or `/etc/runwisp/runwisp.toml` at euid 0), `--data` (=`.runwisp`, or `/var/lib/runwisp` at euid 0), `-p/--port` (=`9477`), `--host` (=`127.0.0.1`), `--log-level` (debug|info|warn|error), `--log-format` (auto|text|json). Each has an env fallback the flag wins over: `RUNWISP_CONFIG`, `RUNWISP_DATA`, `RUNWISP_PORT`, `RUNWISP_HOST`, `RUNWISP_LOG_LEVEL`, `RUNWISP_LOG_FORMAT`.
 Precedence for `-c`/`--data`: explicit flag > `RUNWISP_CONFIG`/`RUNWISP_DATA` env var > euid-derived default.
-Env: `RUNWISP_PASSWORD` (else ephemeral per-boot), `RUNWISP_NO_AUTH` (1/true disables auth; mutually exclusive with RUNWISP_PASSWORD), `RUNWISP_TLS` (auto|off; overrides `[daemon] tls`, applied on every load incl. reload), `RUNWISP_TRUST_PROXY` (CIDRs), `RUNWISP_CLOUD_TOKEN`, `RUNWISP_CLOUD_URL`.
+Env: `RUNWISP_PASSWORD` (else ephemeral per-boot), `RUNWISP_NO_AUTH` (1/true disables auth; mutually exclusive with RUNWISP_PASSWORD), `RUNWISP_TLS` (auto|off; overrides `[daemon] tls`, default `off`, applied on every load incl. reload), `RUNWISP_TRUST_PROXY` (CIDRs), `RUNWISP_CLOUD_TOKEN`, `RUNWISP_CLOUD_URL`.
 
-Official Docker image: `runwisp/runwisp` (alpine default + `-debian` variant, amd64/arm64). Binds `0.0.0.0`, `RUNWISP_TLS=off`, requires `RUNWISP_PASSWORD` or `RUNWISP_NO_AUTH=1` set or the entrypoint refuses to start; mount config at `/etc/runwisp/runwisp.toml` and data at `/var/lib/runwisp`. See https://docs.runwisp.com/getting-started/docker/.
+Official Docker image: `runwisp/runwisp` (alpine default + `-debian` variant, amd64/arm64). Binds `0.0.0.0`, plain HTTP (daemon's `[daemon] tls` default of `off`; set `-e RUNWISP_TLS=auto` to opt into self-signed HTTPS), requires `RUNWISP_PASSWORD` or `RUNWISP_NO_AUTH=1` set or the entrypoint refuses to start; mount config at `/etc/runwisp/runwisp.toml` and data at `/var/lib/runwisp`. See https://docs.runwisp.com/getting-started/docker/.
 
 ```
 runwisp                      — no subcommand: attach TUI to running daemon, else scaffold toml + spawn daemon + attach

--- a/apps/docs/src/content/docs/configuration/daemon.mdx
+++ b/apps/docs/src/content/docs/configuration/daemon.mdx
@@ -23,7 +23,7 @@ since in practice you tend to think about them together.
 [daemon]
 shutdown_timeout = "10s"
 external_url     = "https://runwisp.example.com"
-tls              = "auto"
+tls              = "off"
 tls_cert         = ""
 tls_key          = ""
 metrics_enabled  = false
@@ -32,17 +32,17 @@ include          = ["conf.d/*.toml"]
 # include_cron   = ["/etc/crontab", "/etc/cron.d/*"]
 ```
 
-| Key                | Default  | What it does                                                                                                                                                                                                                                        |
-| ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `shutdown_timeout` | `"10s"`  | Whole-daemon shutdown budget. After `SIGTERM`, the daemon SIGKILLs any in-flight runs that haven't exited within this window so the process can actually exit.                                                                                      |
-| `external_url`     | _unset_  | Public base URL of this daemon's Web UI. When set, notification messages (Slack, Telegram) include a deep-link back to the run; when unset, the link line is omitted.                                                                               |
-| `tls`              | `"auto"` | `"auto"` serves HTTPS automatically whenever the bind address is non-loopback (self-signing a cert on first boot); `"off"` always serves plain HTTP. Loopback binds stay HTTP either way. Ignored when `tls_cert`/`tls_key` are set.                |
-| `tls_cert`         | _unset_  | Path to a PEM certificate to serve instead of the self-signed one. Set together with `tls_key`. When set, HTTPS is served on every bind address, loopback included.                                                                                 |
-| `tls_key`          | _unset_  | Path to the PEM private key matching `tls_cert`. Both keys are set together or not at all.                                                                                                                                                          |
-| `metrics_enabled`  | `false`  | Master switch for the Prometheus-compatible `/metrics` endpoint. Off by default — task names and the daemon version label are visible to anyone who can reach the endpoint, so it stays closed until you turn it on.                                |
-| `metrics_listen`   | _unset_  | Optional `host:port` for a dedicated metrics listener (e.g. `"127.0.0.1:9478"`). When set, `/metrics` is **only** reachable on this address — never on the main UI/REST listener. Only consulted when `metrics_enabled = true`.                     |
-| `include`          | _unset_  | Glob patterns for extra TOML files to merge into this config at load. Lets you split tasks across `conf.d/*.toml` instead of one giant file. Only valid in the root config.                                                                         |
-| `include_cron`     | _unset_  | Glob patterns for real crontabs (system, `cron.d`, or per-user spool) to read as live task definitions at every load and reload. Point RunWisp at what cron already reads instead of converting everything up front. Only valid in the root config. |
+| Key                | Default | What it does                                                                                                                                                                                                                                        |
+| ------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shutdown_timeout` | `"10s"` | Whole-daemon shutdown budget. After `SIGTERM`, the daemon SIGKILLs any in-flight runs that haven't exited within this window so the process can actually exit.                                                                                      |
+| `external_url`     | _unset_ | Public base URL of this daemon's Web UI. When set, notification messages (Slack, Telegram) include a deep-link back to the run; when unset, the link line is omitted.                                                                               |
+| `tls`              | `"off"` | `"off"` always serves plain HTTP; `"auto"` serves HTTPS whenever the bind address is non-loopback (self-signing a cert on first boot). Loopback binds stay HTTP either way. Ignored when `tls_cert`/`tls_key` are set.                              |
+| `tls_cert`         | _unset_ | Path to a PEM certificate to serve instead of the self-signed one. Set together with `tls_key`. When set, HTTPS is served on every bind address, loopback included.                                                                                 |
+| `tls_key`          | _unset_ | Path to the PEM private key matching `tls_cert`. Both keys are set together or not at all.                                                                                                                                                          |
+| `metrics_enabled`  | `false` | Master switch for the Prometheus-compatible `/metrics` endpoint. Off by default — task names and the daemon version label are visible to anyone who can reach the endpoint, so it stays closed until you turn it on.                                |
+| `metrics_listen`   | _unset_ | Optional `host:port` for a dedicated metrics listener (e.g. `"127.0.0.1:9478"`). When set, `/metrics` is **only** reachable on this address — never on the main UI/REST listener. Only consulted when `metrics_enabled = true`.                     |
+| `include`          | _unset_ | Glob patterns for extra TOML files to merge into this config at load. Lets you split tasks across `conf.d/*.toml` instead of one giant file. Only valid in the root config.                                                                         |
+| `include_cron`     | _unset_ | Glob patterns for real crontabs (system, `cron.d`, or per-user spool) to read as live task definitions at every load and reload. Point RunWisp at what cron already reads instead of converting everything up front. Only valid in the root config. |
 
 ### `shutdown_timeout`
 
@@ -78,17 +78,21 @@ than print a broken URL.
 
 ### `tls`, `tls_cert`, `tls_key`
 
-RunWisp serves HTTPS by itself, with no certificate to obtain and nothing
-to wire up. The rule is simple: **the moment you bind somewhere other than
-loopback, the channel is encrypted.**
+By default RunWisp serves plain HTTP on every bind address, loopback or
+not. Set `tls = "auto"` and it'll serve HTTPS by itself instead, with no
+certificate to obtain and nothing to wire up:
 
-- **Loopback (`--host 127.0.0.1`, the default):** plain HTTP. There's
-  nothing on the wire to eavesdrop, and `curl http://localhost:9477` just
-  works for local dev.
+- **Loopback (`--host 127.0.0.1`, the default):** stays plain HTTP even
+  with `tls = "auto"`. There's nothing on the wire to eavesdrop, and
+  `curl http://localhost:9477` just works for local dev.
 - **Non-loopback (`--host 0.0.0.0`, a LAN IP, …) with `tls = "auto"`:**
   the daemon generates a long-lived self-signed certificate on first boot,
   stores it under `<data>/tls/`, and serves HTTPS. Auth cookies and CHAP
   responses never cross a real network in cleartext.
+
+Leave `tls` unset (or `"off"`) and a non-loopback bind serves plain HTTP —
+the daemon prints a loud startup banner when it does, since that's the
+one case where auth tokens really can cross a real network in the clear.
 
 Because the cert is self-signed, the first browser visit shows the usual
 "not trusted" warning, and the CLI/TUI pin the cert on first connect
@@ -110,7 +114,7 @@ PEM pair — a cert from your internal CA, say, or one a tool like `mkcert`
 made. Supplying a pair forces HTTPS on every bind address (loopback
 included) and skips the self-signed flow entirely.
 
-**Turn it off** with `tls = "off"` when something else already terminates
+**Leave it off** (the default) when something else already terminates
 TLS — most commonly a reverse proxy (nginx, Caddy, Traefik) doing TLS out
 front and forwarding plain HTTP to RunWisp on a private network. In that
 case set `RUNWISP_TRUST_PROXY` to the proxy's CIDR so the daemon honours

--- a/apps/docs/src/content/docs/getting-started/docker.mdx
+++ b/apps/docs/src/content/docs/getting-started/docker.mdx
@@ -294,13 +294,13 @@ docker run --rm -v ./runwisp.toml:/etc/runwisp/runwisp.toml:ro \
 Everything else the image presets is a container-appropriate default you
 can override with a normal `-e`:
 
-| Variable             | Image default               | Why                                                                                                                  |
-| -------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `RUNWISP_CONFIG`     | `/etc/runwisp/runwisp.toml` | Where the entrypoint looks for your mounted config.                                                                  |
-| `RUNWISP_DATA`       | `/var/lib/runwisp`          | SQLite database, per-task logs, and the control socket — mount a volume here so state survives a container recreate. |
-| `RUNWISP_HOST`       | `0.0.0.0`                   | Containers need a non-loopback bind for port mapping to reach anything.                                              |
-| `RUNWISP_TLS`        | `off`                       | See [Plain HTTP by default](#plain-http-by-default).                                                                 |
-| `RUNWISP_LOG_FORMAT` | `text`                      | Human-readable `docker logs`. Set `json` if something downstream parses them.                                        |
+| Variable             | Image default                      | Why                                                                                                                  |
+| -------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `RUNWISP_CONFIG`     | `/etc/runwisp/runwisp.toml`        | Where the entrypoint looks for your mounted config.                                                                  |
+| `RUNWISP_DATA`       | `/var/lib/runwisp`                 | SQLite database, per-task logs, and the control socket — mount a volume here so state survives a container recreate. |
+| `RUNWISP_HOST`       | `0.0.0.0`                          | Containers need a non-loopback bind for port mapping to reach anything.                                              |
+| `RUNWISP_TLS`        | _unset_ (daemon defaults to `off`) | See [Plain HTTP by default](#plain-http-by-default).                                                                 |
+| `RUNWISP_LOG_FORMAT` | `text`                             | Human-readable `docker logs`. Set `json` if something downstream parses them.                                        |
 
 Prefer `-e RUNWISP_DATA=…` over `--data` on the command line. Both reach
 the daemon, but the healthcheck reads only the environment, so a flag
@@ -333,17 +333,16 @@ if you'd rather supply your own.
 
 ## Plain HTTP by default
 
-Outside a container, RunWisp's [auto-TLS](/configuration/daemon/#tls-tls_cert-tls_key)
-generates a self-signed certificate the moment you bind anywhere other
-than loopback. Good default on a bare host, wrong one here, where a
-reverse proxy is usually already terminating TLS. So the image sets
-`RUNWISP_TLS=off` and expects you to either:
+RunWisp serves plain HTTP by default on every bind address, so the image
+doesn't need to set `RUNWISP_TLS` at all — a reverse proxy is usually
+already terminating TLS in front of a container anyway. You either:
 
 - put a proxy in front and set `RUNWISP_TRUST_PROXY` to its CIDR, so the
   daemon honors `X-Forwarded-Proto` and still marks session cookies
   `Secure`; or
 - set `-e RUNWISP_TLS=auto` and let RunWisp terminate TLS itself with a
-  self-signed cert you trust out of band.
+  [self-signed cert](/configuration/daemon/#tls-tls_cert-tls_key) you
+  trust out of band.
 
 ## Timezone
 

--- a/apps/docs/src/content/docs/operations/auth.mdx
+++ b/apps/docs/src/content/docs/operations/auth.mdx
@@ -51,9 +51,8 @@ HMAC-SHA-256), and sends back the derived response the daemon can
 verify. The password itself never hits the wire, and the slow KDF
 makes a captured transcript expensive to brute-force offline. That's
 defense in depth _behind_ the encrypted channel, not a substitute for
-it — and whenever the daemon binds beyond loopback it serves HTTPS by
-default (see [TLS](/configuration/daemon/#tls-tls_cert-tls_key)), so
-the handshake rides an encrypted connection too.
+it — set `tls = "auto"` (see [TLS](/configuration/daemon/#tls-tls_cert-tls_key))
+on a non-loopback bind and the handshake rides an encrypted connection too.
 
 Once you're in, the daemon hands you a session inside a secure
 cookie. Set a new `RUNWISP_PASSWORD` and restart, and every
@@ -233,14 +232,15 @@ close some open log views and try again.
 ## Reverse proxies
 
 RunWisp binds to `127.0.0.1:9477` by default and serves plain HTTP
-there. Bind beyond loopback and it self-signs and serves HTTPS on its
-own — enough for a LAN or a tailnet, no proxy required. Where a
-reverse proxy still earns its keep is a **publicly-trusted**
-certificate: put it on the public internet behind nginx, Caddy,
-Traefik, or a Cloudflare Tunnel, let the proxy own TLS, set
-[`tls = "off"`](/configuration/daemon/#tls-tls_cert-tls_key) so
-RunWisp serves plain HTTP on its private side, and tell the daemon
-which IP ranges that proxy will be calling from:
+there. Bind beyond loopback and set
+[`tls = "auto"`](/configuration/daemon/#tls-tls_cert-tls_key) and it
+self-signs and serves HTTPS on its own — enough for a LAN or a
+tailnet, no proxy required. Where a reverse proxy still earns its
+keep is a **publicly-trusted** certificate: put it on the public
+internet behind nginx, Caddy, Traefik, or a Cloudflare Tunnel, let
+the proxy own TLS, leave `tls` at its default of `"off"` so RunWisp
+serves plain HTTP on its private side, and tell the daemon which IP
+ranges that proxy will be calling from:
 
 ```bash
 export RUNWISP_TRUST_PROXY='10.0.0.0/8,2001:db8::/32'

--- a/apps/runwisp/cmd/runwisp/cmd_demo.go
+++ b/apps/runwisp/cmd/runwisp/cmd_demo.go
@@ -162,7 +162,7 @@ func runDemo(cmd *cobra.Command, f Flags) error {
 // reportDemoNoTUI leaves the background daemon running and prints its Web UI password to stdout.
 // This is the --no-tui path that mirrors the TUI's "Keep Running" quit. Returns a passwordExit* code.
 func reportDemoNoTUI(stdout, stderr io.Writer, client credentialsFetcher, f Flags) int {
-	fmt.Fprintf(stderr, "RunWisp demo is running at %s\n", localBindURL(tlsScheme(config.Daemon{}, f.Host), f.Host, f.Port))
+	fmt.Fprintf(stderr, "RunWisp demo is running at %s\n", localBindURL(tlsScheme(config.Daemon{TLS: config.TLSModeOff}, f.Host), f.Host, f.Port))
 	fmt.Fprintf(stderr, "Stop it with: runwisp stop --data %s\n", f.DataDir)
 	fmt.Fprintln(stderr, "Web UI password:")
 	return runPassword(stdout, stderr, client, localAPISocketPath(f))

--- a/apps/runwisp/cmd/runwisp/cmd_demo_test.go
+++ b/apps/runwisp/cmd/runwisp/cmd_demo_test.go
@@ -40,8 +40,8 @@ func TestReportDemoNoTUI_WildcardBindReportsLocalhost(t *testing.T) {
 
 	reportDemoNoTUI(&stdout, &stderr, client, f)
 
-	assert.Contains(t, stderr.String(), "https://localhost:8080",
-		"a 0.0.0.0 bind is not connectable (report localhost) and auto-TLS makes it https")
+	assert.Contains(t, stderr.String(), "http://localhost:8080",
+		"a 0.0.0.0 bind is not connectable (report localhost); TLS defaults to off")
 }
 
 func TestReportDemoNoTUI_NoPasswordExitsNonZeroWithoutLeaking(t *testing.T) {

--- a/apps/runwisp/cmd/runwisp/daemon_tls.go
+++ b/apps/runwisp/cmd/runwisp/daemon_tls.go
@@ -25,8 +25,8 @@ type tlsSetup struct {
 // resolveTLS decides how the main listener serves, generating a self-signed
 // cert when auto-HTTPS engages. The matrix (see config.Daemon docs):
 //   - operator-supplied tls_cert/tls_key  → HTTPS with those files (any host)
-//   - tls = "off"                          → plain HTTP (operator owns TLS upstream)
-//   - tls = "auto" + non-loopback bind     → self-signed HTTPS (the secure default)
+//   - tls = "off" (the default)            → plain HTTP (operator owns TLS upstream)
+//   - tls = "auto" + non-loopback bind     → self-signed HTTPS (opt-in)
 //   - tls = "auto" + loopback bind         → plain HTTP (no eavesdrop risk locally)
 //
 // It is called once at boot, before the server is constructed, so a cert

--- a/apps/runwisp/internal/config/config.go
+++ b/apps/runwisp/internal/config/config.go
@@ -482,7 +482,7 @@ func validateDefaults(d *Defaults) error {
 // must exist and load as a usable key pair, so a typo'd path fails at boot
 // rather than when the first HTTPS request arrives.
 func validateTLS(d *Daemon) error {
-	// "" is the not-yet-defaulted state (ApplyDefaults fills it with "auto");
+	// "" is the not-yet-defaulted state (ApplyDefaults fills it with "off");
 	// accept it so Validate is order-independent with respect to ApplyDefaults.
 	switch d.TLS {
 	case "", TLSModeAuto, TLSModeOff:
@@ -1245,7 +1245,8 @@ const (
 
 // TLS modes for [daemon] tls. TLSModeAuto serves HTTP on loopback and
 // self-signed HTTPS on a non-loopback bind; TLSModeOff is plain HTTP on every
-// bind (operator terminates TLS upstream or trusts the network).
+// bind (operator terminates TLS upstream or trusts the network) and is the
+// default.
 const (
 	TLSModeAuto = "auto"
 	TLSModeOff  = "off"
@@ -1291,7 +1292,7 @@ func ApplyDefaults(cfg *Config) {
 		cfg.Daemon.ShutdownTimeout = DefaultDaemonShutdown
 	}
 	if cfg.Daemon.TLS == "" {
-		cfg.Daemon.TLS = TLSModeAuto
+		cfg.Daemon.TLS = TLSModeOff
 	}
 	if cfg.Defaults.HealthyAfter == 0 {
 		cfg.Defaults.HealthyAfter = DefaultHealthyAfter

--- a/apps/runwisp/internal/config/config.schema.json
+++ b/apps/runwisp/internal/config/config.schema.json
@@ -122,7 +122,7 @@
         "external_url": { "type": "string", "description": "Public Web UI base for notification deep-links; absolute http(s) with host." },
         "metrics_enabled": { "type": "boolean", "default": false, "description": "Master switch for /metrics." },
         "metrics_listen": { "type": "string", "description": "Dedicated metrics listener host:port; requires metrics_enabled=true." },
-        "tls": { "type": "string", "description": "TLS mode for the HTTP server." },
+        "tls": { "type": "string", "default": "off", "description": "TLS mode for the HTTP server." },
         "tls_cert": { "type": "string", "description": "Path to the TLS certificate." },
         "tls_key": { "type": "string", "description": "Path to the TLS private key." },
         "include": {

--- a/apps/runwisp/internal/config/parse.go
+++ b/apps/runwisp/internal/config/parse.go
@@ -157,7 +157,7 @@ func parseExternalURL(raw string) (string, error) {
 	return trimmed, nil
 }
 
-// parseTLSMode validates [daemon] tls: empty (apply the "auto" default later),
+// parseTLSMode validates [daemon] tls: empty (apply the "off" default later),
 // "auto", or "off". The literal is normalised to lower case so "AUTO"/"Off"
 // don't trip validation. The actual auto-vs-off behaviour (loopback stays HTTP,
 // non-loopback self-signs) is resolved at boot against the bind host.

--- a/apps/runwisp/internal/config/schema.go
+++ b/apps/runwisp/internal/config/schema.go
@@ -212,13 +212,14 @@ type NotificationRoute struct {
 // sharing the main UI/REST listener — useful when --host exposes the UI
 // publicly but the scrape surface should stay on loopback.
 //
-// TLS controls transport encryption for the main UI/REST listener. "auto"
-// (the default) serves plain HTTP on loopback but self-signs and serves HTTPS
-// the moment the bind host is non-loopback, so a network-exposed daemon is
-// encrypted with zero operator effort; "off" forces plain HTTP everywhere
-// (the operator is terminating TLS at a reverse proxy, or knows the network is
-// trusted). TLSCert/TLSKey, when both set, supply an operator-provided
-// certificate and key that take precedence over auto self-signing on any bind.
+// TLS controls transport encryption for the main UI/REST listener. "off"
+// (the default) forces plain HTTP everywhere (the operator is terminating TLS
+// at a reverse proxy, trusts the network, or hasn't opted in yet); "auto"
+// serves plain HTTP on loopback but self-signs and serves HTTPS the moment
+// the bind host is non-loopback, so a network-exposed daemon can be encrypted
+// with zero further operator effort once opted in. TLSCert/TLSKey, when both
+// set, supply an operator-provided certificate and key that take precedence
+// over auto self-signing on any bind.
 type Daemon struct {
 	AllowCloudDispatch bool          `toml:"-"`
 	ShutdownTimeout    time.Duration `toml:"-"`

--- a/apps/runwisp/internal/config/tls_env_test.go
+++ b/apps/runwisp/internal/config/tls_env_test.go
@@ -24,14 +24,14 @@ run = "/bin/true"
 		assert.Equal(t, TLSModeOff, cfg.Daemon.TLS)
 	})
 
-	t.Run("unset leaves default auto untouched", func(t *testing.T) {
+	t.Run("unset leaves default off untouched", func(t *testing.T) {
 		path := writeTOML(t, `
 [tasks.t]
 run = "/bin/true"
 `)
 		cfg, err := Load(path)
 		require.NoError(t, err)
-		assert.Equal(t, TLSModeAuto, cfg.Daemon.TLS)
+		assert.Equal(t, TLSModeOff, cfg.Daemon.TLS)
 	})
 
 	t.Run("env off overrides TOML auto", func(t *testing.T) {

--- a/apps/runwisp/tests/e2e/tls_test.go
+++ b/apps/runwisp/tests/e2e/tls_test.go
@@ -46,13 +46,26 @@ func (s *mapPinStore) Store(k, v string) {
 	s.m[k] = v
 }
 
-// startTLSDaemon boots a daemon bound to 0.0.0.0, which triggers auto-HTTPS
-// (loopback would stay plain HTTP). It returns the daemon process handle and
-// the https base URL reachable over loopback — the self-signed cert's SANs
-// include 127.0.0.1, and pinning skips hostname verification anyway.
+// startTLSDaemon boots a daemon bound to 0.0.0.0 with tls = "auto", which
+// triggers auto-HTTPS (loopback would stay plain HTTP; tls off, the default,
+// would too). It returns the daemon process handle and the https base URL
+// reachable over loopback — the self-signed cert's SANs include 127.0.0.1,
+// and pinning skips hostname verification anyway.
 func startTLSDaemon(t *testing.T) *daemonProcess {
 	t.Helper()
-	return startNonLoopbackDaemon(t, writeE2EConfig(t, t.TempDir()), "https")
+
+	configPath := filepath.Join(t.TempDir(), "runwisp.tls-auto.toml")
+	config := `
+[daemon]
+tls = "auto"
+shutdown_timeout = "500ms"
+
+[tasks.noop]
+run = "true"
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+
+	return startNonLoopbackDaemon(t, configPath, "https")
 }
 
 // startNonLoopbackDaemon boots a daemon bound to 0.0.0.0 with the given config

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,15 +40,13 @@ COPY context/${TARGETARCH}/runwisp /usr/local/bin/runwisp
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/runwisp /usr/local/bin/docker-entrypoint.sh
 
-# Bind 0.0.0.0 and keep plain HTTP by default: a container is meant to sit
-# behind a reverse proxy or be port-mapped directly, and the daemon's
-# auto-TLS (self-signed HTTPS on any non-loopback bind) is a worse default
-# here than it is on a laptop. Operators wanting the daemon to terminate TLS
-# itself can set RUNWISP_TLS=auto.
+# Bind 0.0.0.0 and rely on the daemon's own plain-HTTP-by-default: a
+# container is meant to sit behind a reverse proxy or be port-mapped
+# directly. Operators wanting the daemon to terminate TLS itself (self-signed
+# HTTPS) can set RUNWISP_TLS=auto.
 ENV RUNWISP_CONFIG=/etc/runwisp/runwisp.toml \
 	RUNWISP_DATA=/var/lib/runwisp \
 	RUNWISP_HOST=0.0.0.0 \
-	RUNWISP_TLS=off \
 	RUNWISP_LOG_FORMAT=text
 
 EXPOSE 9477


### PR DESCRIPTION
## Summary

- `[daemon] tls` now defaults to `"off"`. A non-loopback bind used to self-sign a certificate and serve HTTPS automatically; it now serves plain HTTP unless you opt in with `tls = "auto"` (self-signed HTTPS) or supply `tls_cert`/`tls_key`.
- The official Docker image no longer sets `RUNWISP_TLS=off` explicitly, since it now matches the daemon's own default.

## Test plan

- [x] `bun run ci` (generate, format, check, unit tests, e2e tests, binary build) passes
- [x] `apps/runwisp/tests/e2e/tls_test.go` exercises both the opt-in auto-HTTPS path and the plain-HTTP-on-non-loopback path against the real binary