### PR TITLE
fix(release): package runwisp as executable (0755) in release tarballs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
           sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
           shellcheck -s sh docker/docker-entrypoint.sh docker/tests/entrypoint_test.sh
           shellcheck docker/build-local.sh docker/tests/smoke.sh
+          shellcheck apps/runwisp/scripts/package-all.sh apps/runwisp/scripts/tests/package-all_test.sh
 
       - name: Entrypoint unit tests (dash and bash)
         run: |
@@ -218,6 +219,10 @@ jobs:
             ENTRYPOINT_SH="${shell}" sh docker/tests/entrypoint_test.sh
             echo "::endgroup::"
           done
+
+      # Guards the release packaging: a tarball must ship an executable runwisp.
+      - name: Release packaging unit tests
+        run: apps/runwisp/scripts/tests/package-all_test.sh
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: CHANGELOG.md
+          sparse-checkout: |
+            CHANGELOG.md
+            apps/runwisp/scripts/package-all.sh
+          sparse-checkout-cone-mode: false
 
       - name: Extract release notes from CHANGELOG
         id: notes
@@ -138,12 +141,13 @@ jobs:
           name: binaries
           path: dist
 
-      - name: Package archives
-        run: |
-          for dir in dist/*/; do
-            target=$(basename "${dir}")
-            tar czf "runwisp-${target}.tar.gz" -C "${dir}" runwisp
-          done
+      # Force the packaged binary to mode 0755 and verify every archive ships an
+      # executable member. actions/upload-artifact does not preserve the Unix
+      # executable bit, so the downloaded binary is mode 0644 — packaging it
+      # as-is (as v0.14.0 did) yields a tarball whose extracted `runwisp` fails
+      # with "permission denied".
+      - name: Package and verify archives
+        run: apps/runwisp/scripts/package-all.sh dist .
 
       - name: Generate checksums
         run: sha256sum runwisp-*.tar.gz > checksums-sha256.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,11 +141,6 @@ jobs:
           name: binaries
           path: dist
 
-      # Force the packaged binary to mode 0755 and verify every archive ships an
-      # executable member. actions/upload-artifact does not preserve the Unix
-      # executable bit, so the downloaded binary is mode 0644 — packaging it
-      # as-is (as v0.14.0 did) yields a tarball whose extracted `runwisp` fails
-      # with "permission denied".
       - name: Package and verify archives
         run: apps/runwisp/scripts/package-all.sh dist .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release tarballs now package `runwisp` as an executable (mode 0755).** The v0.14.0 archives shipped it as mode 0644, so the documented extract-and-move install failed with "permission denied". See [Quick start](https://docs.runwisp.com/getting-started/quick-start/).
 - **CPU and memory stats now report real host values on macOS.** The system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system` and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%. macOS now reads host RAM and load average directly (via `sysctl` and a mach VM-statistics call), matching the Linux figures.
 - **The TUI's shutdown command now targets the daemon it's connected to via `--socket`, and surfaces an error if the shutdown fails.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Release tarballs now package `runwisp` as an executable (mode 0755).** The v0.14.0 archives shipped it as mode 0644, so the documented extract-and-move install failed with "permission denied". See [Quick start](https://docs.runwisp.com/getting-started/quick-start/).
+- **Release tarballs now package `runwisp` as an executable (mode 0755).**
 - **CPU and memory stats now report real host values on macOS.** The system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system` and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%. macOS now reads host RAM and load average directly (via `sysctl` and a mach VM-statistics call), matching the Linux figures.
 - **The TUI's shutdown command now targets the daemon it's connected to via `--socket`, and surfaces an error if the shutdown fails.**
 

--- a/apps/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/src/content/docs/getting-started/quick-start.mdx
@@ -79,8 +79,11 @@ dependencies, so as soon as it lands on your `PATH`, you're done.
 
         ```bash
         tar -xzf runwisp-linux-x64.tar.gz
-        sudo mv runwisp /usr/local/bin/runwisp
+        sudo install -m 0755 runwisp /usr/local/bin/runwisp
         ```
+
+        `install -m 0755` sets the executable bit as it copies, so
+        RunWisp runs whatever mode the tarball happened to carry.
 
         [releases]: https://github.com/runwisp/runwisp/releases
     </TabItem>

--- a/apps/runwisp/scripts/package-all.sh
+++ b/apps/runwisp/scripts/package-all.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Package cross-compiled binaries (from build-all.sh) into release tarballs.
+#
+# Usage: package-all.sh <dist-dir> [out-dir]
+#
+# For each <dist-dir>/<target>/runwisp it writes
+# <out-dir>/runwisp-<target>.tar.gz with the `runwisp` member forced to mode
+# 0755, then verifies every archive actually contains an executable member.
+#
+# Why force the mode: the release pipeline round-trips the binaries through
+# actions/upload-artifact, which does not preserve the Unix executable bit, so
+# the downloaded binary is mode 0644. Packaging that as-is ships a tarball whose
+# extracted `runwisp` is not runnable — the documented `tar -xzf … && mv`
+# install then fails with "permission denied". The final verification pass is a
+# release-time guard so a future regression fails the build instead of the user.
+
+set -euo pipefail
+
+dist_dir=${1:?usage: package-all.sh <dist-dir> [out-dir]}
+out_dir=${2:-.}
+mkdir -p "${out_dir}"
+
+shopt -s nullglob
+archives=()
+for dir in "${dist_dir}"/*/; do
+  target=$(basename "${dir}")
+  binary="${dir}runwisp"
+  if [[ ! -f "${binary}" ]]; then
+    printf 'No runwisp binary in %s\n' "${dir}" >&2
+    exit 1
+  fi
+  chmod 0755 "${binary}"
+  archive="${out_dir}/runwisp-${target}.tar.gz"
+  printf '  Packaging %s → %s\n' "${binary}" "${archive}"
+  tar czf "${archive}" -C "${dir}" runwisp
+  archives+=("${archive}")
+done
+
+if [[ ${#archives[@]} -eq 0 ]]; then
+  printf 'No target directories found under %s\n' "${dist_dir}" >&2
+  exit 1
+fi
+
+# Independently confirm every packaged archive carries an executable member; a
+# release must never ship a runwisp the operator then has to chmod by hand.
+status=0
+for archive in "${archives[@]}"; do
+  mode=$(tar tzvf "${archive}" | awk '$NF == "runwisp" { print $1 }')
+  printf '  %s  %s\n' "${mode:-<missing>}" "${archive}"
+  case "${mode}" in
+    -rwxr-xr-x*) ;;
+    *)
+      printf 'ERROR: %s packages runwisp as %s, expected -rwxr-xr-x\n' \
+        "${archive}" "${mode:-<missing>}" >&2
+      status=1
+      ;;
+  esac
+done
+
+exit "${status}"

--- a/apps/runwisp/scripts/tests/package-all_test.sh
+++ b/apps/runwisp/scripts/tests/package-all_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: PoppyCake, s.r.o.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Offline tests for package-all.sh. No Go, no network — a fake dist tree stands
+# in for build-all.sh output so we can assert the packaged tarball carries an
+# executable `runwisp` member regardless of the on-disk mode it was handed.
+#
+# The regression under guard: actions/upload-artifact strips the Unix
+# executable bit, so the release job packages a mode-0644 binary. v0.14.0
+# shipped four tarballs whose extracted `runwisp` was not runnable.
+set -euo pipefail
+
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+script="${here}/../package-all.sh"
+[[ -f "${script}" ]] || { echo "cannot find ${script}" >&2; exit 2; }
+
+passed=0
+failed=0
+
+# Mode of the `runwisp` member inside a tarball, e.g. "-rwxr-xr-x".
+member_mode() {
+  tar tzvf "$1" | awk '$NF == "runwisp" { print $1 }'
+}
+
+pass() { passed=$((passed + 1)); printf 'ok   - %s\n' "$1"; }
+fail() { failed=$((failed + 1)); printf 'FAIL - %s\n' "$1" >&2; }
+
+# --- packs a 0644 binary as an executable member (the actual v0.14.0 bug) ---
+work=$(mktemp -d)
+trap 'rm -rf "${work}"' EXIT
+mkdir -p "${work}/dist/linux-x64" "${work}/dist/darwin-arm64" "${work}/out"
+for t in linux-x64 darwin-arm64; do
+  printf '#!/bin/sh\necho hi\n' > "${work}/dist/${t}/runwisp"
+  chmod 0644 "${work}/dist/${t}/runwisp" # as returned by download-artifact
+done
+
+if "${script}" "${work}/dist" "${work}/out" >/dev/null; then
+  pass "package-all.sh exits 0 on a valid dist tree"
+else
+  fail "package-all.sh exits 0 on a valid dist tree"
+fi
+
+for t in linux-x64 darwin-arm64; do
+  mode=$(member_mode "${work}/out/runwisp-${t}.tar.gz")
+  case "${mode}" in
+    -rwxr-xr-x*) pass "runwisp-${t}.tar.gz member is executable (${mode})" ;;
+    *) fail "runwisp-${t}.tar.gz member is ${mode:-<missing>}, want -rwxr-xr-x" ;;
+  esac
+done
+
+# --- fails loudly when a target directory has no binary ---
+empty=$(mktemp -d)
+mkdir -p "${empty}/dist/linux-x64"
+if "${script}" "${empty}/dist" "${empty}/out" >/dev/null 2>&1; then
+  fail "package-all.sh should reject a target dir with no runwisp binary"
+else
+  pass "package-all.sh rejects a target dir with no runwisp binary"
+fi
+rm -rf "${empty}"
+
+# --- fails loudly when there are no targets at all ---
+none=$(mktemp -d)
+mkdir -p "${none}/dist"
+if "${script}" "${none}/dist" "${none}/out" >/dev/null 2>&1; then
+  fail "package-all.sh should reject an empty dist dir"
+else
+  pass "package-all.sh rejects an empty dist dir"
+fi
+rm -rf "${none}"
+
+printf '\n%d passed, %d failed\n' "${passed}" "${failed}"
+[[ "${failed}" -eq 0 ]]


