### PR TITLE
fix(server): report real host CPU/memory stats on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CPU and memory stats now report real host values on macOS.** The system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system` and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%. macOS now reads host RAM and load average directly (via `sysctl` and a mach VM-statistics call), matching the Linux figures.
+
 ## [0.14.0] - 2026-08-04
 
 ### Added
@@ -54,7 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`runwisp status` and the TUI header now show the live task set**, not the one from when the daemon started.
 - **`runwisp service install --dry-run` now runs its checks before reporting success.** See [Autostart](https://docs.runwisp.com/operations/autostart/#flag-reference).
 - **`runwisp service` commands now respect `--config`/`--data` and their environment-variable equivalents.** See [Autostart](https://docs.runwisp.com/operations/autostart/#resolving-paths).
-- **CPU and memory stats now report real host values on macOS.** The system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system` and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%. macOS now reads host RAM and load average directly (via `sysctl` and a mach VM-statistics call), matching the Linux figures.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`runwisp status` and the TUI header now show the live task set**, not the one from when the daemon started.
 - **`runwisp service install --dry-run` now runs its checks before reporting success.** See [Autostart](https://docs.runwisp.com/operations/autostart/#flag-reference).
 - **`runwisp service` commands now respect `--config`/`--data` and their environment-variable equivalents.** See [Autostart](https://docs.runwisp.com/operations/autostart/#resolving-paths).
+- **CPU and memory stats now report real host values on macOS.** The system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system` and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%. macOS now reads host RAM and load average directly (via `sysctl` and a mach VM-statistics call), matching the Linux figures.
 
 ### Security
 

--- a/apps/runwisp/internal/server/metrics.go
+++ b/apps/runwisp/internal/server/metrics.go
@@ -71,11 +71,7 @@ func (mc *MetricsCollector) loop(interval time.Duration) {
 
 func (mc *MetricsCollector) collect() {
 	s := model.MetricsSample{Timestamp: time.Now().Unix()}
-	if runtime.GOOS == "linux" {
-		populateLinuxSample(&s)
-	} else {
-		populateFallbackSample(&s)
-	}
+	populatePlatformSample(&s)
 	s.CPUUsage = float64(int(s.CPUUsage*10)) / 10
 	s.MemUsage = float64(int(s.MemUsage*10)) / 10
 
@@ -93,20 +89,16 @@ func (mc *MetricsCollector) collect() {
 	}
 }
 
-func populateLinuxSample(s *model.MetricsSample) {
-	memTotal, memAvailable := getMemInfo()
-	if memTotal > 0 {
-		s.MemTotal = memTotal
-		s.MemUsed = memTotal - memAvailable
-		s.MemUsage = float64(s.MemUsed) / float64(s.MemTotal) * 100
-	}
-
-	load1 := getLoadAvg()
-	usage := (load1 / float64(runtime.NumCPU())) * 100
-	if usage > 100 {
-		usage = 100
-	}
-	s.CPUUsage = usage
+// populatePlatformStats fills a one-shot SystemStats snapshot from the same
+// per-OS collector the ring buffer uses, so /api/system and the metrics history
+// never disagree. Platform files supply populatePlatformSample.
+func populatePlatformStats(stats *model.SystemStats) {
+	var s model.MetricsSample
+	populatePlatformSample(&s)
+	stats.MemTotal = s.MemTotal
+	stats.MemUsed = s.MemUsed
+	stats.MemUsage = s.MemUsage
+	stats.CPUUsage = s.CPUUsage
 }
 
 func populateFallbackSample(s *model.MetricsSample) {

--- a/apps/runwisp/internal/server/metrics_darwin.go
+++ b/apps/runwisp/internal/server/metrics_darwin.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build darwin
+
+package server
+
+import (
+	"encoding/binary"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"github.com/runwisp/runwisp/internal/model"
+	"golang.org/x/sys/unix"
+)
+
+// macOS has no /proc, so memory and CPU come from sysctl plus a mach VM
+// statistics call. Total RAM is hw.memsize; CPU mirrors the Linux path
+// (1-minute load average over core count); used memory is total minus the
+// reclaimable pages (free + inactive) reported by host_statistics64 — the macOS
+// analog of Linux's MemAvailable. golang.org/x/sys/unix exposes the sysctls but
+// not the mach call, so we reach host_statistics64 / mach_host_self through
+// libSystem the same cgo-free way x/sys/unix does internally (works with
+// CGO_ENABLED=0 because darwin always links libSystem dynamically).
+//
+// ponytail: free+inactive is a coarse "available" heuristic (ignores purgeable
+// and file-backed reclaim); swap the formula if the number reads off vs
+// Activity Monitor.
+
+const (
+	// From <mach/host_info.h>: HOST_VM_INFO64 flavor, and its size in
+	// integer_t (int32) units. vm_statistics64_data_t is 152 bytes → 38.
+	hostVMInfo64      = 4
+	hostVMInfo64Count = 38
+)
+
+func populatePlatformSample(s *model.MetricsSample) {
+	total, err := unix.SysctlUint64("hw.memsize")
+	if err != nil || total == 0 {
+		populateFallbackSample(s)
+		return
+	}
+	free, inactive, ok := vmPageCounts()
+	if !ok {
+		populateFallbackSample(s)
+		return
+	}
+
+	pageSize := uint64(unix.Getpagesize())
+	available := (free + inactive) * pageSize
+	if available > total {
+		available = total
+	}
+	s.MemTotal = total
+	s.MemUsed = total - available
+	s.MemUsage = float64(s.MemUsed) / float64(total) * 100
+
+	s.CPUUsage = loadCPUPercent()
+}
+
+// loadCPUPercent reads the 1-minute load average via sysctl vm.loadavg and
+// expresses it as a percentage of the core count, capped at 100 — identical to
+// the Linux path. The sysctl returns a struct loadavg { fixpt_t ldavg[3]; long
+// fscale; } (little-endian on both amd64 and arm64); load = ldavg[0] / fscale.
+func loadCPUPercent() float64 {
+	raw, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil || len(raw) < 16 {
+		return 0
+	}
+	ldavg0 := binary.LittleEndian.Uint32(raw[0:4])
+
+	var fscale uint64
+	switch {
+	case len(raw) >= 24: // 64-bit long, 8-byte aligned after the uint32[3]
+		fscale = binary.LittleEndian.Uint64(raw[16:24])
+	default:
+		fscale = uint64(binary.LittleEndian.Uint32(raw[12:16]))
+	}
+	if fscale == 0 {
+		return 0
+	}
+
+	load1 := float64(ldavg0) / float64(fscale)
+	usage := (load1 / float64(runtime.NumCPU())) * 100
+	if usage > 100 {
+		usage = 100
+	}
+	return usage
+}
+
+// vmPageCounts returns the free and inactive page counts from the mach VM
+// statistics. ok is false if the mach calls fail, so the caller can degrade to
+// the heap fallback.
+func vmPageCounts() (free, inactive uint64, ok bool) {
+	host, _, _ := syscallSyscall6(machHostSelfTrampolineAddr, 0, 0, 0, 0, 0, 0)
+	if host == 0 {
+		return 0, 0, false
+	}
+
+	// vm_statistics64_data_t's leading fields are natural_t (uint32):
+	// [0]=free_count, [1]=active_count, [2]=inactive_count, [3]=wire_count.
+	// host_statistics64 writes the full flavor, so the buffer must be full size.
+	var stat [hostVMInfo64Count]uint32
+	count := uint32(hostVMInfo64Count)
+	ret, _, _ := syscallSyscall6(
+		hostStatistics64TrampolineAddr,
+		host,
+		uintptr(hostVMInfo64),
+		uintptr(unsafe.Pointer(&stat[0])),
+		uintptr(unsafe.Pointer(&count)),
+		0, 0,
+	)
+	if ret != 0 { // non-zero kern_return_t
+		return 0, 0, false
+	}
+	return uint64(stat[0]), uint64(stat[2]), true
+}
+
+// libSystem bridge, mirroring golang.org/x/sys/unix's cgo-free scheme. The
+// trampoline address symbols are defined in metrics_darwin.s.
+
+//go:linkname syscallSyscall6 syscall.syscall6
+func syscallSyscall6(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
+
+//go:cgo_import_dynamic libc_host_statistics64 host_statistics64 "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_mach_host_self mach_host_self "/usr/lib/libSystem.B.dylib"
+
+var (
+	hostStatistics64TrampolineAddr uintptr
+	machHostSelfTrampolineAddr     uintptr
+)

--- a/apps/runwisp/internal/server/metrics_darwin.s
+++ b/apps/runwisp/internal/server/metrics_darwin.s
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "textflag.h"
+
+// Trampolines to the libSystem functions imported via //go:cgo_import_dynamic
+// in metrics_darwin.go. Same form x/sys/unix generates; works for amd64 and
+// arm64 alike.
+
+TEXT libc_host_statistics64_trampoline<>(SB),NOSPLIT,$0-0
+	JMP	libc_host_statistics64(SB)
+GLOBL	·hostStatistics64TrampolineAddr(SB), RODATA, $8
+DATA	·hostStatistics64TrampolineAddr(SB)/8, $libc_host_statistics64_trampoline<>(SB)
+
+TEXT libc_mach_host_self_trampoline<>(SB),NOSPLIT,$0-0
+	JMP	libc_mach_host_self(SB)
+GLOBL	·machHostSelfTrampolineAddr(SB), RODATA, $8
+DATA	·machHostSelfTrampolineAddr(SB)/8, $libc_mach_host_self_trampoline<>(SB)

--- a/apps/runwisp/internal/server/metrics_darwin_test.go
+++ b/apps/runwisp/internal/server/metrics_darwin_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build darwin
+
+package server
+
+import (
+	"testing"
+
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPopulatePlatformSampleDarwin exercises the real mach/sysctl collector and
+// asserts it reports host-level (not Go-heap) numbers — the regression this
+// package fixes was macOS falling back to runtime.MemStats with CPU stuck at 0.
+func TestPopulatePlatformSampleDarwin(t *testing.T) {
+	var s model.MetricsSample
+	populatePlatformSample(&s)
+
+	require.Greater(t, s.MemTotal, uint64(1<<30), "MemTotal must be host RAM (> 1 GiB), not the Go heap")
+	assert.Positive(t, s.MemUsed, "MemUsed must be non-zero")
+	assert.LessOrEqual(t, s.MemUsed, s.MemTotal, "MemUsed cannot exceed MemTotal")
+	assert.Greater(t, s.MemUsage, 0.0)
+	assert.LessOrEqual(t, s.MemUsage, 100.0)
+	assert.GreaterOrEqual(t, s.CPUUsage, 0.0)
+	assert.LessOrEqual(t, s.CPUUsage, 100.0)
+}

--- a/apps/runwisp/internal/server/metrics_linux.go
+++ b/apps/runwisp/internal/server/metrics_linux.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build linux
+
+package server
+
+import (
+	"bufio"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/runwisp/runwisp/internal/model"
+)
+
+// populatePlatformSample reads real host CPU and memory usage from /proc.
+// Memory used is total minus MemAvailable; CPU is the 1-minute load average
+// expressed as a percentage of the core count, capped at 100.
+func populatePlatformSample(s *model.MetricsSample) {
+	memTotal, memAvailable := getMemInfo()
+	if memTotal > 0 {
+		s.MemTotal = memTotal
+		s.MemUsed = memTotal - memAvailable
+		s.MemUsage = float64(s.MemUsed) / float64(s.MemTotal) * 100
+	}
+
+	load1 := getLoadAvg()
+	usage := (load1 / float64(runtime.NumCPU())) * 100
+	if usage > 100 {
+		usage = 100
+	}
+	s.CPUUsage = usage
+}
+
+func getMemInfo() (uint64, uint64) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, 0
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var total, available uint64
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		val, _ := strconv.ParseUint(parts[1], 10, 64)
+		if strings.HasPrefix(parts[0], "MemTotal") {
+			total = val * 1024 // kB to B
+		} else if strings.HasPrefix(parts[0], "MemAvailable") {
+			available = val * 1024
+		}
+	}
+	return total, available
+}
+
+func getLoadAvg() float64 {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) > 0 {
+		val, _ := strconv.ParseFloat(fields[0], 64)
+		return val
+	}
+	return 0
+}

--- a/apps/runwisp/internal/server/metrics_other.go
+++ b/apps/runwisp/internal/server/metrics_other.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !linux && !darwin
+
+package server
+
+import "github.com/runwisp/runwisp/internal/model"
+
+// populatePlatformSample has no host-metrics backend on unsupported platforms,
+// so it reports the daemon's own Go heap and leaves CPU at zero.
+func populatePlatformSample(s *model.MetricsSample) {
+	populateFallbackSample(s)
+}

--- a/apps/runwisp/internal/server/system.go
+++ b/apps/runwisp/internal/server/system.go
@@ -4,15 +4,12 @@
 package server
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"maps"
 	"os"
 	"runtime"
 	"slices"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -56,11 +53,7 @@ func (p *statsProvider) GetSystemStats() model.SystemStats {
 
 	stats.Uptime = formatUptime(time.Since(p.startTime))
 
-	if runtime.GOOS == "linux" {
-		populateLinuxStats(&stats)
-	} else {
-		populateFallbackStats(&stats)
-	}
+	populatePlatformStats(&stats)
 
 	stats.CPUUsage = float64(int(stats.CPUUsage*10)) / 10
 	stats.MemUsage = float64(int(stats.MemUsage*10)) / 10
@@ -175,44 +168,6 @@ func (srv *Server) humaGetMetricsHistory(ctx context.Context, input *struct{}) (
 	return &MetricsHistoryOutput{Body: srv.metrics.History()}, nil
 }
 
-func getMemInfo() (uint64, uint64) {
-	f, err := os.Open("/proc/meminfo")
-	if err != nil {
-		return 0, 0
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	var total, available uint64
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.Fields(line)
-		if len(parts) < 2 {
-			continue
-		}
-		val, _ := strconv.ParseUint(parts[1], 10, 64)
-		if strings.HasPrefix(parts[0], "MemTotal") {
-			total = val * 1024 // kB to B
-		} else if strings.HasPrefix(parts[0], "MemAvailable") {
-			available = val * 1024
-		}
-	}
-	return total, available
-}
-
-func getLoadAvg() float64 {
-	data, err := os.ReadFile("/proc/loadavg")
-	if err != nil {
-		return 0
-	}
-	fields := strings.Fields(string(data))
-	if len(fields) > 0 {
-		val, _ := strconv.ParseFloat(fields[0], 64)
-		return val
-	}
-	return 0
-}
-
 func formatUptime(duration time.Duration) string {
 	days := int(duration.Hours()) / 24
 	hours := int(duration.Hours()) % 24
@@ -225,15 +180,6 @@ func formatUptime(duration time.Duration) string {
 		return fmt.Sprintf("%dh %dm", hours, minutes)
 	}
 	return fmt.Sprintf("%dm", minutes)
-}
-
-func populateLinuxStats(stats *model.SystemStats) {
-	var s model.MetricsSample
-	populateLinuxSample(&s)
-	stats.MemTotal = s.MemTotal
-	stats.MemUsed = s.MemUsed
-	stats.MemUsage = s.MemUsage
-	stats.CPUUsage = s.CPUUsage
 }
 
 func populateFallbackStats(stats *model.SystemStats) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -45,6 +45,9 @@ sonar.coverage.exclusions=\
   apps/runwisp/internal/storage/sqlcdb/**,\
   packages/common/src/generated/**,\
   apps/runwisp/internal/server/peercred_darwin.go,\
+  apps/runwisp/internal/server/metrics_darwin.go,\
+  apps/runwisp/internal/server/metrics_darwin.s,\
+  apps/runwisp/internal/server/metrics_other.go,\
   apps/runwisp/cmd/runwisp/daemon_lifecycle.go,\
   apps/runwisp/cmd/runwisp/cmd_default.go,\
   apps/runwisp/cmd/runwisp/cmd_demo.go,\


### PR DESCRIPTION
## Summary

CPU and memory stats now report real host values on macOS. Previously the system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system`, and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%.

macOS now reads host RAM (`hw.memsize`) and load average (`vm.loadavg`) via `sysctl`, plus free/inactive page counts via a mach VM-statistics call, matching the Linux `/proc`-based figures. No new runtime dependency — the mach call goes through libSystem the same cgo-free way `golang.org/x/sys/unix` does internally.

## Test plan

- [x] `go build ./...` and `go test ./internal/server/...` pass on macOS (darwin/arm64)
- [x] Cross-compiles clean for `GOOS=linux`
- [x] `bun run ci` green