### PR TITLE
fix(tui): stop the connected daemon, not one named by --data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **CPU and memory stats now report real host values on macOS.** The system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system` and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%. macOS now reads host RAM and load average directly (via `sysctl` and a mach VM-statistics call), matching the Linux figures.
+- **The TUI's shutdown command now targets the daemon it's connected to via `--socket`, and surfaces an error if the shutdown fails.**
 
 ## [0.14.0] - 2026-08-04
 

--- a/apps/runwisp/cmd/runwisp/cmd_default.go
+++ b/apps/runwisp/cmd/runwisp/cmd_default.go
@@ -86,7 +86,7 @@ func ensurePortFreeOrHandle(f Flags) (spawn bool, err error) {
 	case conflictConnect:
 		return false, runTUIConnect(apiclient.NewUnix(info.SocketPath), f)
 	case conflictStopAndLaunch:
-		if stopErr := stopConflictingDaemon(f, info); stopErr != nil {
+		if stopErr := stopDaemonByInstance(f, info); stopErr != nil {
 			return false, stopErr
 		}
 		return true, nil // other daemon stopped; spawn our own
@@ -98,8 +98,21 @@ func ensurePortFreeOrHandle(f Flags) (spawn bool, err error) {
 // runTUIConnect launches the TUI against a local daemon via Unix socket.
 func runTUIConnect(client *apiclient.Client, f Flags) error {
 	return launchConnectedTUI(client, tuiConnectMode{
-		shutdownFunc: func() error { return shutdownDaemon(f) },
+		shutdownFunc: func() error { return shutdownConnectedDaemon(client, f) },
 	})
+}
+
+// shutdownConnectedDaemon stops the daemon the TUI is actually attached to. It
+// resolves that daemon's data dir and PID from GET /api/instance rather than
+// trusting the local --data flag: `runwisp tui --socket <path>` connects by
+// socket alone, so f.DataDir may name a different daemon (or none), and
+// signalling it would leave the connected daemon running.
+func shutdownConnectedDaemon(client *apiclient.Client, f Flags) error {
+	info, err := client.GetInstanceInfo()
+	if err != nil {
+		return fmt.Errorf("locate the connected daemon to stop it: %w", err)
+	}
+	return stopDaemonByInstance(f, info)
 }
 
 // tuiConnectMode carries the few things that differ between attaching the TUI

--- a/apps/runwisp/cmd/runwisp/port_conflict.go
+++ b/apps/runwisp/cmd/runwisp/port_conflict.go
@@ -106,9 +106,11 @@ func resolvePortConflict(f Flags, bindErr error, info *model.InstanceInfo, inter
 	}
 }
 
-// stopConflictingDaemon SIGTERMs the discovered daemon and waits for it to
-// exit, reusing the same path as `runwisp stop` (PID file in its datadir).
-func stopConflictingDaemon(f Flags, info *model.InstanceInfo) error {
+// stopDaemonByInstance SIGTERMs the daemon described by info and waits for it to
+// exit, reusing the same path as `runwisp stop` (PID file in its datadir). The
+// data dir and socket come from the daemon's own /api/instance report, so it
+// targets the right daemon even when the local --data flag points elsewhere.
+func stopDaemonByInstance(f Flags, info *model.InstanceInfo) error {
 	other := f
 	other.DataDir = info.DataDir
 	other.Socket = info.SocketPath

--- a/apps/runwisp/internal/tui/model.go
+++ b/apps/runwisp/internal/tui/model.go
@@ -78,8 +78,11 @@ type Model struct {
 	layout headerLayout
 
 	// Quit action chosen by the user (keep daemon or shut down).
-	quitAction       uikit.QuitAction
-	shutdownFunc     func() error
+	quitAction   uikit.QuitAction
+	shutdownFunc func() error
+	// shutdownErr records a failed daemon shutdown so the caller can report it
+	// instead of the TUI closing as if the daemon had stopped.
+	shutdownErr      error
 	launchTicketFunc func() (string, error)
 
 	mouse mouseState
@@ -364,6 +367,12 @@ func (m *Model) autoOpenService(taskName string) tea.Cmd {
 // QuitAction returns the quit action chosen by the user.
 func (m Model) QuitAction() uikit.QuitAction {
 	return m.quitAction
+}
+
+// ShutdownErr returns the error from a shutdown-on-exit attempt, or nil when the
+// daemon stopped cleanly (or the user kept it running).
+func (m Model) ShutdownErr() error {
+	return m.shutdownErr
 }
 
 // showQuitConfirm displays the quit dialog with keep-daemon/shutdown options.

--- a/apps/runwisp/internal/tui/model_update.go
+++ b/apps/runwisp/internal/tui/model_update.go
@@ -379,6 +379,7 @@ func (m Model) interceptShuttingDownDialog(msg tea.Msg) (tea.Model, tea.Cmd, boo
 		cmd := m.dialogs.UpdateSpinner(msg.Inner)
 		return m, cmd, true
 	case uikit.ShutdownDoneMsg:
+		m.shutdownErr = msg.Err
 		return m, tea.Quit, true
 	case tea.MouseMsg:
 		return m, nil, true

--- a/apps/runwisp/internal/tui/model_update_test.go
+++ b/apps/runwisp/internal/tui/model_update_test.go
@@ -248,6 +248,28 @@ func TestInterceptShuttingDownDialog_ShutdownDone(t *testing.T) {
 	}
 }
 
+// TestInterceptShuttingDownDialog_ShutdownError verifies a failed shutdown is
+// recorded on the model rather than swallowed — otherwise the TUI would close
+// as if the daemon had stopped when it is still running.
+func TestInterceptShuttingDownDialog_ShutdownError(t *testing.T) {
+	m := newTestModel(nil)
+	m.dialogs.ShowConfirm(NewConfirmDialog("Test", "msg", func() tea.Msg { return nil }))
+	_ = m.dialogs.StartShutdown()
+
+	wantErr := errors.New("could not signal daemon")
+	next, _, intercepted := m.interceptShuttingDownDialog(uikit.ShutdownDoneMsg{Err: wantErr})
+	if !intercepted {
+		t.Fatal("expected intercepted=true for ShutdownDoneMsg")
+	}
+	fm, ok := next.(Model)
+	if !ok {
+		t.Fatalf("expected Model, got %T", next)
+	}
+	if fm.ShutdownErr() != wantErr {
+		t.Fatalf("expected ShutdownErr %v, got %v", wantErr, fm.ShutdownErr())
+	}
+}
+
 func TestInterceptShuttingDownDialog_OtherKey(t *testing.T) {
 	m := newTestModel(nil)
 	m.dialogs.ShowConfirm(NewConfirmDialog("Test", "msg", func() tea.Msg { return nil }))

--- a/apps/runwisp/internal/tui/tui.go
+++ b/apps/runwisp/internal/tui/tui.go
@@ -81,7 +81,7 @@ func StartTUI(info uikit.StartupInfo, client *apiclient.Client, debugWriter *Deb
 	}
 
 	if fm, ok := finalModel.(Model); ok {
-		return fm.QuitAction(), nil
+		return fm.QuitAction(), fm.ShutdownErr()
 	}
 	return uikit.QuitShutdownDaemon, nil
 }


### PR DESCRIPTION
## Summary

- When the TUI attaches to a daemon over `--socket` (rather than via the local `--data` dir), shutting down on quit stopped whatever daemon `--data` pointed to instead of the daemon the TUI was actually connected to.
- The shutdown target is now resolved from the connected daemon's own `GET /api/instance`, so it stops the right process regardless of `--data`.
- A failed shutdown attempt now surfaces as an error instead of the TUI closing silently as if the daemon had stopped.

## Test plan

- [x] `bun run ci` (new/existing TUI unit tests cover the shutdown-error path; unrelated pre-existing flake in `internal/executor` compose tests under parallel load, confirmed unrelated by running in isolation on both `main` and this branch)