### PR DESCRIPTION
## What

The four v0.14.0 release tarballs package the `runwisp` member as mode `0644`, so the documented manual install fails:

```
tar -xzf runwisp-linux-x64.tar.gz
sudo mv runwisp /usr/local/bin/runwisp
runwisp   # permission denied
```

## Why

The `build` job cross-compiles the binaries (mode `0755`) and uploads them via `actions/upload-artifact`, which does **not** preserve the Unix executable bit. The `github-release` job downloads them back as mode `0644` and `tar czf`s them as-is, so the archived member is non-executable.

## Change

- **`apps/runwisp/scripts/package-all.sh`** (new): packages each `dist/<target>/runwisp` into `runwisp-<target>.tar.gz` with the member forced to mode `0755`, then verifies every archive ships an executable member and fails the build otherwise (release-time guard against a regression).
- **`release.yml`**: `github-release` calls the script instead of the inline `tar` loop.
- **`ci.yml`**: shellchecks the script and runs a new unit test.
- **`package-all_test.sh`** (new): builds a fake `dist` tree with a mode-`0644` binary (reproducing the download-artifact round-trip) and asserts the packaged member is `0755`; also covers the empty/missing-binary failure paths.
- **Docs**: the manual install uses `sudo install -m 0755` so it's robust regardless of the tarball's mode.

Verified locally by packaging a `0644` binary through the script and independently extracting it: `stat` reports `-rwxr-xr-x`.