### PR TITLE
chore: ponytail audit pass — cut dead code and duplication

### DIFF
--- a/apps/runwisp/cmd/runwisp/cli_errors.go
+++ b/apps/runwisp/cmd/runwisp/cli_errors.go
@@ -165,19 +165,6 @@ func unknownTaskError(taskName string, available []string) error {
 	}
 }
 
-// passwordMismatchError is returned when a different RunWisp daemon is
-// already running on the configured port with a different password.
-func passwordMismatchError(port int) error {
-	return &userFacingError{
-		title: fmt.Sprintf("another RunWisp daemon is already running on port %d with a different password", port),
-		details: "This usually happens when an instance was started from a different directory.\n" +
-			"To resolve this, you can:\n" +
-			"  - Stop the other daemon first\n" +
-			"  - Use a different port:  runwisp --port <PORT>\n" +
-			"  - Set RUNWISP_PASSWORD to the other daemon's password to connect to it",
-	}
-}
-
 // runwispPortConflictError is shown (non-interactively) when the port is held
 // by *another RunWisp daemon* started from a different data directory. Unlike
 // portConflictError, we know exactly what is there — so we name its datadir and
@@ -209,23 +196,6 @@ func instanceSummaryLines(info *model.InstanceInfo) []string {
 	return []string{
 		"  - data dir:  " + info.DataDir,
 		"  - config:    " + info.ConfigPath,
-	}
-}
-
-// tuiPasswordMismatchError is the variant shown by the `tui` subcommand.
-// explicit indicates the user supplied the password themselves.
-func tuiPasswordMismatchError(port int, explicit bool) error {
-	if explicit {
-		return &userFacingError{
-			title: fmt.Sprintf("the password does not match the daemon on port %d", port),
-		}
-	}
-	return &userFacingError{
-		title: fmt.Sprintf("password mismatch with the daemon on port %d", port),
-		details: "The daemon was likely started from a different directory with its own password.\n" +
-			"To fix this, either:\n" +
-			"  - Use --password or RUNWISP_PASSWORD with the correct password\n" +
-			"  - Stop the other daemon and restart from this directory",
 	}
 }
 

--- a/apps/runwisp/cmd/runwisp/cli_errors_test.go
+++ b/apps/runwisp/cmd/runwisp/cli_errors_test.go
@@ -105,30 +105,6 @@ func TestRenderError_WithHint(t *testing.T) {
 	assert.Contains(t, out, "Run 'runwisp --help' for usage.")
 }
 
-func TestPasswordMismatchError_PortInTitle(t *testing.T) {
-	err := passwordMismatchError(9477)
-	var ufe *userFacingError
-	require.True(t, errors.As(err, &ufe))
-	assert.Contains(t, ufe.title, "9477")
-	assert.Contains(t, ufe.details, "RUNWISP_PASSWORD")
-}
-
-func TestTUIPasswordMismatchError_Explicit(t *testing.T) {
-	err := tuiPasswordMismatchError(9477, true)
-	var ufe *userFacingError
-	require.True(t, errors.As(err, &ufe))
-	assert.Contains(t, ufe.title, "does not match")
-	assert.Empty(t, ufe.details)
-}
-
-func TestTUIPasswordMismatchError_Implicit(t *testing.T) {
-	err := tuiPasswordMismatchError(9477, false)
-	var ufe *userFacingError
-	require.True(t, errors.As(err, &ufe))
-	assert.Contains(t, ufe.title, "password mismatch")
-	assert.Contains(t, ufe.details, "--password")
-}
-
 func TestAuthRateLimitedError_HasHints(t *testing.T) {
 	err := authRateLimitedError(9477)
 	var ufe *userFacingError

--- a/apps/runwisp/cmd/runwisp/cloud_adapters.go
+++ b/apps/runwisp/cmd/runwisp/cloud_adapters.go
@@ -19,54 +19,19 @@ type cloudRuntime interface {
 }
 
 // cloudTaskRunner adapts the concrete runtime task manager to cloud.TaskRunner.
-// Specifically it translates the cloud's "trigger a cloud-tagged run for this
-// execution id" call into the runtime's richer TriggerRunWithOptions API.
+// It embeds the runtime surface so every observe/trigger method forwards for
+// free; only TriggerCloudRun needs translating into the runtime's richer
+// TriggerRunWithOptions API.
 type cloudTaskRunner struct {
-	inner cloudRuntime
-}
-
-func (a *cloudTaskRunner) GetTask(name string) (*model.Task, bool) {
-	return a.inner.GetTask(name)
-}
-
-func (a *cloudTaskRunner) ListServiceTasks() []*model.Task {
-	return a.inner.ListServiceTasks()
-}
-
-func (a *cloudTaskRunner) UpsertTask(task *model.Task) {
-	a.inner.UpsertTask(task)
-}
-
-func (a *cloudTaskRunner) RemoveTask(taskName string) {
-	a.inner.RemoveTask(taskName)
+	cloudRuntime
 }
 
 func (a *cloudTaskRunner) TriggerCloudRun(taskName, externalExecutionID string, params map[string]string) (*model.Run, error) {
-	return a.inner.TriggerRunWithOptions(taskName, runtime.TriggerRunOptions{
+	return a.TriggerRunWithOptions(taskName, runtime.TriggerRunOptions{
 		TriggeredBy:         model.TriggeredByCloud,
 		ExternalExecutionID: externalExecutionID,
 		// The cloud protocol carries plain string values (no explicit-omit state),
 		// so every supplied key is a present value; absent keys use the default.
 		Params: model.PointerValues(params),
 	})
-}
-
-func (a *cloudTaskRunner) TerminateRunByExternalExecutionID(externalExecutionID string) error {
-	return a.inner.TerminateRunByExternalExecutionID(externalExecutionID)
-}
-
-func (a *cloudTaskRunner) StartServiceInstances(taskName string, triggeredBy model.TriggeredBy) error {
-	return a.inner.StartServiceInstances(taskName, triggeredBy)
-}
-
-func (a *cloudTaskRunner) StopService(taskName string) error {
-	return a.inner.StopService(taskName)
-}
-
-func (a *cloudTaskRunner) RestartServiceInstances(taskName string) error {
-	return a.inner.RestartServiceInstances(taskName)
-}
-
-func (a *cloudTaskRunner) ServiceSnapshot(taskName string) (model.ServiceSnapshot, bool) {
-	return a.inner.ServiceSnapshot(taskName)
 }

--- a/apps/runwisp/cmd/runwisp/cloud_adapters_test.go
+++ b/apps/runwisp/cmd/runwisp/cloud_adapters_test.go
@@ -85,7 +85,7 @@ func TestCloudTaskRunner_GetTask_DelegatesAndPropagates(t *testing.T) {
 		getTaskOut: &model.Task{Name: "backup"},
 		getTaskOK:  true,
 	}
-	a := &cloudTaskRunner{inner: inner}
+	a := &cloudTaskRunner{cloudRuntime: inner}
 
 	got, ok := a.GetTask("backup")
 	assert.True(t, ok)
@@ -96,7 +96,7 @@ func TestCloudTaskRunner_GetTask_DelegatesAndPropagates(t *testing.T) {
 
 func TestCloudTaskRunner_UpsertTask_DelegatesTask(t *testing.T) {
 	inner := &stubTaskRunner{}
-	a := &cloudTaskRunner{inner: inner}
+	a := &cloudTaskRunner{cloudRuntime: inner}
 
 	task := &model.Task{Name: "alpha"}
 	a.UpsertTask(task)
@@ -106,7 +106,7 @@ func TestCloudTaskRunner_UpsertTask_DelegatesTask(t *testing.T) {
 func TestCloudTaskRunner_TriggerCloudRun_TagsTriggeredByCloud(t *testing.T) {
 	want := &model.Run{ID: "r1", TaskName: "alpha", CreatedAt: time.Now()}
 	inner := &stubTaskRunner{triggerRun: want}
-	a := &cloudTaskRunner{inner: inner}
+	a := &cloudTaskRunner{cloudRuntime: inner}
 
 	got, err := a.TriggerCloudRun("alpha", "exec-123", map[string]string{"REGION": "eu"})
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestCloudTaskRunner_TriggerCloudRun_TagsTriggeredByCloud(t *testing.T) {
 func TestCloudTaskRunner_TriggerCloudRun_PropagatesError(t *testing.T) {
 	boom := errors.New("trigger failed")
 	inner := &stubTaskRunner{triggerErr: boom}
-	a := &cloudTaskRunner{inner: inner}
+	a := &cloudTaskRunner{cloudRuntime: inner}
 
 	_, err := a.TriggerCloudRun("x", "e", nil)
 	assert.ErrorIs(t, err, boom)
@@ -131,7 +131,7 @@ func TestCloudTaskRunner_TriggerCloudRun_PropagatesError(t *testing.T) {
 
 func TestCloudTaskRunner_TerminateRunByExternalExecutionID_Delegates(t *testing.T) {
 	inner := &stubTaskRunner{}
-	a := &cloudTaskRunner{inner: inner}
+	a := &cloudTaskRunner{cloudRuntime: inner}
 
 	require.NoError(t, a.TerminateRunByExternalExecutionID("ext-42"))
 	assert.Equal(t, "ext-42", inner.terminatedExternal)
@@ -140,7 +140,7 @@ func TestCloudTaskRunner_TerminateRunByExternalExecutionID_Delegates(t *testing.
 func TestCloudTaskRunner_TerminateRunByExternalExecutionID_PropagatesError(t *testing.T) {
 	boom := errors.New("nope")
 	inner := &stubTaskRunner{terminatedErr: boom}
-	a := &cloudTaskRunner{inner: inner}
+	a := &cloudTaskRunner{cloudRuntime: inner}
 
 	err := a.TerminateRunByExternalExecutionID("ext")
 	assert.ErrorIs(t, err, boom)

--- a/apps/runwisp/cmd/runwisp/cmd_service_install.go
+++ b/apps/runwisp/cmd/runwisp/cmd_service_install.go
@@ -91,7 +91,7 @@ func runServiceInstall(cmd *cobra.Command, f Flags) error {
 // decision now lives in internal/cutover, and all this does about cron is point
 // at `runwisp takeover` when one would help.
 func installService(cmd *cobra.Command, f Flags, req installRequest) (installed bool, err error) {
-	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), cmd.ErrOrStderr(), os.Stdin, req.Yes)
+	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), os.Stdin, req.Yes)
 	if err != nil {
 		return false, err
 	}
@@ -518,7 +518,7 @@ func handStartedDaemonError(info *model.InstanceInfo, host string, port int) err
 }
 
 // printDryRun emits a plan summary for --dry-run.
-func printDryRun(w interface{ Write([]byte) (int, error) }, plan autostart.Plan) {
+func printDryRun(w io.Writer, plan autostart.Plan) {
 	fmt.Fprintf(w, "Plan: %s\n", plan.Kind)
 	fmt.Fprintf(w, "Reason: %s\n", plan.Reason)
 	fmt.Fprintln(w)

--- a/apps/runwisp/cmd/runwisp/cmd_service_status.go
+++ b/apps/runwisp/cmd/runwisp/cmd_service_status.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 func runServiceStatus(cmd *cobra.Command, f Flags) error {
-	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), cmd.ErrOrStderr(), os.Stdin, true)
+	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), os.Stdin, true)
 	if err != nil {
 		return err
 	}

--- a/apps/runwisp/cmd/runwisp/cmd_service_uninstall.go
+++ b/apps/runwisp/cmd/runwisp/cmd_service_uninstall.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 func runServiceUninstall(cmd *cobra.Command, f Flags) error {
-	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), cmd.ErrOrStderr(), os.Stdin, serviceUninstallOpts.Yes)
+	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), os.Stdin, serviceUninstallOpts.Yes)
 	if err != nil {
 		return err
 	}

--- a/apps/runwisp/cmd/runwisp/cutover_wiring.go
+++ b/apps/runwisp/cmd/runwisp/cutover_wiring.go
@@ -58,7 +58,7 @@ func newCutover(f Flags, deps autostart.Deps, installer autostart.Installer, opt
 // so `takeover --dry-run` on a non-root macOS box still prints what it found and
 // what would stop it, instead of dying before it can say anything.
 func resolveCutover(cmd *cobra.Command, f Flags, req takeoverRequest) (*cutover.Cutover, error) {
-	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), cmd.ErrOrStderr(), os.Stdin, req.Yes)
+	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), os.Stdin, req.Yes)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,6 @@ func resolveCutover(cmd *cobra.Command, f Flags, req takeoverRequest) (*cutover.
 	}
 
 	return newCutover(f, deps, installer, opts, cutover.Options{
-		DryRun:               req.DryRun,
 		AllowSkippedCronJobs: req.AllowSkippedCronJobs,
 	}), nil
 }

--- a/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
+++ b/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
@@ -41,7 +41,7 @@ func startCloudClient(
 	}
 
 	cloudClient, clientErr := cloud.NewClient(cfg.CloudConfig, cloud.Dependencies{
-		TaskManager:       &cloudTaskRunner{inner: svc.TaskManager},
+		TaskManager:       &cloudTaskRunner{cloudRuntime: svc.TaskManager},
 		RunRepo:           svc.DB,
 		PendingUploadRepo: svc.DB,
 		EventBus:          svc.EventBus,

--- a/apps/runwisp/cmd/runwisp/daemon_lifecycle_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_lifecycle_test.go
@@ -177,7 +177,7 @@ func TestGracefulShutdown_WithScheduler(t *testing.T) {
 	tasks := runtime.NewTaskRegistry(tasksMap)
 
 	loc, _ := config.ResolveTimezone("scheduler.timezone", "UTC")
-	scheduler := runtime.NewScheduler(tm, tasksMap, loc)
+	scheduler := runtime.NewScheduler(tm, tasksMap, loc, nil)
 	_, _ = scheduler.Start()
 
 	svc := &daemonServices{

--- a/apps/runwisp/cmd/runwisp/daemon_notify.go
+++ b/apps/runwisp/cmd/runwisp/daemon_notify.go
@@ -86,7 +86,7 @@ func initNotify(
 	var hub *inapp.Hub
 	var inappCh *inapp.Channel
 	if inappWanted {
-		hub = inapp.NewHub(32, 50)
+		hub = inapp.NewHub(32)
 
 		coalescerCfg := inapp.CoalescerConfig{
 			Window:      notifyCfg.CoalesceWindow,

--- a/apps/runwisp/cmd/runwisp/daemon_notify_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_notify_test.go
@@ -31,7 +31,7 @@ func TestServerHub(t *testing.T) {
 		assert.Nil(t, b.serverHub(), "serverHub() leaked a typed-nil interface")
 	})
 	t.Run("real hub passes through", func(t *testing.T) {
-		b := notifyBundle{Hub: inapp.NewHub(32, 50)}
+		b := notifyBundle{Hub: inapp.NewHub(32)}
 		got := b.serverHub()
 		require.NotNil(t, got)
 		assert.Same(t, b.Hub, got)

--- a/apps/runwisp/cmd/runwisp/daemon_services.go
+++ b/apps/runwisp/cmd/runwisp/daemon_services.go
@@ -169,7 +169,7 @@ func startStandaloneScheduling(ctx context.Context, cfg *daemonConfig, db storag
 		return boot, locErr
 	}
 	boot.schedLoc = schedLoc
-	scheduler := runtime.NewScheduler(taskManager, tasksMap, schedLoc)
+	scheduler := runtime.NewScheduler(taskManager, tasksMap, schedLoc, nil)
 	boot.scheduler = scheduler
 	schedResult, err := scheduler.Start()
 	if err != nil {

--- a/apps/runwisp/cmd/runwisp/daemon_services_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_services_test.go
@@ -256,6 +256,6 @@ func TestBuildDaemonInfo_SchedulingActiveReflectsScheduler(t *testing.T) {
 	assert.False(t, buildDaemonInfo(dc, svc, time.Time{}, f.Port).SchedulingActive)
 
 	// Standalone mode: scheduler present.
-	svc.Scheduler = runtime.NewScheduler(tm, tasksMap, time.UTC)
+	svc.Scheduler = runtime.NewScheduler(tm, tasksMap, time.UTC, nil)
 	assert.True(t, buildDaemonInfo(dc, svc, time.Time{}, f.Port).SchedulingActive)
 }

--- a/apps/runwisp/cmd/runwisp/firstrun.go
+++ b/apps/runwisp/cmd/runwisp/firstrun.go
@@ -151,7 +151,7 @@ var offerFirstRunCutover = probeFirstRunCutover
 // scaffold: a directory with both crontabs and a docker-compose.yml gets both, off
 // the one question already on screen.
 func probeFirstRunCutover(f Flags, out io.Writer, writeConfig func(path string, patterns []string) error) *firstRunCutover {
-	deps, err := autostart.DefaultDeps(out, out, os.Stdin, false)
+	deps, err := autostart.DefaultDeps(out, os.Stdin, false)
 	if err != nil {
 		return nil
 	}

--- a/apps/runwisp/cmd/runwisp/import_report.go
+++ b/apps/runwisp/cmd/runwisp/import_report.go
@@ -4,11 +4,11 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/runwisp/runwisp/internal/importer"
+	"github.com/runwisp/runwisp/internal/textutil"
 )
 
 // This file lays out the import report. Every function here is pure — it takes
@@ -180,11 +180,11 @@ func importFooterLine(res *importer.Result, validationErr error) string {
 	}
 	// "item", not "task": a blocked row may be a crontab line that never became a
 	// task at all, and it pairs with the epilogue's "Fix the items above".
-	subject := fmt.Sprintf("%d %s", blocked, plural(blocked, "item", "items"))
+	subject := textutil.Count(blocked, "item", "items")
 	if validationErr != nil {
-		return subject + " " + plural(blocked, "needs", "need") + " a fix before this config loads."
+		return subject + " " + textutil.Pluralize(blocked, "needs", "need") + " a fix before this config loads."
 	}
-	return subject + " " + plural(blocked, "carries", "carry") + " a # TODO — fix it before you rely on it."
+	return subject + " " + textutil.Pluralize(blocked, "carries", "carry") + " a # TODO — fix it before you rely on it."
 }
 
 // onlyBlocking keeps the rows that need a human. It is how --quiet silences the

--- a/apps/runwisp/cmd/runwisp/import_summary.go
+++ b/apps/runwisp/cmd/runwisp/import_summary.go
@@ -13,6 +13,7 @@ import (
 	"github.com/runwisp/runwisp/internal/config"
 	"github.com/runwisp/runwisp/internal/configedit"
 	"github.com/runwisp/runwisp/internal/importer"
+	"github.com/runwisp/runwisp/internal/textutil"
 )
 
 // This file owns how an import *reads*: the counts, the per-job rows, the
@@ -314,20 +315,13 @@ func planTail(w io.Writer, st importStyles, rep importReport) {
 func pluralizeCounts(tasks, services int) string {
 	var parts []string
 	if tasks > 0 {
-		parts = append(parts, fmt.Sprintf("%d %s", tasks, plural(tasks, "task", "tasks")))
+		parts = append(parts, textutil.Count(tasks, "task", "tasks"))
 	}
 	if services > 0 {
-		parts = append(parts, fmt.Sprintf("%d %s", services, plural(services, "service", "services")))
+		parts = append(parts, textutil.Count(services, "service", "services"))
 	}
 	if len(parts) == 0 {
 		return "nothing"
 	}
 	return strings.Join(parts, ", ")
-}
-
-func plural(n int, one, many string) string {
-	if n == 1 {
-		return one
-	}
-	return many
 }

--- a/apps/runwisp/cmd/runwisp/json_output.go
+++ b/apps/runwisp/cmd/runwisp/json_output.go
@@ -329,18 +329,19 @@ func messageFromError(err error) messageJSON {
 }
 
 // messagesFromError expands a config error into one messageJSON per underlying
-// problem: a config.MultiError (several unknown keys, or several invalid tasks)
+// problem: a joined error (several unknown keys, or several invalid tasks)
 // yields one entry each with its own key/line/column; any other error yields a
 // single entry. This is why `validate --json` reports every location, not just
 // the first.
 func messagesFromError(err error) []messageJSON {
-	var multi *config.MultiError
-	if errors.As(err, &multi) && len(multi.Errors) > 0 {
-		out := make([]messageJSON, 0, len(multi.Errors))
-		for _, e := range multi.Errors {
-			out = append(out, messageFromError(e))
+	if multi, ok := err.(interface{ Unwrap() []error }); ok {
+		if errs := multi.Unwrap(); len(errs) > 0 {
+			out := make([]messageJSON, 0, len(errs))
+			for _, e := range errs {
+				out = append(out, messageFromError(e))
+			}
+			return out
 		}
-		return out
 	}
 	return []messageJSON{messageFromError(err)}
 }

--- a/apps/runwisp/cmd/runwisp/jsoncache.go
+++ b/apps/runwisp/cmd/runwisp/jsoncache.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"log/slog"
+
+	"github.com/runwisp/runwisp/internal/datadir"
+)
+
+// loadJSONCacheMap reads path as a JSON object into a map, tolerating a
+// missing or corrupt file by returning an empty map — callers treat "no
+// entry" and "unreadable cache" identically.
+func loadJSONCacheMap[V any](path string) map[string]V {
+	cache := map[string]V{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cache
+	}
+	_ = json.Unmarshal(data, &cache)
+	return cache
+}
+
+// storeJSONCacheEntry read-modify-writes entry under key into the JSON object
+// cache at path. Failures are logged at debug and swallowed: these caches are
+// best-effort optimizations, never a precondition for the caller's operation.
+func storeJSONCacheEntry[V any](path, what, key string, entry V) {
+	cache := loadJSONCacheMap[V](path)
+	cache[key] = entry
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		slog.Debug("Skipping "+what+" cache: marshal failed", "err", err)
+		return
+	}
+	if err := datadir.EnsureDir(filepath.Dir(path)); err != nil {
+		slog.Debug("Skipping "+what+" cache: cannot create cache dir", "err", err)
+		return
+	}
+	if err := datadir.WriteSecretFile(path, data); err != nil {
+		slog.Debug("Skipping "+what+" cache: write failed", "err", err)
+	}
+}

--- a/apps/runwisp/cmd/runwisp/remote_cert_pins.go
+++ b/apps/runwisp/cmd/runwisp/remote_cert_pins.go
@@ -4,13 +4,8 @@
 package main
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-
-	"log/slog"
-
-	"github.com/runwisp/runwisp/internal/datadir"
 )
 
 // A remote daemon serving auto-HTTPS presents a self-signed certificate with no
@@ -43,15 +38,7 @@ func (certPinStore) Load(key string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", false
-	}
-	var pins map[string]string
-	if err := json.Unmarshal(data, &pins); err != nil {
-		return "", false
-	}
-	fp, ok := pins[key]
+	fp, ok := loadJSONCacheMap[string](path)[key]
 	return fp, ok && fp != ""
 }
 
@@ -62,25 +49,7 @@ func (certPinStore) Load(key string) (string, bool) {
 func (certPinStore) Store(key, fingerprint string) {
 	path, err := pinStorePath()
 	if err != nil {
-		slog.Debug("Skipping cert pin: no user cache dir", "err", err)
 		return
 	}
-	pins := map[string]string{}
-	if data, readErr := os.ReadFile(path); readErr == nil {
-		_ = json.Unmarshal(data, &pins) // a corrupt file is simply overwritten
-	}
-	pins[key] = fingerprint
-
-	data, err := json.Marshal(pins)
-	if err != nil {
-		slog.Debug("Skipping cert pin: marshal failed", "err", err)
-		return
-	}
-	if err := datadir.EnsureDir(filepath.Dir(path)); err != nil {
-		slog.Debug("Skipping cert pin: cannot create cache dir", "err", err)
-		return
-	}
-	if err := datadir.WriteSecretFile(path, data); err != nil {
-		slog.Debug("Skipping cert pin: write failed", "err", err)
-	}
+	storeJSONCacheEntry(path, "cert pin", key, fingerprint)
 }

--- a/apps/runwisp/cmd/runwisp/remote_token_cache.go
+++ b/apps/runwisp/cmd/runwisp/remote_token_cache.go
@@ -11,10 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"log/slog"
-
 	"github.com/runwisp/runwisp/internal/apiclient"
-	"github.com/runwisp/runwisp/internal/datadir"
 )
 
 // The CLI caches the JWT minted by a remote daemon so repeated `runwisp exec
@@ -54,14 +51,7 @@ func loadCachedToken(baseURL string) string {
 	if err != nil {
 		return ""
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-	var cache map[string]cachedToken
-	if err := json.Unmarshal(data, &cache); err != nil {
-		return ""
-	}
+	cache := loadJSONCacheMap[cachedToken](path)
 	entry, ok := cache[apiclient.NormalizeBaseURL(baseURL)]
 	if !ok || entry.Token == "" {
 		return ""
@@ -78,27 +68,9 @@ func loadCachedToken(baseURL string) string {
 func storeCachedToken(baseURL, token string) {
 	path, err := tokenCachePath()
 	if err != nil {
-		slog.Debug("Skipping token cache: no user cache dir", "err", err)
 		return
 	}
-	cache := map[string]cachedToken{}
-	if data, readErr := os.ReadFile(path); readErr == nil {
-		_ = json.Unmarshal(data, &cache) // a corrupt file is simply overwritten
-	}
-	cache[apiclient.NormalizeBaseURL(baseURL)] = cachedToken{Token: token, ExpiresAt: jwtExpiry(token)}
-
-	data, err := json.Marshal(cache)
-	if err != nil {
-		slog.Debug("Skipping token cache: marshal failed", "err", err)
-		return
-	}
-	if err := datadir.EnsureDir(filepath.Dir(path)); err != nil {
-		slog.Debug("Skipping token cache: cannot create cache dir", "err", err)
-		return
-	}
-	if err := datadir.WriteSecretFile(path, data); err != nil {
-		slog.Debug("Skipping token cache: write failed", "err", err)
-	}
+	storeJSONCacheEntry(path, "token", apiclient.NormalizeBaseURL(baseURL), cachedToken{Token: token, ExpiresAt: jwtExpiry(token)})
 }
 
 // jwtExpiry pulls the `exp` claim (unix seconds) out of a JWT without

--- a/apps/runwisp/cmd/runwisp/service_control.go
+++ b/apps/runwisp/cmd/runwisp/service_control.go
@@ -49,7 +49,7 @@ func serviceManagerName(st autostart.Status) string {
 // block a plain stop. local mirrors the --local flag; without it the scope
 // is detected from what is actually installed.
 func serviceState(cmd *cobra.Command, f Flags, local bool) (autostart.Installer, autostart.InstallOptions, autostart.Status, bool) {
-	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), cmd.ErrOrStderr(), os.Stdin, true)
+	deps, err := autostart.DefaultDeps(cmd.OutOrStdout(), os.Stdin, true)
 	if err != nil {
 		return nil, autostart.InstallOptions{}, autostart.Status{}, false
 	}

--- a/apps/runwisp/internal/autostart/common_test.go
+++ b/apps/runwisp/internal/autostart/common_test.go
@@ -186,12 +186,11 @@ func TestNewOSFileSystem_WriteReadStatRemove(t *testing.T) {
 }
 
 func TestDefaultDeps_RealEnvironment(t *testing.T) {
-	d, err := DefaultDeps(io.Discard, io.Discard, nil, true)
+	d, err := DefaultDeps(io.Discard, nil, true)
 	require.NoError(t, err)
 	assert.NotEmpty(t, d.Home, "home directory present")
 	assert.NotEmpty(t, d.User, "user present")
 	assert.NotEmpty(t, d.Fingerprint, "fingerprint generated")
-	assert.True(t, d.AutoOK)
 	assert.NotNil(t, d.FS)
 	assert.NotNil(t, d.Cmd)
 	assert.NotNil(t, d.Prompter)
@@ -213,12 +212,4 @@ func TestFakeRunner_LogAndExhaustion(t *testing.T) {
 	log := r.Log()
 	assert.Len(t, log, 2)
 	assert.Equal(t, "systemctl", log[0].Name)
-}
-
-func TestArgsEqual(t *testing.T) {
-	assert.True(t, argsEqual(nil, nil))
-	assert.True(t, argsEqual([]string{}, []string{}))
-	assert.True(t, argsEqual([]string{"a", "b"}, []string{"a", "b"}))
-	assert.False(t, argsEqual([]string{"a"}, []string{"a", "b"}))
-	assert.False(t, argsEqual([]string{"a", "b"}, []string{"a", "c"}))
 }

--- a/apps/runwisp/internal/autostart/deps.go
+++ b/apps/runwisp/internal/autostart/deps.go
@@ -19,7 +19,6 @@ type Deps struct {
 	Cmd      Runner
 	Prompter Prompter
 	Stdout   io.Writer
-	Stderr   io.Writer
 
 	// Home is the operator's home directory. Drives unit path,
 	// linger username, the "binary under ~/.cache" warning, etc.
@@ -39,9 +38,6 @@ type Deps struct {
 	// non-conflicting units. Required.
 	Fingerprint string
 
-	// AutoOK reflects the --yes flag.
-	AutoOK bool
-
 	// StdinIsTTY reflects whether stdin is attached to a terminal.
 	StdinIsTTY bool
 
@@ -55,8 +51,8 @@ type Deps struct {
 
 // DefaultDeps returns a Deps with production seams, sniffing the
 // usual environment signals for home / user / XDG / WSL / TTY.
-func DefaultDeps(stdout, stderr io.Writer, stdin *os.File, autoOK bool) (Deps, error) {
-	home, err := UserHomeDir()
+func DefaultDeps(stdout io.Writer, stdin *os.File, autoOK bool) (Deps, error) {
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return Deps{}, err
 	}
@@ -69,14 +65,12 @@ func DefaultDeps(stdout, stderr io.Writer, stdin *os.File, autoOK bool) (Deps, e
 		FS:          NewOSFileSystem(),
 		Cmd:         NewRunner(),
 		Stdout:      stdout,
-		Stderr:      stderr,
 		Home:        home,
 		User:        u.Username,
 		XDGDataHome: os.Getenv("XDG_DATA_HOME"),
 		XDGConfHome: os.Getenv("XDG_CONFIG_HOME"),
 		WSL:         DetectWSLFromEnv(),
 		Fingerprint: fingerprint.Generate(),
-		AutoOK:      autoOK,
 		StdinIsTTY:  isTTY,
 		Euid:        os.Geteuid(),
 	}

--- a/apps/runwisp/internal/autostart/exec.go
+++ b/apps/runwisp/internal/autostart/exec.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"slices"
 	"sync"
 )
 
@@ -72,7 +73,7 @@ func (f *FakeRunner) Run(_ context.Context, name string, args ...string) ([]byte
 	defer f.mu.Unlock()
 	f.log = append(f.log, FakeCallLog{Name: name, Args: append([]string(nil), args...)})
 	for i, c := range f.calls {
-		if c.name == name && argsEqual(c.args, args) {
+		if c.name == name && slices.Equal(c.args, args) {
 			f.calls = append(f.calls[:i], f.calls[i+1:]...)
 			return c.stdout, c.stderr, c.err
 		}
@@ -94,16 +95,4 @@ func (f *FakeRunner) Remaining() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.calls)
-}
-
-func argsEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/apps/runwisp/internal/autostart/launchd_darwin.go
+++ b/apps/runwisp/internal/autostart/launchd_darwin.go
@@ -314,8 +314,5 @@ func (l *launchdInstaller) Status(ctx context.Context, opts InstallOptions) (Sta
 
 // envPathDarwin returns the PATH the LaunchAgent will inherit.
 func envPathDarwin() string {
-	if p := os.Getenv("PATH"); p != "" {
-		return p
-	}
-	return "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
+	return envPathOrDefault("/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin")
 }

--- a/apps/runwisp/internal/autostart/paths.go
+++ b/apps/runwisp/internal/autostart/paths.go
@@ -65,11 +65,20 @@ func transientBinaryReason(p string) string {
 	if strings.Contains(p, "/go-build") && strings.Contains(p, "/exe/") {
 		return "this looks like a `go run` cache path"
 	}
+	return transientPathReason(p, "/var/tmp is not a durable install location")
+}
+
+// transientPathReason returns a short reason string when p lives in a
+// location that will not survive a reboot. Empty means "no hard reject".
+// varTmpReason lets callers phrase the /var/tmp case for their own risk (a
+// binary needs it durable across reboots; a data dir just needs it to survive
+// tmpwatch).
+func transientPathReason(p, varTmpReason string) string {
 	switch {
 	case strings.HasPrefix(p, "/tmp/"), p == "/tmp":
 		return "/tmp is wiped on reboot"
 	case strings.HasPrefix(p, "/var/tmp/"), p == "/var/tmp":
-		return "/var/tmp is not a durable install location"
+		return varTmpReason
 	case strings.HasPrefix(p, "/dev/shm/"), p == "/dev/shm":
 		return "/dev/shm is a tmpfs that is wiped on reboot"
 	}
@@ -228,15 +237,7 @@ func ResolveDataDir(opts ResolveDataDirOptions) (ResolveDataDirResult, error) {
 
 // transientDataDirReason mirrors transientBinaryReason for data dirs.
 func transientDataDirReason(p string) string {
-	switch {
-	case strings.HasPrefix(p, "/tmp/"), p == "/tmp":
-		return "/tmp is wiped on reboot"
-	case strings.HasPrefix(p, "/var/tmp/"), p == "/var/tmp":
-		return "/var/tmp may be cleaned by tmpwatch"
-	case strings.HasPrefix(p, "/dev/shm/"), p == "/dev/shm":
-		return "/dev/shm is a tmpfs that is wiped on reboot"
-	}
-	return ""
+	return transientPathReason(p, "/var/tmp may be cleaned by tmpwatch")
 }
 
 // ResolveConfigOptions configures ResolveConfigPath.
@@ -329,11 +330,12 @@ func DetectWSLFromEnv() bool {
 	})
 }
 
-// UserHomeDir returns the home directory, preferring $HOME for
-// determinism in unit/service contexts.
-func UserHomeDir() (string, error) {
-	if h := os.Getenv("HOME"); h != "" {
-		return h, nil
+// envPathOrDefault returns $PATH, or fallback when it's unset — a
+// non-interactive service manager may not propagate a login PATH to the unit
+// it launches.
+func envPathOrDefault(fallback string) string {
+	if p := os.Getenv("PATH"); p != "" {
+		return p
 	}
-	return os.UserHomeDir()
+	return fallback
 }

--- a/apps/runwisp/internal/autostart/paths_test.go
+++ b/apps/runwisp/internal/autostart/paths_test.go
@@ -373,25 +373,6 @@ func TestResolveConfigPath_ExplicitDefaultIgnored(t *testing.T) {
 	assert.Equal(t, "/home/alice/.config/runwisp/runwisp.toml", p)
 }
 
-func TestUserHomeDir_PrefersHOMEEnv(t *testing.T) {
-	t.Setenv("HOME", "/custom/home")
-	got, err := UserHomeDir()
-	require.NoError(t, err)
-	assert.Equal(t, "/custom/home", got)
-}
-
-func TestUserHomeDir_FallsBackWhenHOMEEmpty(t *testing.T) {
-	// On Linux/macOS the os.UserHomeDir() fallback also reads $HOME;
-	// to actually hit os.UserHomeDir() we have to unset HOME entirely.
-	t.Setenv("HOME", "")
-	got, err := UserHomeDir()
-	// We don't assert success — on a stripped env os.UserHomeDir
-	// may legitimately fail. We only need both branches executed.
-	if err == nil {
-		assert.NotEmpty(t, got)
-	}
-}
-
 func TestDetectWSLFromEnv_NoSignals(t *testing.T) {
 	t.Setenv("WSL_DISTRO_NAME", "")
 	// We can't unset /proc/sys/kernel/osrelease, but DetectWSL is the

--- a/apps/runwisp/internal/autostart/systemd_linux.go
+++ b/apps/runwisp/internal/autostart/systemd_linux.go
@@ -632,10 +632,7 @@ func (s *systemdInstaller) checkLinger(ctx context.Context) (bool, error) {
 
 // envPath returns the PATH the unit will inherit.
 func envPath() string {
-	if p := os.Getenv("PATH"); p != "" {
-		return p
-	}
-	return defaultPATH
+	return envPathOrDefault(defaultPATH)
 }
 
 // parseSystemdTimestamp parses the ActiveEnterTimestamp emitted by

--- a/apps/runwisp/internal/autostart/systemd_linux_test.go
+++ b/apps/runwisp/internal/autostart/systemd_linux_test.go
@@ -34,12 +34,10 @@ func newFakeInstaller(t *testing.T, wsl bool) (*systemdInstaller, *FakeFS, *Fake
 		Cmd:         cmd,
 		Prompter:    prompter,
 		Stdout:      &bytes.Buffer{},
-		Stderr:      &bytes.Buffer{},
 		Home:        "/home/alice",
 		User:        "alice",
 		WSL:         wsl,
 		Fingerprint: "bright-falcon",
-		AutoOK:      true,
 		StdinIsTTY:  false,
 		Euid:        1000, // alice: non-root, so a systemWide call needs "sudo".
 	}

--- a/apps/runwisp/internal/cloud/client.go
+++ b/apps/runwisp/internal/cloud/client.go
@@ -363,14 +363,14 @@ func (client *Client) startSession(ctx context.Context, connection *websocket.Co
 	}
 	session.lastReceived.Store(time.Now().UnixMilli())
 
-	change := client.conn.attachSession(session)
+	isFirstConnect := client.conn.attachSession(session)
 
 	// Clear stale log listeners from a previous session. This is a safety net
 	// in case the previous session's teardown was interrupted by a panic.
 	if client.handler != nil {
 		client.handler.ClearLogListeners()
 	}
-	if change.IsFirstConnect && client.onConnected != nil {
+	if isFirstConnect && client.onConnected != nil {
 		client.onConnected()
 	}
 	client.conn.flushPendingUpdates()
@@ -400,7 +400,7 @@ func closeConnection(conn *websocket.Conn, reason string) {
 }
 
 func sendMessage(session *wsSession, message any) error {
-	payload, err := EncodeOutboundMessage(message)
+	payload, err := json.Marshal(message)
 	if err != nil {
 		return &CloudError{Kind: CloudErrorKindValidation, Message: "failed to encode outbound message", Err: err}
 	}

--- a/apps/runwisp/internal/cloud/config.go
+++ b/apps/runwisp/internal/cloud/config.go
@@ -28,11 +28,6 @@ type Config struct {
 	TaskSyncTimeout time.Duration
 }
 
-// LoadConfigFromEnv loads cloud configuration from environment variables only.
-func LoadConfigFromEnv(agentVersion, fingerprint string) (Config, error) {
-	return LoadConfig(agentVersion, "", "", fingerprint)
-}
-
 // LoadConfig loads cloud configuration. CLI overrides (tokenOverride, urlOverride)
 // take precedence over environment variables. fingerprint must be pre-resolved
 // by the caller (from persistent storage or environment).

--- a/apps/runwisp/internal/cloud/config_test.go
+++ b/apps/runwisp/internal/cloud/config_test.go
@@ -91,26 +91,6 @@ func TestLoadConfigURLOverrideTakesPrecedenceOverEnv(t *testing.T) {
 	assert.Equal(t, "override.example.com", cfg.BaseURL.Host)
 }
 
-func TestLoadConfigFromEnv_TokenSet(t *testing.T) {
-	t.Setenv("RUNWISP_CLOUD_TOKEN", "env-token")
-	t.Setenv("RUNWISP_CLOUD_URL", "")
-	t.Setenv("RUNWISP_CLOUD_ALLOW_INSECURE", "")
-
-	cfg, err := LoadConfigFromEnv("1.0.0", "fp")
-	require.NoError(t, err)
-	assert.True(t, cfg.Enabled)
-	assert.Equal(t, "env-token", cfg.CloudToken)
-}
-
-func TestLoadConfigFromEnv_NoToken(t *testing.T) {
-	t.Setenv("RUNWISP_CLOUD_TOKEN", "")
-	t.Setenv("RUNWISP_CLOUD_URL", "")
-
-	cfg, err := LoadConfigFromEnv("1.0.0", "fp")
-	require.NoError(t, err)
-	assert.False(t, cfg.Enabled)
-}
-
 func TestLoadConfigInvalidScheme(t *testing.T) {
 	_, err := LoadConfig("1.0.0", "tok", "ftp://example.com", "fp")
 	require.Error(t, err)

--- a/apps/runwisp/internal/cloud/connection_manager.go
+++ b/apps/runwisp/internal/cloud/connection_manager.go
@@ -23,10 +23,6 @@ type connectionManager struct {
 	ready        bool
 }
 
-type SessionChange struct {
-	IsFirstConnect bool
-}
-
 func newConnectionManager(tracker *ExecutionTracker) *connectionManager {
 	return &connectionManager{
 		tracker: tracker,
@@ -71,19 +67,17 @@ func (cm *connectionManager) refreshExecutionState() {
 	cm.applyExecutionStateLocked()
 }
 
-// attachSession sets the active session and transitions to ready state.
-func (cm *connectionManager) attachSession(s *wsSession) SessionChange {
+// attachSession sets the active session and transitions to ready state,
+// reporting whether this is the first time the session has gone ready.
+func (cm *connectionManager) attachSession(s *wsSession) (isFirstConnect bool) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	change := SessionChange{
-		IsFirstConnect: !cm.ready,
-	}
-
+	isFirstConnect = !cm.ready
 	cm.session = s
 	cm.ready = true
 	cm.applyExecutionStateLocked()
-	return change
+	return isFirstConnect
 }
 
 func (cm *connectionManager) detachSession() {

--- a/apps/runwisp/internal/cloud/inbound_handler.go
+++ b/apps/runwisp/internal/cloud/inbound_handler.go
@@ -126,7 +126,7 @@ func (h *InboundHandler) HandleExecutionDispatch(ctx context.Context, message pr
 	if resolveErr != nil {
 		h.queueExecUpdate(NewExecutionUpdateMessage(executionID, protocol.ExecutionStatusErr, ptr(-1), nil, nowPtr()))
 		if h.uploader != nil {
-			h.uploader.Forget(ctx, executionID)
+			h.uploader.forget(ctx, executionID)
 		}
 		return resolveErr
 	}
@@ -183,7 +183,7 @@ func (h *InboundHandler) handleTriggerError(ctx context.Context, executionID str
 		h.queueExecUpdate(NewExecutionUpdateMessage(executionID, protocol.ExecutionStatusErr, ptr(-1), nil, nowPtr()))
 	}
 	if h.uploader != nil {
-		h.uploader.Forget(ctx, executionID)
+		h.uploader.forget(ctx, executionID)
 	}
 	return &CloudError{Kind: CloudErrorKindConflict, Message: triggerErr.Error()}
 }
@@ -308,9 +308,7 @@ func (h *InboundHandler) HandleLogStop(message protocol.LogStopMessage) {
 	if executionID == "" {
 		return
 	}
-	h.mu.Lock()
-	delete(h.logListeners, executionID)
-	h.mu.Unlock()
+	h.RemoveLogListener(executionID)
 }
 
 // IsLogListener reports whether the given execution has an active subscription.
@@ -322,15 +320,11 @@ func (h *InboundHandler) IsLogListener(executionID string) bool {
 }
 
 // RemoveLogListener removes a log listener (terminal-status cleanup or
-// log:stop). Returns true if the listener existed.
-func (h *InboundHandler) RemoveLogListener(executionID string) bool {
+// log:stop). A no-op when the listener doesn't exist.
+func (h *InboundHandler) RemoveLogListener(executionID string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if _, ok := h.logListeners[executionID]; !ok {
-		return false
-	}
 	delete(h.logListeners, executionID)
-	return true
 }
 
 // ClearLogListeners removes all active log listeners (e.g. on reconnect).

--- a/apps/runwisp/internal/cloud/inbound_handler_test.go
+++ b/apps/runwisp/internal/cloud/inbound_handler_test.go
@@ -298,7 +298,7 @@ func TestInboundHandler_FreshHandlerGetters(t *testing.T) {
 	assert.Equal(t, "/tmp/logs", h.LogDir())
 	assert.Nil(t, h.Uploader(), "uploader must be nil when not configured")
 	assert.False(t, h.IsLogListener("exec-1"), "no listener registered → must be false")
-	assert.False(t, h.RemoveLogListener("exec-1"), "removing absent listener must return false")
+	assert.NotPanics(t, func() { h.RemoveLogListener("exec-1") }, "removing an absent listener must be a no-op")
 }
 
 func TestInboundHandler_HandleLogListen_And_IsLogListener(t *testing.T) {
@@ -325,7 +325,7 @@ func TestInboundHandler_HandleLogListen_Idempotent(t *testing.T) {
 func TestInboundHandler_RemoveLogListener_Present(t *testing.T) {
 	h := newTestInboundHandler()
 	_ = h.HandleLogListen(protocol.LogListenMessage{ExecutionID: "exec-1"})
-	assert.True(t, h.RemoveLogListener("exec-1"))
+	h.RemoveLogListener("exec-1")
 	assert.False(t, h.IsLogListener("exec-1"))
 }
 

--- a/apps/runwisp/internal/cloud/log_uploader.go
+++ b/apps/runwisp/internal/cloud/log_uploader.go
@@ -35,12 +35,11 @@ type LogUploaderResult struct {
 // `pending_log_uploads` SQLite table written at dispatch time and removed
 // only on successful upload.
 type LogUploader struct {
-	repo         PendingLogUploadRepository
-	runRepo      ExternalRunGetter
-	logDir       string
-	httpClient   *http.Client
-	now          func() time.Time
-	deleteOnDone bool
+	repo       PendingLogUploadRepository
+	runRepo    ExternalRunGetter
+	logDir     string
+	httpClient *http.Client
+	now        func() time.Time
 
 	mu      sync.Mutex
 	pending map[string]uploadEntry
@@ -60,13 +59,12 @@ func NewLogUploader(repo PendingLogUploadRepository, runRepo ExternalRunGetter, 
 		now = time.Now
 	}
 	return &LogUploader{
-		repo:         repo,
-		runRepo:      runRepo,
-		logDir:       logDir,
-		httpClient:   logarchive.SafeClient(),
-		now:          func() time.Time { return now().UTC() },
-		deleteOnDone: true,
-		pending:      make(map[string]uploadEntry),
+		repo:       repo,
+		runRepo:    runRepo,
+		logDir:     logDir,
+		httpClient: logarchive.SafeClient(),
+		now:        func() time.Time { return now().UTC() },
+		pending:    make(map[string]uploadEntry),
 	}
 }
 
@@ -129,13 +127,11 @@ func (u *LogUploader) Archive(ctx context.Context, executionID, logFilePath stri
 	}
 
 	u.forget(ctx, executionID)
-	if u.deleteOnDone {
-		if removeErr := os.Remove(logFilePath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			slog.Warn("failed to remove archived log file", "executionId", executionID, "path", logFilePath, "err", removeErr)
-		}
-		// Drop the meta sidecar too — it is meaningless once the log is gone.
-		_ = os.Remove(logutil.MetaPath(logFilePath))
+	if removeErr := os.Remove(logFilePath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		slog.Warn("failed to remove archived log file", "executionId", executionID, "path", logFilePath, "err", removeErr)
 	}
+	// Drop the meta sidecar too — it is meaningless once the log is gone.
+	_ = os.Remove(logutil.MetaPath(logFilePath))
 	return &LogUploaderResult{LogPath: entry.logPath, LogSize: size}, nil
 }
 
@@ -191,12 +187,6 @@ func (u *LogUploader) recoverOrphanRecord(ctx context.Context, rec model.Pending
 	}
 }
 
-// Forget drops in-memory state for an execution without touching storage.
-// Used when the dispatch is invalid or a run terminates with no upload URL.
-func (u *LogUploader) Forget(ctx context.Context, executionID string) {
-	u.forget(ctx, executionID)
-}
-
 func (u *LogUploader) lookup(executionID string) (uploadEntry, bool) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -204,6 +194,8 @@ func (u *LogUploader) lookup(executionID string) (uploadEntry, bool) {
 	return e, ok
 }
 
+// forget drops in-memory state for an execution without touching storage.
+// Used when the dispatch is invalid or a run terminates with no upload URL.
 func (u *LogUploader) forget(ctx context.Context, executionID string) {
 	u.mu.Lock()
 	delete(u.pending, executionID)

--- a/apps/runwisp/internal/cloud/log_uploader_test.go
+++ b/apps/runwisp/internal/cloud/log_uploader_test.go
@@ -172,7 +172,7 @@ func TestForgetRemovesRowAndCachedEntry(t *testing.T) {
 		t.Fatalf("RegisterDispatch: %v", err)
 	}
 
-	u.Forget(context.Background(), "exec-1")
+	u.forget(context.Background(), "exec-1")
 
 	if got := repo.count(); got != 0 {
 		t.Errorf("repo rows = %d, want 0", got)
@@ -591,7 +591,7 @@ func TestRecoverOrphansNilEmitIsSafe(t *testing.T) {
 func TestForgetTolerantOfRepoDeleteError(t *testing.T) {
 	u := NewLogUploader(&failingDeleteRepo{}, &fakeRunRepo{}, t.TempDir(), fixedClock())
 	// Must not panic; the error is logged and swallowed.
-	u.Forget(context.Background(), "exec-1")
+	u.forget(context.Background(), "exec-1")
 }
 
 func TestRegisterDispatchPropagatesUpsertError(t *testing.T) {

--- a/apps/runwisp/internal/cloud/protocol.go
+++ b/apps/runwisp/internal/cloud/protocol.go
@@ -294,10 +294,6 @@ func DecodeInboundMessage(payload []byte) (any, error) {
 	return decoder(payload)
 }
 
-func EncodeOutboundMessage(message any) ([]byte, error) {
-	return json.Marshal(message)
-}
-
 func decodeStrict(payload []byte, target any) error {
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 

--- a/apps/runwisp/internal/cloud/protocol_test.go
+++ b/apps/runwisp/internal/cloud/protocol_test.go
@@ -4,6 +4,7 @@
 package cloud
 
 import (
+	"encoding/json"
 	"errors"
 	"sort"
 	"testing"
@@ -126,8 +127,8 @@ func TestDecodeInboundMessage_KnownTypeRoundtrips(t *testing.T) {
 	assert.Equal(t, "pong", pong.Type)
 }
 
-func TestEncodeOutboundMessage_RoundTrip(t *testing.T) {
-	out, err := EncodeOutboundMessage(NewPingMessage(nil))
+func TestPingMessage_OmitsEmptySystemStats(t *testing.T) {
+	out, err := json.Marshal(NewPingMessage(nil))
 	require.NoError(t, err)
 	assert.Contains(t, string(out), `"type":"ping"`)
 	// A plain ping must not carry an empty systemStats object — the field is
@@ -152,7 +153,7 @@ func TestNewPingMessage_CarriesSystemStats(t *testing.T) {
 	assert.Equal(t, 8, ping.SystemStats.CpuCores)
 
 	// Identity-only / path-leaking fields are intentionally not on the wire.
-	out, err := EncodeOutboundMessage(ping)
+	out, err := json.Marshal(ping)
 	require.NoError(t, err)
 	assert.NotContains(t, string(out), "/secret/path")
 }

--- a/apps/runwisp/internal/cloud/sync_client.go
+++ b/apps/runwisp/internal/cloud/sync_client.go
@@ -79,15 +79,6 @@ type syncTaskSchedule struct {
 	Enabled  bool   `json:"enabled"`
 }
 
-// taskSyncResponse is the bare response shape returned by the new cloud
-// /api/v1/runner/tasks/sync endpoint — no tRPC `result.data` wrapper.
-// Errors come back as non-2xx HTTP plus a JSON body the handler logs from
-// the status line; we don't try to decode them.
-type taskSyncResponse struct {
-	Success bool            `json:"success"`
-	Summary TaskSyncSummary `json:"summary"`
-}
-
 func NewTaskSyncClient(syncURL string, timeout time.Duration) *TaskSyncClient {
 	return &TaskSyncClient{
 		httpClient: &http.Client{Timeout: timeout},
@@ -149,18 +140,15 @@ func (client *TaskSyncClient) SyncTasks(ctx context.Context, token string, tasks
 		}
 	}
 
-	var data taskSyncResponse
-	if err := json.Unmarshal(responseBody, &data); err != nil {
+	// The /api/v1/runner/tasks/sync endpoint returns this shape bare — no tRPC
+	// `result.data` wrapper — so it decodes directly into TaskSyncResult.
+	result := &TaskSyncResult{}
+	if err := json.Unmarshal(responseBody, result); err != nil {
 		return nil, &CloudError{
 			Kind:    CloudErrorKindValidation,
 			Message: "failed to decode task sync response",
 			Err:     err,
 		}
-	}
-
-	result := &TaskSyncResult{
-		Success: data.Success,
-		Summary: data.Summary,
 	}
 
 	if !result.Success {

--- a/apps/runwisp/internal/config/compose.go
+++ b/apps/runwisp/internal/config/compose.go
@@ -6,6 +6,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -282,7 +283,7 @@ func parseComposeBlock(alias string, raw map[string]any) (*composeBlock, error) 
 		subTable, ok := value.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("unknown key %q (not a per-service override table; reserved keys: %s)",
-				key, strings.Join(sortedKeys(composeReservedKeys), ", "))
+				key, strings.Join(slices.Sorted(maps.Keys(composeReservedKeys)), ", "))
 		}
 		override, err := decodeServiceOverride(key, subTable)
 		if err != nil {
@@ -773,13 +774,4 @@ func resolveComposeFile(declared, baseDir string) (string, error) {
 	}
 	return "", fmt.Errorf("no compose file found in %s (searched: %s)",
 		baseDir, strings.Join(ComposeAutoDiscoveryFilenames, ", "))
-}
-
-func sortedKeys(m map[string]struct{}) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
 }

--- a/apps/runwisp/internal/config/config.go
+++ b/apps/runwisp/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -507,8 +508,8 @@ func validateTLS(d *Daemon) error {
 // Validate collects every configuration problem it can rather than returning at
 // the first, so `runwisp validate` reports them all in one pass (one entry per
 // offending task, plus each top-level check). Independent checks each contribute
-// at most one error; the result collapses to nil / a single error / a
-// *MultiError via joinConfigErrors.
+// at most one error; the result collapses to nil / a single error / a joined
+// error via errors.Join.
 func Validate(cfg *Config) error {
 	var errs []error
 	if err := validateDefaults(&cfg.Defaults); err != nil {
@@ -536,7 +537,7 @@ func Validate(cfg *Config) error {
 	if err := validateNotify(&cfg.Notify); err != nil {
 		errs = append(errs, err)
 	}
-	return joinConfigErrors(errs)
+	return errors.Join(errs...)
 }
 
 // validateServiceDependencies checks every service's depends_on graph: each ref

--- a/apps/runwisp/internal/config/decode_error.go
+++ b/apps/runwisp/internal/config/decode_error.go
@@ -30,39 +30,6 @@ type LocatedError struct {
 
 func (e *LocatedError) Error() string { return e.Msg }
 
-// MultiError carries more than one config error so `runwisp validate` can report
-// every problem in one pass instead of the first alone. Its Unwrap satisfies
-// errors.As/Is against the wrapped errors, so a caller can still lift individual
-// LocatedError locations. Load/Validate return a plain error for the zero/one
-// case and a *MultiError only when there are genuinely several.
-type MultiError struct {
-	Errors []error
-}
-
-func (m *MultiError) Error() string {
-	msgs := make([]string, len(m.Errors))
-	for i, e := range m.Errors {
-		msgs[i] = e.Error()
-	}
-	return strings.Join(msgs, "\n")
-}
-
-// Unwrap exposes the wrapped errors to errors.As/Is (Go 1.20+ multi-unwrap).
-func (m *MultiError) Unwrap() []error { return m.Errors }
-
-// joinConfigErrors collapses a slice of errors into the smallest form: nil for
-// none, the sole error for one, a *MultiError otherwise.
-func joinConfigErrors(errs []error) error {
-	switch len(errs) {
-	case 0:
-		return nil
-	case 1:
-		return errs[0]
-	default:
-		return &MultiError{Errors: errs}
-	}
-}
-
 // keyPath renders a go-toml key as a dotted path, e.g. tasks.backup.cron.
 func keyPath(key toml.Key) string {
 	return strings.Join([]string(key), ".")
@@ -91,7 +58,7 @@ func formatDecodeError(err error) error {
 					Column: col,
 				})
 			}
-			return joinConfigErrors(located)
+			return errors.Join(located...)
 		}
 		return &LocatedError{Msg: fmt.Sprintf("failed to parse config file:%s", formatStrictMissing(strict))}
 	}

--- a/apps/runwisp/internal/configedit/block.go
+++ b/apps/runwisp/internal/configedit/block.go
@@ -4,7 +4,9 @@
 package configedit
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -141,14 +143,9 @@ type blockSpan struct {
 }
 
 // sortSpans orders spans by their start offset so the splice walks the document
-// forward exactly once. Insertion sort: a promote request holds a handful of
-// names, not thousands.
+// forward exactly once.
 func sortSpans(spans []blockSpan) {
-	for i := 1; i < len(spans); i++ {
-		for j := i; j > 0 && spans[j].start < spans[j-1].start; j-- {
-			spans[j], spans[j-1] = spans[j-1], spans[j]
-		}
-	}
+	slices.SortFunc(spans, func(a, b blockSpan) int { return cmp.Compare(a.start, b.start) })
 }
 
 // findBlock locates the named entry's full byte range: its lead comments, its

--- a/apps/runwisp/internal/configedit/cron_include.go
+++ b/apps/runwisp/internal/configedit/cron_include.go
@@ -53,12 +53,7 @@ func EnsureCronInclude(rootTOML []byte, patterns []string) (out []byte, err erro
 		return nil, ErrCronIncludeAlreadySet
 	}
 
-	text := ensureTrailingNewline(string(rootTOML))
-	key := config.CronIncludeArray(patterns)
-	if end, ok := daemonHeaderEnd(text); ok {
-		return []byte(text[:end] + key + text[end:]), nil
-	}
-	return []byte(text + "\n[daemon]\n" + key), nil
+	return insertDaemonKey(rootTOML, config.CronIncludeArray(patterns)), nil
 }
 
 // WireCronInclude applies EnsureCronInclude to the config at path and writes it

--- a/apps/runwisp/internal/configedit/include_edit.go
+++ b/apps/runwisp/internal/configedit/include_edit.go
@@ -54,11 +54,7 @@ func EnsureStagingInclude(rootTOML []byte, rootDir string) (out []byte, changed 
 		return nil, false, ErrIncludeNeedsManualWiring
 	}
 
-	text := ensureTrailingNewline(string(rootTOML))
-	if end, ok := daemonHeaderEnd(text); ok {
-		return []byte(text[:end] + stagingIncludeLine() + text[end:]), true, nil
-	}
-	return []byte(text + "\n[daemon]\n" + stagingIncludeLine()), true, nil
+	return insertDaemonKey(rootTOML, stagingIncludeLine()), true, nil
 }
 
 // stagingIncludeLine is the include declaration wired into the root config.
@@ -110,4 +106,15 @@ func ensureTrailingNewline(text string) string {
 		return text
 	}
 	return text + "\n"
+}
+
+// insertDaemonKey inserts keyLine into rootTOML's [daemon] table — right after
+// the header when one exists, or into a freshly appended table otherwise. It
+// never reformats or reorders the operator's existing bytes.
+func insertDaemonKey(rootTOML []byte, keyLine string) []byte {
+	text := ensureTrailingNewline(string(rootTOML))
+	if end, ok := daemonHeaderEnd(text); ok {
+		return []byte(text[:end] + keyLine + text[end:])
+	}
+	return []byte(text + "\n[daemon]\n" + keyLine)
 }

--- a/apps/runwisp/internal/configedit/promote.go
+++ b/apps/runwisp/internal/configedit/promote.go
@@ -70,20 +70,6 @@ func PromotableNames(cfg *config.Config) []string {
 	return names
 }
 
-// StagedNames returns just the entries whose definitions live in the staging file,
-// in config order. Distinct from PromotableNames because these are the only ones
-// whose bytes are *moved* out of a file — the rest are copied.
-func StagedNames(cfg *config.Config, layout Layout) []string {
-	var names []string
-	for i := range cfg.Tasks {
-		name := cfg.Tasks[i].Name
-		if cfg.OriginFile(name) == layout.StagingPath {
-			names = append(names, name)
-		}
-	}
-	return names
-}
-
 // Select resolves a promote request against the loaded config: all=true takes
 // every staged entry, otherwise each requested name is checked and returned in
 // the order the operator gave. Nothing is read from or written to disk here —

--- a/apps/runwisp/internal/configedit/promote_test.go
+++ b/apps/runwisp/internal/configedit/promote_test.go
@@ -130,7 +130,6 @@ func TestPromote_RemovesTheEmptiedStagingFile(t *testing.T) {
 	// The root still loads with everything, and nothing is staged any more.
 	cfg := loadLayout(t, layout)
 	assert.ElementsMatch(t, []string{"mine", "backup", "reindex"}, taskNames(cfg))
-	assert.Empty(t, StagedNames(cfg, layout))
 }
 
 // TestPromote_KeepsTheStagingFileWhenSomethingElseRemains guards the other side
@@ -205,27 +204,6 @@ func TestPromote_NoNamesWritesNothing(t *testing.T) {
 
 	assert.Empty(t, res.Promoted)
 	assert.Equal(t, before, readFile(t, layout.RootPath))
-}
-
-func TestStagedNames_OnlyTheStagingFile(t *testing.T) {
-	root := `[daemon]
-include = ["runwisp.d/*.toml", "conf.d/*.toml"]
-
-[tasks.native]
-run = "echo native"
-`
-	dir := writeFileTree(t, map[string]string{
-		"runwisp.toml":                "",
-		"conf.d/hand.toml":            "[tasks.hand]\nrun = \"echo hand\"\n",
-		"runwisp.d/imported.toml":     "[tasks.staged_one]\nrun = \"a\"\n\n[services.staged_two]\nrun = \"b\"\n",
-		"runwisp.d/also_imported.tml": "ignored: not a .toml\n",
-	})
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "runwisp.toml"), []byte(root), 0o644))
-	layout := NewLayout(filepath.Join(dir, "runwisp.toml"))
-
-	got := StagedNames(loadLayout(t, layout), layout)
-
-	assert.ElementsMatch(t, []string{"staged_one", "staged_two"}, got)
 }
 
 func TestSelect(t *testing.T) {

--- a/apps/runwisp/internal/cutover/compute.go
+++ b/apps/runwisp/internal/cutover/compute.go
@@ -14,6 +14,7 @@ import (
 	"github.com/runwisp/runwisp/internal/autostart"
 	"github.com/runwisp/runwisp/internal/config"
 	"github.com/runwisp/runwisp/internal/configedit"
+	"github.com/runwisp/runwisp/internal/textutil"
 )
 
 // Compute answers "what would a cutover do to this box, and what stops it",
@@ -261,7 +262,7 @@ func includeCronMismatchBlocker(path string, ev Evidence) Blocker {
 	return Blocker{
 		Kind: BlockerIncludeCronMissesCrontabs,
 		Title: fmt.Sprintf("%s sets its own include_cron, and %s on this box %s not in it",
-			path, pluralCrontabs(len(ev.Uncovered)), isAre(len(ev.Uncovered))),
+			path, textutil.Count(len(ev.Uncovered), "crontab", "crontabs"), textutil.Pluralize(len(ev.Uncovered), "is", "are")),
 		Details: "Not read by this config:\n" +
 			indent(strings.Join(ev.Uncovered, "\n"), "  ") +
 			"\nMasking cron would stop those jobs with nothing left scheduling them. RunWisp will " +
@@ -305,7 +306,6 @@ func (c *Cutover) cronSourceBlockers(ev Evidence) []Blocker {
 			Details: strings.Join(reasons, "\n") +
 				"\n\nFix these first, or pass --allow-skipped-cron-jobs to take over cron anyway " +
 				"(those jobs stay stopped).",
-			Override: "--allow-skipped-cron-jobs",
 		})
 	}
 
@@ -376,21 +376,6 @@ func (c *Cutover) installStep(ctx context.Context, p Plan) ([]Step, error) {
 		})
 	}
 	return steps, nil
-}
-
-// pluralCrontabs and isAre keep the mismatch blocker's title grammatical.
-func pluralCrontabs(n int) string {
-	if n == 1 {
-		return "1 crontab"
-	}
-	return fmt.Sprintf("%d crontabs", n)
-}
-
-func isAre(n int) string {
-	if n == 1 {
-		return "is"
-	}
-	return "are"
 }
 
 // indent prefixes every non-empty line of s with pad, and guarantees a trailing

--- a/apps/runwisp/internal/cutover/compute_test.go
+++ b/apps/runwisp/internal/cutover/compute_test.go
@@ -110,7 +110,6 @@ func TestCompute_OperatorsOwnIncludeCronIsNeverRewritten(t *testing.T) {
 	assert.True(t, hasBlocker(p, BlockerIncludeCronMissesCrontabs), "%v", blockerKinds(p))
 
 	b, _ := p.FirstBlocker()
-	assert.Empty(t, b.Override, "this blocker must not be waivable — masking cron would stop those jobs")
 	assert.Contains(t, b.Details, "include_cron = [", "it has to print the array to paste")
 	assert.Contains(t, b.Details, "crontabs")
 }
@@ -212,8 +211,6 @@ func TestCompute_SkippedCronSourcesBlockUnlessAllowed(t *testing.T) {
 	p, err := c.Compute(context.Background())
 	require.NoError(t, err)
 	require.True(t, hasBlocker(p, BlockerCronSourcesFailed), "%v", blockerKinds(p))
-	b, _ := p.FirstBlocker()
-	assert.Equal(t, "--allow-skipped-cron-jobs", b.Override)
 
 	fx.allowSkipped = true
 	c, _, _ = fx.build(t)
@@ -241,8 +238,6 @@ func TestCompute_SkippedJobBlocksWithNoConfigOnDisk(t *testing.T) {
 	p, err := c.Compute(context.Background())
 	require.NoError(t, err)
 	require.True(t, hasBlocker(p, BlockerCronSourcesFailed), "%v", blockerKinds(p))
-	b, _ := p.FirstBlocker()
-	assert.Equal(t, "--allow-skipped-cron-jobs", b.Override)
 
 	fx.allowSkipped = true
 	c, _, _ = fx.build(t)

--- a/apps/runwisp/internal/cutover/cutover.go
+++ b/apps/runwisp/internal/cutover/cutover.go
@@ -104,10 +104,6 @@ type Deps struct {
 // --yes and --force are absent on purpose: the first lives in the Prompter, the
 // second on Opts.
 type Options struct {
-	// DryRun renders the plan and stops. Because every operator-facing "no" is a
-	// Blocker in the value rather than an error out of Compute, a dry run is
-	// total — it can always print something, which is the bug that started this.
-	DryRun bool
 	// AllowSkippedCronJobs proceeds even though some cron sources won't load.
 	// Those jobs stay stopped.
 	AllowSkippedCronJobs bool

--- a/apps/runwisp/internal/cutover/plan.go
+++ b/apps/runwisp/internal/cutover/plan.go
@@ -70,12 +70,9 @@ type Blocker struct {
 	Kind BlockerKind
 	// Title is one line, lower case, no trailing period.
 	Title string
-	// Details is the remedy, and may be several lines.
+	// Details is the remedy, and may be several lines. When a flag waives
+	// this blocker, Details spells it out in prose.
 	Details string
-	// Override names the flag that waives this blocker, or "" when there isn't
-	// one. A blocker with no override is a genuine dead end, and the Details
-	// have to carry the operator all the way out.
-	Override string
 }
 
 // Evidence is everything one machine scan plus at most one config load

--- a/apps/runwisp/internal/cutover/render.go
+++ b/apps/runwisp/internal/cutover/render.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/runwisp/runwisp/internal/importer"
+	"github.com/runwisp/runwisp/internal/textutil"
 )
 
 // Render writes the plan block an operator reads before approving anything: what
@@ -54,7 +55,7 @@ func renderFindings(w io.Writer, p Plan) {
 	switch {
 	case ev.Scan.Jobs > 0:
 		fmt.Fprintf(w, "Found %s on this box:\n  %s\n",
-			pluralJobs(ev.Scan.Jobs), strings.Join(ev.Sources, ", "))
+			textutil.Count(ev.Scan.Jobs, "cron job", "cron jobs"), strings.Join(ev.Sources, ", "))
 		if skipped := ev.Scan.Jobs - ev.Scan.Live; skipped > 0 {
 			fmt.Fprintf(w, "  (%d of them need a fix first and would not run)\n", skipped)
 		}
@@ -164,12 +165,4 @@ func JoinSources(sources []string) string {
 		return fmt.Sprintf("%s and %s",
 			strings.Join(sources[:len(sources)-1], ", "), sources[len(sources)-1])
 	}
-}
-
-// pluralJobs renders a job count with the right noun.
-func pluralJobs(n int) string {
-	if n == 1 {
-		return "1 cron job"
-	}
-	return fmt.Sprintf("%d cron jobs", n)
 }

--- a/apps/runwisp/internal/cutover/render_test.go
+++ b/apps/runwisp/internal/cutover/render_test.go
@@ -221,8 +221,3 @@ func TestJoinSources(t *testing.T) {
 	assert.Equal(t, "/etc/crontab, /etc/cron.d and bob's crontab",
 		JoinSources([]string{"/etc/crontab", "/etc/cron.d", "bob's crontab"}))
 }
-
-func TestPluralJobs(t *testing.T) {
-	assert.Equal(t, "1 cron job", pluralJobs(1))
-	assert.Equal(t, "12 cron jobs", pluralJobs(12))
-}

--- a/apps/runwisp/internal/executor/compose.go
+++ b/apps/runwisp/internal/executor/compose.go
@@ -6,9 +6,10 @@ package executor
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -353,24 +354,13 @@ func composeMergedEnv(task *model.Task, run *model.Run, instanceIndex int) map[s
 	return merged
 }
 
-// sortedKeys returns the map's keys in ascending order — the single source of
-// the deterministic ordering shared by composeEnvFlags and composeEnv.
-func sortedKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
 // composeEnvFlags returns the deterministically ordered variable NAMES to
 // forward into the container as value-less `-e KEY` flags. Docker's `-e KEY`
 // form reads each value from the calling process's environment — which Start
 // populates via composeEnv — so secret values never appear on argv (and thus
 // never in `ps` output).
 func composeEnvFlags(task *model.Task, run *model.Run, instanceIndex int) []string {
-	return sortedKeys(composeMergedEnv(task, run, instanceIndex))
+	return slices.Sorted(maps.Keys(composeMergedEnv(task, run, instanceIndex)))
 }
 
 // composeEnv returns the forwarded variables as deterministically ordered
@@ -379,7 +369,7 @@ func composeEnvFlags(task *model.Task, run *model.Run, instanceIndex int) []stri
 // how the actual values reach the container without ever touching argv.
 func composeEnv(task *model.Task, run *model.Run, instanceIndex int) []string {
 	merged := composeMergedEnv(task, run, instanceIndex)
-	keys := sortedKeys(merged)
+	keys := slices.Sorted(maps.Keys(merged))
 	out := make([]string, len(keys))
 	for i, k := range keys {
 		out[i] = k + "=" + merged[k]

--- a/apps/runwisp/internal/executor/executor.go
+++ b/apps/runwisp/internal/executor/executor.go
@@ -89,10 +89,9 @@ type Options struct {
 	EventBus             events.EventBus
 	CloudDispatchEnabled bool
 	HasLocalTasks        bool
-	Docker               Backend          // container backend; nil when Docker is unavailable
-	Compose              Backend          // compose backend; nil when docker compose is unavailable
-	MinFreeDisk          int64            // minimum free disk space in bytes; 0 = disabled
-	OnRunUpdate          func(*model.Run) // called when run state changes (e.g. LogPath set)
+	Docker               Backend // container backend; nil when Docker is unavailable
+	Compose              Backend // compose backend; nil when docker compose is unavailable
+	MinFreeDisk          int64   // minimum free disk space in bytes; 0 = disabled
 	// Clock is the wall-clock source for captured-output timestamps (system
 	// lines and the per-line timestamp index). nil defaults to time.Now;
 	// the demo seeder injects a backdated clock so historical runs carry
@@ -162,7 +161,6 @@ func New(opts Options) Executor {
 
 	return &RoutingExecutor{
 		logDir:       opts.LogDir,
-		onUpdate:     opts.OnRunUpdate,
 		eventBus:     opts.EventBus,
 		backends:     backends,
 		availability: avail,
@@ -171,14 +169,9 @@ func New(opts Options) Executor {
 	}
 }
 
-// now returns the executor's wall-clock instant, defaulting to time.Now when no
-// clock was injected. The constructor always sets one; this guards the
-// direct struct construction used by white-box tests so a missing clock can
-// never nil-panic in the output-timestamping path.
+// now returns the executor's wall-clock instant. The constructor always sets
+// clock (defaulting to time.Now), so callers can rely on it being non-nil.
 func (r *RoutingExecutor) now() time.Time {
-	if r.clock == nil {
-		return time.Now()
-	}
 	return r.clock()
 }
 

--- a/apps/runwisp/internal/executor/executor_test.go
+++ b/apps/runwisp/internal/executor/executor_test.go
@@ -191,14 +191,14 @@ func TestRunUpdateCallback(t *testing.T) {
 
 	eb := events.NewEventBus()
 	called := false
-	exec := New(Options{
+	exec := newTestExecutor(t, Options{
 		LogDir:               tmpDir,
 		EventBus:             eb,
 		CloudDispatchEnabled: true,
 		HasLocalTasks:        true,
-		OnRunUpdate: func(r *model.Run) {
-			called = true
-		},
+	})
+	exec.SetRunUpdateCallback(func(r *model.Run) {
+		called = true
 	})
 	getLogPath := captureLogPath(eb)
 

--- a/apps/runwisp/internal/executor/stream_manager_test.go
+++ b/apps/runwisp/internal/executor/stream_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/runwisp/runwisp/internal/events"
 	"github.com/runwisp/runwisp/internal/logutil"
@@ -57,7 +58,7 @@ func TestStreamManager_OneEventPerLine(t *testing.T) {
 
 	eb := events.NewEventBus()
 	drain := captureLogEvents(t, eb)
-	sm := &RoutingExecutor{eventBus: eb}
+	sm := &RoutingExecutor{eventBus: eb, clock: time.Now}
 
 	task := &model.Task{Name: "t"}
 	run := &model.Run{ID: "r1"}
@@ -93,7 +94,7 @@ func TestStreamManager_StderrTaggedNoPrefixInText(t *testing.T) {
 
 	eb := events.NewEventBus()
 	drain := captureLogEvents(t, eb)
-	sm := &RoutingExecutor{eventBus: eb}
+	sm := &RoutingExecutor{eventBus: eb, clock: time.Now}
 
 	task := &model.Task{Name: "t"}
 	run := &model.Run{ID: "r1"}
@@ -126,7 +127,7 @@ func TestStreamManager_OversizedLineSplit(t *testing.T) {
 
 	eb := events.NewEventBus()
 	drain := captureLogEvents(t, eb)
-	sm := &RoutingExecutor{eventBus: eb}
+	sm := &RoutingExecutor{eventBus: eb, clock: time.Now}
 
 	task := &model.Task{Name: "t"}
 	run := &model.Run{ID: "r1"}

--- a/apps/runwisp/internal/importer/cron.go
+++ b/apps/runwisp/internal/importer/cron.go
@@ -871,10 +871,17 @@ func deriveCronName(command string) string {
 	if ext := filepath.Ext(base); ext != "" && len(ext) <= 5 {
 		base = strings.TrimSuffix(base, ext)
 	}
+	return finalizeTaskName(base, "job")
+}
+
+// finalizeTaskName sanitizes base to RunWisp's name rules, trims stray
+// separators, falls back to fallback when nothing usable remains, and caps
+// the result at model.TaskNameMaxLength.
+func finalizeTaskName(base, fallback string) string {
 	base = model.SanitizeTaskName(base)
 	base = strings.Trim(base, "_-")
 	if base == "" {
-		base = "job"
+		base = fallback
 	}
 	if len(base) > model.TaskNameMaxLength {
 		base = base[:model.TaskNameMaxLength]

--- a/apps/runwisp/internal/importer/golden_test.go
+++ b/apps/runwisp/internal/importer/golden_test.go
@@ -151,10 +151,24 @@ func TestSupervisordIncludeGolden(t *testing.T) {
 // file, which would have the operator looking for a task the daemon won't have.
 // itemRef.emit is the only path to either, so this is really a check that no
 // future code path routes around it.
+// tableNames lists the top-level tables the emitted TOML defines — the
+// [tasks.x] / [services.x] headers, without their .env children.
+func tableNames(r *Result) []string {
+	var out []string
+	for _, b := range r.blocks {
+		path := strings.Split(b.header, ".")
+		if len(path) != 2 {
+			continue // a .env child, or a table that names no job
+		}
+		out = append(out, path[1])
+	}
+	return out
+}
+
 func assertReportAccountsForTOML(t *testing.T, res *Result) {
 	t.Helper()
 	inTOML := map[string]bool{}
-	for _, name := range res.tableNames() {
+	for _, name := range tableNames(res) {
 		if inTOML[name] {
 			t.Errorf("the TOML defines %q twice", name)
 		}

--- a/apps/runwisp/internal/importer/importer.go
+++ b/apps/runwisp/internal/importer/importer.go
@@ -40,22 +40,6 @@ type Result struct {
 	notes []Note
 }
 
-// tableNames lists the top-level tables the emitted TOML defines — the
-// [tasks.x] / [services.x] headers, without their .env children. It exists for
-// the test that checks the emitted file against the report; nothing in the
-// package's behavior depends on it.
-func (r *Result) tableNames() []string {
-	var out []string
-	for _, b := range r.blocks {
-		path := strings.Split(b.header, ".")
-		if len(path) != 2 {
-			continue // a .env child, or a table that names no job
-		}
-		out = append(out, path[1])
-	}
-	return out
-}
-
 // field is one `key = value` line. value is already TOML-formatted.
 type field struct {
 	key     string
@@ -96,19 +80,6 @@ func (r *Result) TOML() string { return r.TOMLFor(func(Item) bool { return true 
 // handed a config to *run*, so a job whose imported form isn't what the source
 // would have run must not be in it. See Item.LiveEligible.
 func (r *Result) LiveTOML() string { return r.TOMLFor(Item.LiveEligible) }
-
-// SkippedLive lists the rows LiveTOML left out, so the caller can say which jobs
-// aren't running and why. Dropping a job without a way to name it is the failure
-// mode this exists to prevent.
-func (r *Result) SkippedLive() []Item {
-	var out []Item
-	for _, it := range r.items {
-		if !it.LiveEligible() {
-			out = append(out, it)
-		}
-	}
-	return out
-}
 
 // TOMLFor renders the annotated configuration for the rows keep accepts. Blocks
 // are emitted in the order the parser produced them; fields keep their insertion

--- a/apps/runwisp/internal/importer/live_test.go
+++ b/apps/runwisp/internal/importer/live_test.go
@@ -72,7 +72,12 @@ func TestSkippedLiveNamesEveryDroppedJob(t *testing.T) {
 		"not-a-cron-line\n"
 	res := parseCron(t, in, CronOptions{})
 
-	skipped := res.SkippedLive()
+	var skipped []Item
+	for _, it := range res.Items() {
+		if !it.LiveEligible() {
+			skipped = append(skipped, it)
+		}
+	}
 	if len(skipped) != 2 {
 		t.Fatalf("expected 2 skipped jobs, got %+v", skipped)
 	}

--- a/apps/runwisp/internal/importer/load_test.go
+++ b/apps/runwisp/internal/importer/load_test.go
@@ -188,6 +188,18 @@ func cronFixtures(t *testing.T) map[string]importer.CronOptions {
 	return out
 }
 
+// skippedLive lists the rows LiveTOML left out, for failure messages that say
+// which jobs aren't running and why.
+func skippedLive(res *importer.Result) []importer.Item {
+	var out []importer.Item
+	for _, it := range res.Items() {
+		if !it.LiveEligible() {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
 // TestLiveTOMLAlwaysLoads is the guard the daemon's boot depends on. `include_cron`
 // renders LiveTOML and hands it to the config loader, so a crontab that produces
 // TOML the loader rejects doesn't degrade one task — it takes down the whole
@@ -210,7 +222,7 @@ func TestLiveTOMLAlwaysLoads(t *testing.T) {
 			live := res.LiveTOML()
 			if _, err := loadTOML(t, live); err != nil {
 				t.Fatalf("LiveTOML does not load: %v\n--- live toml ---\n%s\n--- skipped ---\n%+v",
-					err, live, res.SkippedLive())
+					err, live, skippedLive(res))
 			}
 		})
 	}
@@ -278,7 +290,7 @@ func TestLiveTOMLOfAWhollyUnusableCrontabIsStillValid(t *testing.T) {
 	if len(cfg.Tasks) != 0 {
 		t.Errorf("expected no tasks, got %d", len(cfg.Tasks))
 	}
-	if len(res.SkippedLive()) != 2 {
-		t.Errorf("expected both jobs reported as skipped, got %+v", res.SkippedLive())
+	if len(skippedLive(res)) != 2 {
+		t.Errorf("expected both jobs reported as skipped, got %+v", skippedLive(res))
 	}
 }

--- a/apps/runwisp/internal/importer/supervisord.go
+++ b/apps/runwisp/internal/importer/supervisord.go
@@ -479,15 +479,7 @@ func splitSectionName(s string) (kind, name string) {
 }
 
 func sanitizeProgramName(name string) string {
-	n := model.SanitizeTaskName(strings.TrimSpace(name))
-	n = strings.Trim(n, "_-")
-	if n == "" {
-		n = "program"
-	}
-	if len(n) > model.TaskNameMaxLength {
-		n = n[:model.TaskNameMaxLength]
-	}
-	return n
+	return finalizeTaskName(strings.TrimSpace(name), "program")
 }
 
 func parseBool(value string) (bool, bool) {

--- a/apps/runwisp/internal/notify/bridge_test.go
+++ b/apps/runwisp/internal/notify/bridge_test.go
@@ -50,11 +50,6 @@ func TestMapEvent_SkipNeverNotifies(t *testing.T) {
 	}
 }
 
-func TestService_DroppedIngressCount_Zero(t *testing.T) {
-	svc := New(Config{Bus: events.NewEventBus()})
-	assert.Equal(t, uint64(0), svc.DroppedIngressCount())
-}
-
 // TestMapEvent_LogDiskPressure verifies the new event surface introduced
 // when min_free_space stops honouring per-task log_on_full silently.
 func TestMapEvent_LogDiskPressure(t *testing.T) {

--- a/apps/runwisp/internal/notify/channel/inapp/coalescer_test.go
+++ b/apps/runwisp/internal/notify/channel/inapp/coalescer_test.go
@@ -35,7 +35,7 @@ func makeEvent(task string) *notify.Event {
 
 func TestCoalescer_FoldsRepeatsWithinWindow(t *testing.T) {
 	db := newDB(t)
-	hub := NewHub(8, 50)
+	hub := NewHub(8)
 	clk := testutil.NewFakeClock(time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC))
 	c := NewCoalescer(db, hub, clk, CoalescerConfig{Window: time.Hour, OccurrenceN: 5}, nil)
 
@@ -54,7 +54,7 @@ func TestCoalescer_FoldsRepeatsWithinWindow(t *testing.T) {
 
 func TestCoalescer_InsertsNewRowAfterWindow(t *testing.T) {
 	db := newDB(t)
-	hub := NewHub(8, 50)
+	hub := NewHub(8)
 	clk := testutil.NewFakeClock(time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC))
 	c := NewCoalescer(db, hub, clk, CoalescerConfig{Window: time.Hour, OccurrenceN: 5}, nil)
 
@@ -69,7 +69,7 @@ func TestCoalescer_InsertsNewRowAfterWindow(t *testing.T) {
 
 func TestCoalescer_SeparatesByFingerprint(t *testing.T) {
 	db := newDB(t)
-	hub := NewHub(8, 50)
+	hub := NewHub(8)
 	clk := testutil.NewFakeClock(time.Now().UTC())
 	c := NewCoalescer(db, hub, clk, CoalescerConfig{Window: time.Hour, OccurrenceN: 5}, nil)
 
@@ -84,7 +84,7 @@ func TestCoalescer_SeparatesByFingerprint(t *testing.T) {
 
 func TestCoalescer_OccurrenceRingTrimmed(t *testing.T) {
 	db := newDB(t)
-	hub := NewHub(8, 50)
+	hub := NewHub(8)
 	clk := testutil.NewFakeClock(time.Now().UTC())
 	const ringSize = 4
 	c := NewCoalescer(db, hub, clk, CoalescerConfig{Window: time.Hour, OccurrenceN: ringSize}, nil)
@@ -102,7 +102,7 @@ func TestCoalescer_OccurrenceRingTrimmed(t *testing.T) {
 
 func TestCoalescer_PublishesCreatedThenUpdated(t *testing.T) {
 	db := newDB(t)
-	hub := NewHub(16, 50)
+	hub := NewHub(16)
 	sub, unsub := hub.Subscribe()
 	defer unsub()
 
@@ -137,7 +137,7 @@ loop:
 
 func TestCoalescer_DistinctFingerprintsAllPersist(t *testing.T) {
 	db := newDB(t)
-	hub := NewHub(8, 50)
+	hub := NewHub(8)
 	clk := testutil.NewFakeClock(time.Now().UTC())
 	c := NewCoalescer(db, hub, clk, CoalescerConfig{Window: time.Hour, OccurrenceN: 5}, nil)
 
@@ -150,25 +150,9 @@ func TestCoalescer_DistinctFingerprintsAllPersist(t *testing.T) {
 	assert.Len(t, rows, 5, "each distinct fingerprint persists as its own row")
 }
 
-func TestHub_SubscriberCount_ZeroInitially(t *testing.T) {
-	h := NewHub(8, 50)
-	if h.SubscriberCount() != 0 {
-		t.Fatalf("expected 0 subscribers initially, got %d", h.SubscriberCount())
-	}
-}
-
-func TestHub_SubscriberCount_AfterSubscribe(t *testing.T) {
-	h := NewHub(8, 50)
-	_, cancel := h.Subscribe()
-	defer cancel()
-	if h.SubscriberCount() != 1 {
-		t.Fatalf("expected 1 subscriber, got %d", h.SubscriberCount())
-	}
-}
-
 func TestIngestSynthetic_NoPanic(t *testing.T) {
 	db := newDB(t)
-	hub := NewHub(8, 50)
+	hub := NewHub(8)
 	clk := testutil.NewFakeClock(time.Now().UTC())
 	coalescer := NewCoalescer(db, hub, clk, CoalescerConfig{Window: time.Hour, OccurrenceN: 5}, nil)
 	ch := New("inapp", &fakeRenderer{}, coalescer)
@@ -184,7 +168,7 @@ func (f *fakeRenderer) Render(ev *notify.Event) (render.RenderedMessage, error) 
 
 func TestCoalescer_Receive_NilEvent(t *testing.T) {
 	db := newDB(t)
-	hub := NewHub(8, 50)
+	hub := NewHub(8)
 	clk := testutil.NewFakeClock(time.Now().UTC())
 	c := NewCoalescer(db, hub, clk, CoalescerConfig{Window: time.Hour, OccurrenceN: 5}, nil)
 	c.Receive(context.Background(), "t", "b", nil) // must not panic

--- a/apps/runwisp/internal/notify/channel/inapp/hub.go
+++ b/apps/runwisp/internal/notify/channel/inapp/hub.go
@@ -52,10 +52,8 @@ type Hub struct {
 }
 
 // NewHub constructs a Hub. bufSize is the per-subscriber channel capacity;
-// 32 is a sensible default for the SSE handler. recent is retained for call-site
-// compatibility but no longer used.
-func NewHub(bufSize, recent int) *Hub {
-	_ = recent
+// 32 is a sensible default for the SSE handler.
+func NewHub(bufSize int) *Hub {
 	if bufSize <= 0 {
 		bufSize = 32
 	}
@@ -96,11 +94,4 @@ func (h *Hub) Publish(u Update) {
 		default:
 		}
 	}
-}
-
-// SubscriberCount reports the current subscriber count. Diagnostic-only.
-func (h *Hub) SubscriberCount() int {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return len(h.subs)
 }

--- a/apps/runwisp/internal/notify/channel/inapp/hub_test.go
+++ b/apps/runwisp/internal/notify/channel/inapp/hub_test.go
@@ -18,7 +18,7 @@ import (
 // sends under the read lock, mutually exclusive with the close, so this runs to
 // completion without panicking.
 func TestHubConcurrentPublishUnsubscribe(t *testing.T) {
-	hub := NewHub(1, 0)
+	hub := NewHub(1)
 
 	stop := make(chan struct{})
 	var pubWg sync.WaitGroup
@@ -58,7 +58,7 @@ func TestHubConcurrentPublishUnsubscribe(t *testing.T) {
 	close(stop)
 	pubWg.Wait()
 
-	if got := hub.SubscriberCount(); got != 0 {
+	if got := len(hub.subs); got != 0 {
 		t.Fatalf("expected all subscribers removed, got %d", got)
 	}
 }

--- a/apps/runwisp/internal/notify/coalesce/coalesce.go
+++ b/apps/runwisp/internal/notify/coalesce/coalesce.go
@@ -39,11 +39,8 @@ type Config struct {
 	EveryN int
 }
 
-// Default values for Config.
-const (
-	DefaultWindow = time.Hour
-	DefaultEveryN = 10
-)
+// DefaultWindow is the default Config.Window value.
+const DefaultWindow = time.Hour
 
 // timerStopper is the slice of *time.Timer that coalesce relies on: the ability
 // to cancel a scheduled window-close flush. Tests inject a fake to fire

--- a/apps/runwisp/internal/notify/configload/configload.go
+++ b/apps/runwisp/internal/notify/configload/configload.go
@@ -35,11 +35,7 @@ func Resolve(cfg config.NotifyConfig, renderCtx render.TemplateContext) (Resolve
 
 	rules := make([]notify.Rule, 0, len(cfg.Routes))
 	for _, r := range cfg.Routes {
-		rule, err := compileRoute(r)
-		if err != nil {
-			return ResolvedNotify{}, err
-		}
-		rules = append(rules, rule)
+		rules = append(rules, compileRoute(r))
 	}
 
 	return ResolvedNotify{
@@ -110,7 +106,7 @@ func fillSMTPSpec(spec *channel.NotifierSpec, n config.NotifierSpec) {
 	spec.BCC = append([]string(nil), n.BCC...)
 }
 
-func compileRoute(r config.NotificationRoute) (notify.Rule, error) {
+func compileRoute(r config.NotificationRoute) notify.Rule {
 	preds := make([]notify.Predicate, 0, 3)
 	if len(r.Kinds) > 0 {
 		kinds := make([]notify.Kind, len(r.Kinds))
@@ -128,5 +124,5 @@ func compileRoute(r config.NotificationRoute) (notify.Rule, error) {
 	return notify.Rule{
 		Match:     notify.And(preds...),
 		ActionIDs: append([]string(nil), r.NotifierID...),
-	}, nil
+	}
 }

--- a/apps/runwisp/internal/notify/event.go
+++ b/apps/runwisp/internal/notify/event.go
@@ -42,20 +42,6 @@ const (
 	KindNotifyDeliveryFailed Kind = "notify.delivery_failed"
 )
 
-// AllKinds is the canonical enumeration; useful for validation in configload.
-var AllKinds = []Kind{
-	KindRunStarted,
-	KindRunSucceeded,
-	KindRunFailed,
-	KindRunTimeout,
-	KindRunStopped,
-	KindRunCrashed,
-	KindRunMissed,
-	KindServiceFatal,
-	KindLogDiskPressure,
-	KindNotifyDeliveryFailed,
-}
-
 // Title returns the user-facing title fragment for this Kind.
 func (k Kind) Title(ev *Event) string {
 	switch k {
@@ -116,9 +102,6 @@ func FingerprintKey(ev *Event) string {
 	}
 	return string(ev.Kind) + "|" + ev.TaskName + "|" + extra
 }
-
-// AllSeverities mirrors AllKinds for severity validation.
-var AllSeverities = []Severity{SevInfo, SevWarn, SevError}
 
 // Event is the public boundary type the notification subsystem operates on.
 // It is constructed by bridge.go from events.RunEvent or by the dispatcher

--- a/apps/runwisp/internal/notify/event_test.go
+++ b/apps/runwisp/internal/notify/event_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/notify/kinds"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,8 +45,8 @@ func TestFingerprintKey_WithDeliveryFailed(t *testing.T) {
 
 func TestKind_TitleCoversAllKinds(t *testing.T) {
 	ev := &Event{TaskName: "test-task"}
-	for _, k := range AllKinds {
-		title := k.Title(ev)
+	for _, k := range kinds.AllKindStrings {
+		title := Kind(k).Title(ev)
 		assert.NotEmpty(t, title, "Kind.Title() must return a non-empty string for %s", k)
 	}
 }

--- a/apps/runwisp/internal/notify/notify.go
+++ b/apps/runwisp/internal/notify/notify.go
@@ -294,9 +294,3 @@ func (s *Service) runRetention(ctx context.Context) {
 		}
 	}
 }
-
-// DroppedIngressCount reports the cumulative count of events dropped at the
-// bus → service boundary. Diagnostic-only.
-func (s *Service) DroppedIngressCount() uint64 {
-	return s.droppedIngress.Load()
-}

--- a/apps/runwisp/internal/notify/predicate.go
+++ b/apps/runwisp/internal/notify/predicate.go
@@ -88,30 +88,3 @@ func And(preds ...Predicate) Predicate {
 		return true
 	}
 }
-
-// Or composes predicates disjunctively (any may hold).
-func Or(preds ...Predicate) Predicate {
-	if len(preds) == 0 {
-		return MatchAll()
-	}
-	return func(ev *Event) bool {
-		for _, p := range preds {
-			if p(ev) {
-				return true
-			}
-		}
-		return false
-	}
-}
-
-// Not inverts a predicate.
-func Not(p Predicate) Predicate {
-	return func(ev *Event) bool { return !p(ev) }
-}
-
-// ValidGlob reports whether s parses as a path.Match pattern. Used by config
-// validation.
-func ValidGlob(s string) bool {
-	_, err := path.Match(s, "")
-	return err == nil
-}

--- a/apps/runwisp/internal/notify/predicate_test.go
+++ b/apps/runwisp/internal/notify/predicate_test.go
@@ -16,53 +16,6 @@ var testEvent = &notify.Event{
 	Severity: notify.SevError,
 }
 
-func TestOr(t *testing.T) {
-	matchNone := notify.MatchKind("__never__")
-	matchAll := notify.MatchAll()
-	tests := []struct {
-		name string
-		a, b notify.Predicate
-		want bool
-	}{
-		{"both false", matchNone, matchNone, false},
-		{"first true", matchAll, matchNone, true},
-		{"second true", matchNone, matchAll, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := notify.Or(tt.a, tt.b)(testEvent); got != tt.want {
-				t.Fatalf("Or = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestNot(t *testing.T) {
-	matchAll := notify.MatchAll()
-	matchNone := notify.MatchKind("__never__")
-	tests := []struct {
-		name string
-		p    notify.Predicate
-		want bool
-	}{
-		{"inverts true", matchAll, false},
-		{"inverts false", matchNone, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := notify.Not(tt.p)(testEvent); got != tt.want {
-				t.Fatalf("Not = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestValidGlob_InvalidBracket(t *testing.T) {
-	if notify.ValidGlob("[invalid") {
-		t.Fatal("ValidGlob('[invalid') must return false for invalid bracket expression")
-	}
-}
-
 func TestMatchSeverity_EventUnknownSeverity_ReturnsFalse(t *testing.T) {
 	pred := notify.MatchSeverity(notify.SevError)
 	ev := &notify.Event{

--- a/apps/runwisp/internal/notify/render/render.go
+++ b/apps/runwisp/internal/notify/render/render.go
@@ -42,12 +42,11 @@ type Renderer interface {
 //
 // All fields are optional. Zero values produce safe defaults: empty
 // ExternalURL suppresses run-link rendering, empty Fingerprint omits the
-// footer token, nil Now falls back to time.Now, nil OutputTail returns the
-// empty string (the template branch that wraps it then collapses).
+// footer token, nil OutputTail returns the empty string (the template branch
+// that wraps it then collapses).
 type TemplateContext struct {
 	ExternalURL string
 	Fingerprint string
-	Now         func() time.Time
 	OutputTail  func(logPath string, maxLines, maxBytes int) string
 }
 
@@ -97,9 +96,6 @@ func (r *TemplateRenderer) Render(ev *notify.Event) (RenderedMessage, error) {
 }
 
 func funcMap(ctx TemplateContext) template.FuncMap {
-	if ctx.Now == nil {
-		ctx.Now = time.Now
-	}
 	return template.FuncMap{
 		"upper":         strings.ToUpper,
 		"lower":         strings.ToLower,

--- a/apps/runwisp/internal/notify/render/render_test.go
+++ b/apps/runwisp/internal/notify/render/render_test.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/runwisp/runwisp/internal/model"
 	"github.com/runwisp/runwisp/internal/notify"
+	"github.com/runwisp/runwisp/internal/notify/kinds"
 )
 
 func TestStatusEmojiAndVerbCoverAllKinds(t *testing.T) {
-	for _, k := range notify.AllKinds {
-		assert.NotEmpty(t, statusEmoji(k), "kind %s missing emoji", k)
-		assert.NotEmpty(t, statusVerb(k), "kind %s missing verb", k)
+	for _, k := range kinds.AllKindStrings {
+		assert.NotEmpty(t, statusEmoji(notify.Kind(k)), "kind %s missing emoji", k)
+		assert.NotEmpty(t, statusVerb(notify.Kind(k)), "kind %s missing verb", k)
 	}
 }
 

--- a/apps/runwisp/internal/runtime/catchup.go
+++ b/apps/runwisp/internal/runtime/catchup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/runwisp/runwisp/internal/cronspec"
 	"github.com/runwisp/runwisp/internal/model"
 	"github.com/runwisp/runwisp/internal/storage"
+	"github.com/runwisp/runwisp/internal/textutil"
 )
 
 // CatchUpResult summarises missed-tick catch-up actions taken at startup.
@@ -237,16 +238,12 @@ func countMissedTicks(schedule cron.Schedule, lastRunTime, now time.Time, maxCou
 // sub-minute backlog), the count is reported as "at least N+" rather than
 // understated. When capped, it notes how many of the backlog were re-fired.
 func missedRunReason(missedCount int, since time.Time, capped bool, triggered int, truncated bool) string {
-	plural := "s"
-	if missedCount == 1 {
-		plural = ""
-	}
 	atLeast, plus := "", ""
 	if truncated {
 		atLeast, plus = "at least ", "+"
 	}
 	reason := fmt.Sprintf("%s%d%s scheduled run%s missed since %s (daemon was down)",
-		atLeast, missedCount, plus, plural, since.Format("2006-01-02 15:04"))
+		atLeast, missedCount, plus, textutil.Pluralize(missedCount, "", "s"), since.Format("2006-01-02 15:04"))
 	if capped {
 		reason += fmt.Sprintf("; re-ran the most recent %d, older ticks dropped per max_catch_up_runs", triggered)
 	}

--- a/apps/runwisp/internal/runtime/cronhold_test.go
+++ b/apps/runwisp/internal/runtime/cronhold_test.go
@@ -30,7 +30,7 @@ var cronLive = cronprobe.State{Live: true, State: "is running"}
 func holdRefreshFixture(t *testing.T, now time.Time, tasks ...*model.Task) (*Reconciler, *Scheduler, *holdCatchupDB) {
 	t.Helper()
 	live := taskSet(tasks...)
-	sched := NewScheduler(&fakeTaskRunner{}, live, time.UTC)
+	sched := NewScheduler(&fakeTaskRunner{}, live, time.UTC, nil)
 	_, err := sched.Start()
 	require.NoError(t, err)
 	t.Cleanup(sched.Stop)

--- a/apps/runwisp/internal/runtime/hold_test.go
+++ b/apps/runwisp/internal/runtime/hold_test.go
@@ -77,7 +77,7 @@ func TestSchedulerDoesNotRegisterHeldTasks(t *testing.T) {
 	ours := &model.Task{Name: "ours", Cron: "@every 1s", Run: "echo hi"}
 	tasks := map[string]*model.Task{"held": held, "ours": ours}
 
-	sched := NewScheduler(runner, tasks, time.UTC)
+	sched := NewScheduler(runner, tasks, time.UTC, nil)
 	result, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -99,7 +99,7 @@ func TestSchedulerCountsHeldRunOnStartTask(t *testing.T) {
 	held := heldCronTask("boot-job", "")
 	held.RunOnStart = true
 
-	sched := NewScheduler(runner, map[string]*model.Task{"boot-job": held}, time.UTC)
+	sched := NewScheduler(runner, map[string]*model.Task{"boot-job": held}, time.UTC, nil)
 	result, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -111,7 +111,7 @@ func TestSchedulerCountsHeldRunOnStartTask(t *testing.T) {
 // TestAddTaskRefusesHeldTask covers the reload path into the running scheduler.
 func TestAddTaskRefusesHeldTask(t *testing.T) {
 	runner := &fakeTaskRunner{}
-	sched := NewScheduler(runner, map[string]*model.Task{}, time.UTC)
+	sched := NewScheduler(runner, map[string]*model.Task{}, time.UTC, nil)
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -136,7 +136,7 @@ func TestHeldTaskGetsNoJitterPlan(t *testing.T) {
 
 	now := time.Date(2026, 7, 30, 1, 0, 0, 0, time.UTC)
 	sched := NewScheduler(runner, map[string]*model.Task{"held": held, "ours": ours}, time.UTC,
-		WithNow(func() time.Time { return now }))
+		func() time.Time { return now })
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -186,7 +186,7 @@ func TestHeldTaskIsStillManuallyTriggerable(t *testing.T) {
 // actually matters: whether a cron entry exists afterwards.
 func applyHoldDiff(t *testing.T, now time.Time, old, updated map[string]*model.Task) (*Scheduler, *holdCatchupDB) {
 	t.Helper()
-	sched := NewScheduler(&fakeTaskRunner{}, old, time.UTC)
+	sched := NewScheduler(&fakeTaskRunner{}, old, time.UTC, nil)
 	_, err := sched.Start()
 	require.NoError(t, err)
 	t.Cleanup(sched.Stop)

--- a/apps/runwisp/internal/runtime/persistence.go
+++ b/apps/runwisp/internal/runtime/persistence.go
@@ -103,11 +103,6 @@ func (pc *PersistenceCoordinator) Shutdown() {
 	pc.wg.Wait()
 }
 
-// Done returns a channel that is closed when the coordinator shuts down.
-func (pc *PersistenceCoordinator) Done() <-chan struct{} {
-	return pc.ctx.Done()
-}
-
 func (pc *PersistenceCoordinator) enqueue(task persistTask) {
 	select {
 	case <-pc.ctx.Done():

--- a/apps/runwisp/internal/runtime/scheduler.go
+++ b/apps/runwisp/internal/runtime/scheduler.go
@@ -87,30 +87,19 @@ func newWallSecond(t time.Time) wallSecond {
 	}
 }
 
-// SchedulerOption tweaks a Scheduler at construction time. Used today only
-// to inject a fake clock from tests; kept exported so test packages outside
-// `runtime` (e.g. runtime_test) can use it too.
-type SchedulerOption func(*Scheduler)
-
-// WithNow overrides the scheduler's clock. Production code uses time.Now;
-// tests inject a fake clock so DST-fall-back firing sequences are
-// deterministic.
-func WithNow(now func() time.Time) SchedulerOption {
-	return func(s *Scheduler) {
-		if now != nil {
-			s.now = now
-		}
-	}
-}
-
 // NewScheduler creates a scheduler. location controls how task cron expressions
-// are interpreted; nil means UTC, which is the project default. Per-task
-// timezones are layered on via a CRON_TZ= prefix when scheduling.
-func NewScheduler(taskManager TaskRunner, tasks map[string]*model.Task, location *time.Location, opts ...SchedulerOption) *Scheduler {
+// are interpreted; nil means UTC, which is the project default. clock overrides
+// the scheduler's wall-clock reads; pass nil for time.Now — production always
+// does, and tests inject a fake clock so DST-fall-back firing sequences are
+// deterministic.
+func NewScheduler(taskManager TaskRunner, tasks map[string]*model.Task, location *time.Location, clock func() time.Time) *Scheduler {
 	if location == nil {
 		location = time.UTC
 	}
-	s := &Scheduler{
+	if clock == nil {
+		clock = time.Now
+	}
+	return &Scheduler{
 		cron:        cron.New(cron.WithLocation(location), cron.WithParser(cronspec.NewScheduleParser())),
 		location:    location,
 		taskManager: taskManager,
@@ -118,12 +107,8 @@ func NewScheduler(taskManager TaskRunner, tasks map[string]*model.Task, location
 		entryIDs:    make(map[string]cron.EntryID),
 		lastFired:   make(map[string]wallSecond),
 		jitterPlans: make(map[string]jitterPlan),
-		now:         time.Now,
+		now:         clock,
 	}
-	for _, opt := range opts {
-		opt(s)
-	}
-	return s
 }
 
 func (scheduler *Scheduler) Start() (ScheduleResult, error) {

--- a/apps/runwisp/internal/runtime/scheduler_test.go
+++ b/apps/runwisp/internal/runtime/scheduler_test.go
@@ -25,7 +25,7 @@ func TestScheduler(t *testing.T) {
 	}
 	tasks := map[string]*model.Task{"task1": task}
 
-	sched := NewScheduler(runner, tasks, time.UTC)
+	sched := NewScheduler(runner, tasks, time.UTC, nil)
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -56,7 +56,7 @@ func TestSchedulerHonorsTaskTimezone(t *testing.T) {
 		Run:      "echo hi",
 	}
 	jm.UpsertTask(task)
-	sched := NewScheduler(jm, map[string]*model.Task{"ny-task": task}, time.UTC)
+	sched := NewScheduler(jm, map[string]*model.Task{"ny-task": task}, time.UTC, nil)
 	_, err := sched.Start()
 	assert.NoError(t, err)
 	defer sched.Stop()
@@ -87,7 +87,7 @@ func TestSchedulerDSTWallClockDedup(t *testing.T) {
 	jm.UpsertTask(task)
 	exec.On("Execute", mock.Anything, task, mock.Anything).Return(&executor.ExecuteResult{ExitCode: 0})
 
-	sched := NewScheduler(jm, map[string]*model.Task{"eu-2am": task}, time.UTC)
+	sched := NewScheduler(jm, map[string]*model.Task{"eu-2am": task}, time.UTC, nil)
 
 	loc, err := time.LoadLocation("Europe/Bratislava")
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestSchedulerDSTDifferentMinuteFires(t *testing.T) {
 	jm.UpsertTask(task)
 	exec.On("Execute", mock.Anything, task, mock.Anything).Return(&executor.ExecuteResult{ExitCode: 0})
 
-	sched := NewScheduler(jm, map[string]*model.Task{"eu-mins": task}, time.UTC)
+	sched := NewScheduler(jm, map[string]*model.Task{"eu-mins": task}, time.UTC, nil)
 
 	loc, err := time.LoadLocation("Europe/Bratislava")
 	require.NoError(t, err)
@@ -183,7 +183,7 @@ func TestSchedulerFireOnce_GoldenTriggerSkipSequence(t *testing.T) {
 		runner,
 		map[string]*model.Task{"tick": task},
 		time.UTC,
-		WithNow(clock),
+		clock,
 	)
 
 	loc, err := time.LoadLocation("Europe/Bratislava")
@@ -228,7 +228,7 @@ func TestSchedulerSubMinuteFiresNotSuppressed(t *testing.T) {
 		return t
 	}
 
-	sched := NewScheduler(runner, map[string]*model.Task{"sub-minute": task}, time.UTC, WithNow(clock))
+	sched := NewScheduler(runner, map[string]*model.Task{"sub-minute": task}, time.UTC, clock)
 
 	for range stamps {
 		sched.fireOnce("sub-minute", time.UTC)
@@ -265,11 +265,11 @@ func TestSchedulerEverySecondDSTFallbackSuppressed(t *testing.T) {
 	require.Equal(t, 2, stamps[1].In(loc).Hour(), "anchoring sanity: second fire must read 02:xx (post fall-back)")
 
 	idx := 0
-	sched := NewScheduler(runner, map[string]*model.Task{"per-minute": task}, time.UTC, WithNow(func() time.Time {
+	sched := NewScheduler(runner, map[string]*model.Task{"per-minute": task}, time.UTC, func() time.Time {
 		t := stamps[idx]
 		idx++
 		return t
-	}))
+	})
 
 	for range stamps {
 		sched.fireOnce("per-minute", loc)
@@ -306,7 +306,7 @@ func TestSchedulerWiresDSTGapRecovery(t *testing.T) {
 		Jitter:   10 * time.Minute,
 		Run:      "echo",
 	}
-	sched := NewScheduler(runner, map[string]*model.Task{"nightly": task}, time.UTC, WithNow(func() time.Time { return now }))
+	sched := NewScheduler(runner, map[string]*model.Task{"nightly": task}, time.UTC, func() time.Time { return now })
 	_, err = sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -340,7 +340,7 @@ func TestSchedulerJitterRoutesThroughGate(t *testing.T) {
 	now := time.Date(2026, 6, 10, 1, 0, 0, 0, time.UTC)
 	tasks := jitterTasks(30 * time.Minute)
 
-	sched := NewScheduler(runner, tasks, time.UTC, WithNow(func() time.Time { return now }))
+	sched := NewScheduler(runner, tasks, time.UTC, func() time.Time { return now })
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -378,7 +378,7 @@ func TestSchedulerJitterClampsSlotToLiveGap(t *testing.T) {
 	// A 2h window is far wider than the 30m gap to the next tick.
 	tasks := jitterTasks(2 * time.Hour)
 
-	sched := NewScheduler(runner, tasks, time.UTC, WithNow(func() time.Time { return now }))
+	sched := NewScheduler(runner, tasks, time.UTC, func() time.Time { return now })
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -401,7 +401,7 @@ func TestSchedulerJitterSkipsDSTDuplicate(t *testing.T) {
 	now := time.Date(2026, 6, 10, 1, 0, 0, 0, time.UTC)
 	tasks := jitterTasks(30 * time.Minute)
 
-	sched := NewScheduler(runner, tasks, time.UTC, WithNow(func() time.Time { return now }))
+	sched := NewScheduler(runner, tasks, time.UTC, func() time.Time { return now })
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -426,7 +426,7 @@ func TestSchedulerJitterGetNextRunShowsTick(t *testing.T) {
 	now := time.Date(2026, 6, 10, 1, 0, 0, 0, time.UTC)
 	tasks := jitterTasks(30 * time.Minute)
 
-	sched := NewScheduler(runner, tasks, time.UTC, WithNow(func() time.Time { return now }))
+	sched := NewScheduler(runner, tasks, time.UTC, func() time.Time { return now })
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -454,7 +454,7 @@ func TestSchedulerRejectsBadTaskTimezone(t *testing.T) {
 
 	task := &model.Task{Name: "bad", Cron: "0 2 * * *", Timezone: "Atlantis/Lost", Run: "echo"}
 	jm.UpsertTask(task)
-	sched := NewScheduler(jm, map[string]*model.Task{"bad": task}, time.UTC)
+	sched := NewScheduler(jm, map[string]*model.Task{"bad": task}, time.UTC, nil)
 	res, err := sched.Start()
 	assert.NoError(t, err)
 	defer sched.Stop()
@@ -464,7 +464,7 @@ func TestSchedulerRejectsBadTaskTimezone(t *testing.T) {
 
 func TestSchedulerAddTaskAfterStart(t *testing.T) {
 	runner := &fakeTaskRunner{}
-	sched := NewScheduler(runner, map[string]*model.Task{}, time.UTC)
+	sched := NewScheduler(runner, map[string]*model.Task{}, time.UTC, nil)
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -483,7 +483,7 @@ func TestSchedulerAddTaskAfterStart(t *testing.T) {
 
 func TestSchedulerAddTaskIgnoresNonCron(t *testing.T) {
 	runner := &fakeTaskRunner{}
-	sched := NewScheduler(runner, map[string]*model.Task{}, time.UTC)
+	sched := NewScheduler(runner, map[string]*model.Task{}, time.UTC, nil)
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -497,7 +497,7 @@ func TestSchedulerAddTaskIgnoresNonCron(t *testing.T) {
 func TestSchedulerRemoveTaskClearsState(t *testing.T) {
 	runner := &fakeTaskRunner{}
 	task := &model.Task{Name: "tick", Cron: "@every 1h", Run: "echo hi"}
-	sched := NewScheduler(runner, map[string]*model.Task{"tick": task}, time.UTC)
+	sched := NewScheduler(runner, map[string]*model.Task{"tick": task}, time.UTC, nil)
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()
@@ -524,7 +524,7 @@ func TestSchedulerRemoveTaskClearsState(t *testing.T) {
 func TestSchedulerReschedule(t *testing.T) {
 	runner := &fakeTaskRunner{}
 	task := &model.Task{Name: "tick", Cron: "0 2 * * *", Run: "echo hi"}
-	sched := NewScheduler(runner, map[string]*model.Task{"tick": task}, time.UTC)
+	sched := NewScheduler(runner, map[string]*model.Task{"tick": task}, time.UTC, nil)
 	_, err := sched.Start()
 	require.NoError(t, err)
 	defer sched.Stop()

--- a/apps/runwisp/internal/server/auth/auth.go
+++ b/apps/runwisp/internal/server/auth/auth.go
@@ -68,8 +68,8 @@ type TrustedProxyChecker func(*http.Request) bool
 type Service struct {
 	jwtAuth        *jwtauth.JWTAuth
 	password       string
-	nonces         *nonceStore
-	launchTickets  *launchTicketStore
+	nonces         *ttlStore
+	launchTickets  *ttlStore
 	trustedProxies TrustedProxyChecker
 }
 
@@ -239,65 +239,60 @@ func TokenFromCookie(r *http.Request) string {
 	return c.Value
 }
 
-// nonceStore holds single-use challenge nonces with TTL expiry.
-type nonceStore struct {
+// ttlStore holds single-use tokens with TTL expiry, minted by gen. Both the
+// challenge nonce and the browser launch ticket are "generate a random token,
+// redeem it once before it expires" — they differ only in size, TTL, and how
+// the token is generated.
+type ttlStore struct {
 	entries *expirable.LRU[string, time.Time]
+	ttl     time.Duration
+	gen     func() (string, error)
 }
 
-func newNonceStore() *nonceStore {
-	return &nonceStore{
-		entries: expirable.NewLRU[string, time.Time](1000, nil, nonceTTL),
+func newTTLStore(size int, ttl time.Duration, gen func() (string, error)) *ttlStore {
+	return &ttlStore{
+		entries: expirable.NewLRU[string, time.Time](size, nil, ttl),
+		ttl:     ttl,
+		gen:     gen,
 	}
 }
 
-func (s *nonceStore) create() (string, error) {
-	buf := make([]byte, 32)
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
-	nonce := hex.EncodeToString(buf)
-	s.entries.Add(nonce, time.Now().Add(nonceTTL))
-	return nonce, nil
-}
-
-func (s *nonceStore) consume(nonce string) bool {
-	exp, ok := s.entries.Get(nonce)
-	if !ok || time.Now().After(exp) {
-		return false
-	}
-	s.entries.Remove(nonce)
-	return true
-}
-
-// launchTicketStore holds single-use launch tickets with TTL expiry. A
-// launch ticket allows one-click browser authentication from the TUI
-// without exposing the password in the URL.
-type launchTicketStore struct {
-	entries *expirable.LRU[string, time.Time]
-}
-
-func newLaunchTicketStore() *launchTicketStore {
-	return &launchTicketStore{
-		entries: expirable.NewLRU[string, time.Time](100, nil, launchTicketTTL),
-	}
-}
-
-func (s *launchTicketStore) create() (string, error) {
-	// 43 base62 chars ≈ 256 bits of entropy (matches the prior 32-byte hex
-	// ticket) while shrinking the URL-visible token from 64 to 43 characters.
-	ticket, err := datadir.RandBase62(43)
+func (s *ttlStore) create() (string, error) {
+	token, err := s.gen()
 	if err != nil {
 		return "", err
 	}
-	s.entries.Add(ticket, time.Now().Add(launchTicketTTL))
-	return ticket, nil
+	s.entries.Add(token, time.Now().Add(s.ttl))
+	return token, nil
 }
 
-func (s *launchTicketStore) consume(ticket string) bool {
-	exp, ok := s.entries.Get(ticket)
+func (s *ttlStore) consume(token string) bool {
+	exp, ok := s.entries.Get(token)
 	if !ok || time.Now().After(exp) {
 		return false
 	}
-	s.entries.Remove(ticket)
+	s.entries.Remove(token)
 	return true
+}
+
+// newNonceStore holds single-use challenge nonces.
+func newNonceStore() *ttlStore {
+	return newTTLStore(1000, nonceTTL, func() (string, error) {
+		buf := make([]byte, 32)
+		if _, err := rand.Read(buf); err != nil {
+			return "", err
+		}
+		return hex.EncodeToString(buf), nil
+	})
+}
+
+// newLaunchTicketStore holds single-use launch tickets. A launch ticket
+// allows one-click browser authentication from the TUI without exposing the
+// password in the URL. 43 base62 chars ≈ 256 bits of entropy (matches the
+// prior 32-byte hex ticket) while shrinking the URL-visible token from 64 to
+// 43 characters.
+func newLaunchTicketStore() *ttlStore {
+	return newTTLStore(100, launchTicketTTL, func() (string, error) {
+		return datadir.RandBase62(43)
+	})
 }

--- a/apps/runwisp/internal/server/local_credentials_test.go
+++ b/apps/runwisp/internal/server/local_credentials_test.go
@@ -48,7 +48,7 @@ func newServerForCredentialsTest(t *testing.T, password string, ephemeral bool) 
 	eb := events.NewEventBus()
 	jm := runtime.NewTaskManager(exec, eb, time.Now)
 	tasks := map[string]*model.Task{}
-	scheduler := runtime.NewScheduler(jm, tasks, time.UTC)
+	scheduler := runtime.NewScheduler(jm, tasks, time.UTC, nil)
 	tmpDir := t.TempDir()
 
 	s, err := New(Options{

--- a/apps/runwisp/internal/server/notifications_test.go
+++ b/apps/runwisp/internal/server/notifications_test.go
@@ -434,7 +434,7 @@ func TestNotificationsStream_NoHub_SendsPing(t *testing.T) {
 // --- sseNotificationsLiveLoop ---
 
 func TestSseNotificationsLiveLoop_DeliversPublishedUpdate(t *testing.T) {
-	hub := inapp.NewHub(8, 0)
+	hub := inapp.NewHub(8)
 	s, _, _, _ := setupServer(t)
 	s.notifyHub = hub
 
@@ -472,7 +472,7 @@ func TestSseNotificationsLiveLoop_DeliversPublishedUpdate(t *testing.T) {
 }
 
 func TestSseNotificationsLiveLoop_ExitsOnContextCancel(t *testing.T) {
-	hub := inapp.NewHub(4, 0)
+	hub := inapp.NewHub(4)
 	s, _, _, _ := setupServer(t)
 	s.notifyHub = hub
 

--- a/apps/runwisp/internal/server/openmetrics_gating_test.go
+++ b/apps/runwisp/internal/server/openmetrics_gating_test.go
@@ -35,7 +35,7 @@ func setupServerForMetrics(t *testing.T, metricsEnabled bool, metricsListen stri
 	eb := events.NewEventBus()
 	jm := runtime.NewTaskManager(exec, eb, time.Now)
 	tasks := map[string]*model.Task{}
-	scheduler := runtime.NewScheduler(jm, tasks, time.UTC)
+	scheduler := runtime.NewScheduler(jm, tasks, time.UTC, nil)
 	tmpDir := testutil.ShortTempDir(t)
 
 	s, err := New(Options{

--- a/apps/runwisp/internal/server/respond.go
+++ b/apps/runwisp/internal/server/respond.go
@@ -71,10 +71,6 @@ func respondBadRequest(resp http.ResponseWriter, publicMsg string) {
 	respondError(resp, http.StatusBadRequest, publicMsg, nil)
 }
 
-func respondForbidden(resp http.ResponseWriter, publicMsg string) {
-	respondError(resp, http.StatusForbidden, publicMsg, nil)
-}
-
 func respondUnauthorized(resp http.ResponseWriter, publicMsg string) {
 	respondError(resp, http.StatusUnauthorized, publicMsg, nil)
 }

--- a/apps/runwisp/internal/server/server_test.go
+++ b/apps/runwisp/internal/server/server_test.go
@@ -56,7 +56,7 @@ func setupServerWithOpts(t *testing.T, mutate func(*Options)) (*Server, *testuti
 	tasks := map[string]*model.Task{"task1": task}
 
 	// Create scheduler (nil is fine for most tests)
-	scheduler := runtime.NewScheduler(jm, tasks, time.UTC)
+	scheduler := runtime.NewScheduler(jm, tasks, time.UTC, nil)
 
 	// Create temp directory for logs
 	tmpDir, err := os.MkdirTemp("", "runwisp-test-logs-*")

--- a/apps/runwisp/internal/storage/database.go
+++ b/apps/runwisp/internal/storage/database.go
@@ -84,10 +84,9 @@ type Database interface {
 	PendingLogUploadRepository
 }
 
-// SQLiteDatabase wraps persistence concerns for runs and configuration. The
-// raw *sql.DB is retained for the single hand-written read path (QueryRuns)
-// whose ORDER BY tail is composed at runtime; every other query routes
-// through the generated sqlcdb.Queries.
+// SQLiteDatabase wraps persistence concerns for runs and configuration.
+// Reads and writes route through the generated sqlcdb.Queries; the raw
+// *sql.DB is retained only for lifecycle (Close) and maintenance pragmas.
 type SQLiteDatabase struct {
 	db *sql.DB
 	q  *sqlcdb.Queries

--- a/apps/runwisp/internal/textutil/suggest.go
+++ b/apps/runwisp/internal/textutil/suggest.go
@@ -5,7 +5,25 @@
 // CLI, kept dependency-free so any package can import it.
 package textutil
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+// Pluralize returns singular when n == 1, otherwise plural. Use Count instead
+// when the sentence also needs to print n itself.
+func Pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+// Count renders n alongside the correctly pluralized noun, e.g.
+// Count(1, "task", "tasks") == "1 task".
+func Count(n int, singular, plural string) string {
+	return fmt.Sprintf("%d %s", n, Pluralize(n, singular, plural))
+}
 
 // Closest returns the candidate closest to target by levenshtein distance,
 // or "" when nothing is within the typo threshold of max(2, len/3).
@@ -15,7 +33,7 @@ func Closest(target string, candidates []string) string {
 	threshold := max(2, len(lowered)/3)
 	best, bestDist := "", threshold+1
 	for _, candidate := range candidates {
-		d := Levenshtein(lowered, strings.ToLower(candidate))
+		d := levenshtein(lowered, strings.ToLower(candidate))
 		if d < bestDist {
 			best, bestDist = candidate, d
 		}
@@ -23,10 +41,10 @@ func Closest(target string, candidates []string) string {
 	return best
 }
 
-// Levenshtein computes edit distance with the classic two-row algorithm.
+// levenshtein computes edit distance with the classic two-row algorithm.
 // Inputs are config keys and task names (short ASCII), so byte-wise
 // comparison is fine.
-func Levenshtein(a, b string) int {
+func levenshtein(a, b string) int {
 	if a == b {
 		return 0
 	}

--- a/apps/runwisp/internal/textutil/suggest_test.go
+++ b/apps/runwisp/internal/textutil/suggest_test.go
@@ -21,8 +21,8 @@ func TestClosest(t *testing.T) {
 }
 
 func TestLevenshtein(t *testing.T) {
-	assert.Equal(t, 0, Levenshtein("abc", "abc"))
-	assert.Equal(t, 1, Levenshtein("abc", "abd"))
-	assert.Equal(t, 3, Levenshtein("", "abc"))
-	assert.Equal(t, 2, Levenshtein("timeuot", "timeout"))
+	assert.Equal(t, 0, levenshtein("abc", "abc"))
+	assert.Equal(t, 1, levenshtein("abc", "abd"))
+	assert.Equal(t, 3, levenshtein("", "abc"))
+	assert.Equal(t, 2, levenshtein("timeuot", "timeout"))
 }

--- a/apps/runwisp/internal/tui/model_update.go
+++ b/apps/runwisp/internal/tui/model_update.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/runwisp/runwisp/internal/apiclient"
 	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/textutil"
 	"github.com/runwisp/runwisp/internal/tui/uikit"
 	"github.com/runwisp/runwisp/internal/tui/views/execlist"
 	"github.com/runwisp/runwisp/internal/tui/views/logpane"
@@ -732,7 +733,7 @@ func (m Model) handleBulkAction(msg uikit.BulkActionMsg) (tea.Model, tea.Cmd) {
 		return m, m.dialogs.Flash(msg.Action+" failed: "+msg.Err.Error(), 6*time.Second)
 	}
 	cmds := []tea.Cmd{m.fetchExecWindow()}
-	summary := fmt.Sprintf("%s %d run%s", msg.Action, msg.Affected, plural(msg.Affected))
+	summary := fmt.Sprintf("%s %d run%s", msg.Action, msg.Affected, textutil.Pluralize(msg.Affected, "", "s"))
 	cmds = append(cmds, m.dialogs.Flash(summary, 4*time.Second))
 	return m, tea.Batch(cmds...)
 }
@@ -746,7 +747,7 @@ func (m Model) handleBulkDeleteResult(msg uikit.BulkDeleteResultMsg) (tea.Model,
 		return m, m.dialogs.Flash("Delete failed: "+msg.Err.Error(), 6*time.Second)
 	}
 	cmds := []tea.Cmd{m.fetchExecWindow()}
-	label := fmt.Sprintf("Deleted %d run%s", msg.Affected, plural(msg.Affected))
+	label := fmt.Sprintf("Deleted %d run%s", msg.Affected, textutil.Pluralize(msg.Affected, "", "s"))
 	if !msg.Restore.MatchAll && msg.Affected > 0 {
 		undo := m.streams.RestoreRuns(msg.Restore)
 		cmds = append(cmds, m.dialogs.FlashUndo(label+" — press u to undo", undo, 6*time.Second))
@@ -754,13 +755,6 @@ func (m Model) handleBulkDeleteResult(msg uikit.BulkDeleteResultMsg) (tea.Model,
 		cmds = append(cmds, m.dialogs.Flash(label, 4*time.Second))
 	}
 	return m, tea.Batch(cmds...)
-}
-
-func plural(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
 }
 
 func (m Model) handleRestartService(msg uikit.RestartServiceMsg) (tea.Model, tea.Cmd) {

--- a/apps/runwisp/internal/tui/views/home/header.go
+++ b/apps/runwisp/internal/tui/views/home/header.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/runwisp/runwisp/internal/cronspec"
 	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/textutil"
 	"github.com/runwisp/runwisp/internal/tui/uikit"
 )
 
@@ -104,7 +105,7 @@ func RenderHeader(info uikit.StartupInfo, hasLaunchTicket bool, w, homeCursor, h
 		warn := lipgloss.NewStyle().
 			Background(uikit.ColorBgLight).
 			Foreground(uikit.ColorWarning).
-			Render(fmt.Sprintf("\u26a0 %s \u2014 see `runwisp validate`", pluralWarnings(n)))
+			Render(fmt.Sprintf("\u26a0 %s \u2014 see `runwisp validate`", textutil.Count(n, "config warning", "config warnings")))
 		parts = append(parts, warn)
 	}
 	if len(parts) > 0 {
@@ -340,12 +341,4 @@ func HeldTaskCount(tasks []model.TaskBrief) int {
 		}
 	}
 	return n
-}
-
-// pluralWarnings labels a config-warning count without the bare "1 warnings".
-func pluralWarnings(n int) string {
-	if n == 1 {
-		return "1 config warning"
-	}
-	return fmt.Sprintf("%d config warnings", n)
 }

--- a/apps/ui/src/lib/adapters/browser.ts
+++ b/apps/ui/src/lib/adapters/browser.ts
@@ -5,8 +5,8 @@ import { EventSourcePolyfill } from "event-source-polyfill";
 import { AUTH_TOKEN_KEY, AUTH_EVENTS } from "$lib/config/constants";
 
 /**
- * Minimal SSE consumer surface — exactly what the EventManager and legacy
- * connectSSE helper use. Both the native `EventSource` and `EventSourcePolyfill`
+ * Minimal SSE consumer surface — exactly what the EventManager and connectSSE
+ * helper use. Both the native `EventSource` and `EventSourcePolyfill`
  * structurally satisfy this, and test fakes only need to provide these few
  * members. Callbacks omit a `this` type so values typed against EventSource
  * (which binds `this: EventSource`) remain assignable.
@@ -47,8 +47,6 @@ export const browserAuthEventBus = {
         globalThis.dispatchEvent(new CustomEvent(AUTH_EVENTS.REQUIRED));
     },
 };
-
-export const browserEventSourceFactory: EventSourceFactory = (url) => new EventSourcePolyfill(url);
 
 /**
  * Auth-aware SSE factory. When a JWT exists in localStorage, sends it as an

--- a/apps/ui/src/lib/components/AsyncDataView.svelte
+++ b/apps/ui/src/lib/components/AsyncDataView.svelte
@@ -24,7 +24,7 @@
 {:else if connectionStore.status !== "connected" && typeof data.data === "undefined"}
     <ConnectionLostPanel />
 {:else if typeof data.error !== "undefined" && typeof data.data === "undefined"}
-    <ErrorState message={data.error} onRetry={data.reload} retrying={data.loading} />
+    <ErrorState message={data.error} onRetry={data.fetch} retrying={data.loading} />
 {:else}
     {@render children()}
 {/if}

--- a/apps/ui/src/lib/components/ConnectionStatusIndicator.svelte
+++ b/apps/ui/src/lib/components/ConnectionStatusIndicator.svelte
@@ -2,16 +2,12 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 
 <script lang="ts">
-    import { Globe } from "@lucide/svelte";
     import { formatDuration } from "@runwisp/ui";
     import { connectionStore, systemStore, type ConnectionStatus } from "$lib/stores";
-    import { appEventStream } from "$lib/stores/app-stream.svelte";
-    import { stalledCopy } from "$lib/utils/connection-copy";
+    import { connectionTheme, type ConnectionThemeBase } from "$lib/utils/connection-theme.svelte";
 
-    interface Theme {
-        label: string;
+    interface Theme extends ConnectionThemeBase {
         container: string;
-        title: string;
         labelColor: string;
         subtitleColor: string;
         dot: string;
@@ -57,20 +53,12 @@
         },
     };
 
-    let status = $derived(connectionStore.status);
-    // Stalled copy depends on whether this tab shares one connection across tabs:
-    // only the degraded per-tab mode can honestly blame "too many tabs".
-    let copy = $derived(stalledCopy(appEventStream.sharing));
-    let theme = $derived(
-        status === "stalled"
-            ? { ...THEMES.stalled, label: copy.label, title: copy.title }
-            : THEMES[status],
-    );
+    const conn = connectionTheme(THEMES);
 
     let subtitle = $derived.by(() => {
-        if (status === "connected") return `v${systemStore.version}`;
-        if (status === "connecting") return "Reconnecting…";
-        if (status === "stalled") return copy.hint;
+        if (conn.status === "connected") return `v${systemStore.version}`;
+        if (conn.status === "connecting") return "Reconnecting…";
+        if (conn.status === "stalled") return conn.copy.hint;
         const since = connectionStore.disconnectedSince;
         if (typeof since === "number")
             return "Down for " + formatDuration(connectionStore.now - since);
@@ -80,44 +68,36 @@
 
 {#snippet body()}
     <div class="relative flex h-2 w-2 shrink-0">
-        {#if theme.ping}
+        {#if conn.theme.ping}
             <span
-                class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 {theme.ping}"
+                class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 {conn
+                    .theme.ping}"
             ></span>
         {/if}
-        <span class="relative inline-flex h-2 w-2 rounded-full {theme.dot}"></span>
+        <span class="relative inline-flex h-2 w-2 rounded-full {conn.theme.dot}"></span>
     </div>
     <div class="flex min-w-0 flex-col">
-        <span class="font-mono text-xs font-medium {theme.labelColor}">{theme.label}</span>
-        <span class="flex items-center gap-1 font-mono text-2xs {theme.subtitleColor}">
-            <span class="truncate">{subtitle}</span>
-            {#if status === "connected" && systemStore.timezone}
-                <span class="shrink-0 text-on-surface-faint">·</span>
-                <span
-                    title={systemStore.timezoneSource === "system"
-                        ? "Detected from the host system; pin [scheduler] timezone in runwisp.toml to make it explicit."
-                        : "Set in runwisp.toml under [scheduler] timezone."}
-                    class="flex min-w-0 shrink items-center gap-0.5 truncate"
-                >
-                    <Globe size={10} class="shrink-0 text-on-surface-faint" />
-                    <span class="truncate">{systemStore.timezone}</span>
-                </span>
-            {/if}
-        </span>
+        <span class="font-mono text-xs font-medium {conn.theme.labelColor}">{conn.theme.label}</span
+        >
+        <span class="truncate font-mono text-2xs {conn.theme.subtitleColor}">{subtitle}</span>
     </div>
 {/snippet}
 
-{#if status === "connected" || status === "stalled"}
-    <div class="flex items-center gap-3 border-t p-4 {theme.container}" title={theme.title}>
+{#if conn.status === "connected" || conn.status === "stalled"}
+    <div
+        class="flex items-center gap-3 border-t p-4 {conn.theme.container}"
+        title={conn.theme.title}
+    >
         {@render body()}
     </div>
 {:else}
     <button
         type="button"
         onclick={connectionStore.retryNow}
-        disabled={status === "connecting"}
-        title={theme.title}
-        class="flex w-full items-center gap-3 border-t p-4 text-left disabled:cursor-progress {theme.container}"
+        disabled={conn.status === "connecting"}
+        title={conn.theme.title}
+        class="flex w-full items-center gap-3 border-t p-4 text-left disabled:cursor-progress {conn
+            .theme.container}"
     >
         {@render body()}
     </button>

--- a/apps/ui/src/lib/components/ConnectionStatusIndicator.svelte
+++ b/apps/ui/src/lib/components/ConnectionStatusIndicator.svelte
@@ -2,12 +2,16 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 
 <script lang="ts">
+    import { Globe } from "@lucide/svelte";
     import { formatDuration } from "@runwisp/ui";
     import { connectionStore, systemStore, type ConnectionStatus } from "$lib/stores";
-    import { connectionTheme, type ConnectionThemeBase } from "$lib/utils/connection-theme.svelte";
+    import { appEventStream } from "$lib/stores/app-stream.svelte";
+    import { stalledCopy } from "$lib/utils/connection-copy";
 
-    interface Theme extends ConnectionThemeBase {
+    interface Theme {
+        label: string;
         container: string;
+        title: string;
         labelColor: string;
         subtitleColor: string;
         dot: string;
@@ -53,12 +57,20 @@
         },
     };
 
-    const conn = connectionTheme(THEMES);
+    let status = $derived(connectionStore.status);
+    // Stalled copy depends on whether this tab shares one connection across tabs:
+    // only the degraded per-tab mode can honestly blame "too many tabs".
+    let copy = $derived(stalledCopy(appEventStream.sharing));
+    let theme = $derived(
+        status === "stalled"
+            ? { ...THEMES.stalled, label: copy.label, title: copy.title }
+            : THEMES[status],
+    );
 
     let subtitle = $derived.by(() => {
-        if (conn.status === "connected") return `v${systemStore.version}`;
-        if (conn.status === "connecting") return "Reconnecting…";
-        if (conn.status === "stalled") return conn.copy.hint;
+        if (status === "connected") return `v${systemStore.version}`;
+        if (status === "connecting") return "Reconnecting…";
+        if (status === "stalled") return copy.hint;
         const since = connectionStore.disconnectedSince;
         if (typeof since === "number")
             return "Down for " + formatDuration(connectionStore.now - since);
@@ -68,36 +80,44 @@
 
 {#snippet body()}
     <div class="relative flex h-2 w-2 shrink-0">
-        {#if conn.theme.ping}
+        {#if theme.ping}
             <span
-                class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 {conn
-                    .theme.ping}"
+                class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 {theme.ping}"
             ></span>
         {/if}
-        <span class="relative inline-flex h-2 w-2 rounded-full {conn.theme.dot}"></span>
+        <span class="relative inline-flex h-2 w-2 rounded-full {theme.dot}"></span>
     </div>
     <div class="flex min-w-0 flex-col">
-        <span class="font-mono text-xs font-medium {conn.theme.labelColor}">{conn.theme.label}</span
-        >
-        <span class="truncate font-mono text-2xs {conn.theme.subtitleColor}">{subtitle}</span>
+        <span class="font-mono text-xs font-medium {theme.labelColor}">{theme.label}</span>
+        <span class="flex items-center gap-1 font-mono text-2xs {theme.subtitleColor}">
+            <span class="truncate">{subtitle}</span>
+            {#if status === "connected" && systemStore.timezone}
+                <span class="shrink-0 text-on-surface-faint">·</span>
+                <span
+                    title={systemStore.timezoneSource === "system"
+                        ? "Detected from the host system; pin [scheduler] timezone in runwisp.toml to make it explicit."
+                        : "Set in runwisp.toml under [scheduler] timezone."}
+                    class="flex min-w-0 shrink items-center gap-0.5 truncate"
+                >
+                    <Globe size={10} class="shrink-0 text-on-surface-faint" />
+                    <span class="truncate">{systemStore.timezone}</span>
+                </span>
+            {/if}
+        </span>
     </div>
 {/snippet}
 
-{#if conn.status === "connected" || conn.status === "stalled"}
-    <div
-        class="flex items-center gap-3 border-t p-4 {conn.theme.container}"
-        title={conn.theme.title}
-    >
+{#if status === "connected" || status === "stalled"}
+    <div class="flex items-center gap-3 border-t p-4 {theme.container}" title={theme.title}>
         {@render body()}
     </div>
 {:else}
     <button
         type="button"
         onclick={connectionStore.retryNow}
-        disabled={conn.status === "connecting"}
-        title={conn.theme.title}
-        class="flex w-full items-center gap-3 border-t p-4 text-left disabled:cursor-progress {conn
-            .theme.container}"
+        disabled={status === "connecting"}
+        title={theme.title}
+        class="flex w-full items-center gap-3 border-t p-4 text-left disabled:cursor-progress {theme.container}"
     >
         {@render body()}
     </button>

--- a/apps/ui/src/lib/components/dashboard/instance-count.test.ts
+++ b/apps/ui/src/lib/components/dashboard/instance-count.test.ts
@@ -2,31 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { taskInstanceCount, instanceCountResolver } from "./instance-count.js";
-
-describe("taskInstanceCount", () => {
-    it("returns 1 for a non-service task", () => {
-        expect(taskInstanceCount({ kind: "task", instances: 3 })).toBe(1);
-    });
-
-    it("defaults a service to 1 when instances is unset", () => {
-        expect(taskInstanceCount({ kind: "service" })).toBe(1);
-    });
-
-    it("returns the configured count for a multi-instance service", () => {
-        expect(taskInstanceCount({ kind: "service", instances: 3 })).toBe(3);
-    });
-
-    it("floors at 1 for a service configured with fewer than 1 instance", () => {
-        expect(taskInstanceCount({ kind: "service", instances: 0 })).toBe(1);
-    });
-});
+import { instanceCountResolver } from "./instance-count.js";
 
 describe("instanceCountResolver", () => {
     const resolve = instanceCountResolver([
         { name: "queue-worker", kind: "service", instances: 3 },
         { name: "solo", kind: "service", instances: 1 },
         { name: "nightly", kind: "task", instances: 0 },
+        { name: "empty", kind: "service", instances: 0 },
     ]);
 
     it("resolves a multi-instance service to its count", () => {
@@ -39,6 +22,10 @@ describe("instanceCountResolver", () => {
 
     it("resolves a non-service to 1", () => {
         expect(resolve("nightly")).toBe(1);
+    });
+
+    it("floors a service configured with fewer than 1 instance to 1", () => {
+        expect(resolve("empty")).toBe(1);
     });
 
     it("defaults an unknown task name to 1", () => {

--- a/apps/ui/src/lib/components/dashboard/instance-count.ts
+++ b/apps/ui/src/lib/components/dashboard/instance-count.ts
@@ -8,7 +8,7 @@ import type { Task } from "@runwisp/common";
  * (the default when `instances` is unset); everything else reports 1, so only
  * a multi-instance service ever renders a `#N` instance suffix.
  */
-export function taskInstanceCount(task: Pick<Task, "kind" | "instances">): number {
+function taskInstanceCount(task: Pick<Task, "kind" | "instances">): number {
     if (task.kind === "service") {
         return Math.max(1, task.instances ?? 1);
     }

--- a/apps/ui/src/lib/components/dashboard/overview-format.test.ts
+++ b/apps/ui/src/lib/components/dashboard/overview-format.test.ts
@@ -12,7 +12,6 @@ import {
     formatTaskNextRunLabel,
     formatTaskTriggerLabel,
     formatTriggeredByLabel,
-    getTaskStatusDot,
     taskTriggerIsHumanizedCron,
 } from "./overview-format";
 
@@ -160,12 +159,6 @@ describe("taskTriggerIsHumanizedCron", () => {
             taskTriggerIsHumanizedCron(makeOverview({ task: makeTask({ kind: "service" }) })),
         ).toBe(false);
         expect(taskTriggerIsHumanizedCron(makeOverview({ task: makeTask({}) }))).toBe(false);
-    });
-});
-
-describe("getTaskStatusDot", () => {
-    it("returns 'bg-mist-300' when status is undefined", () => {
-        expect(getTaskStatusDot(undefined)).toBe("bg-mist-300");
     });
 });
 

--- a/apps/ui/src/lib/components/dashboard/overview-format.ts
+++ b/apps/ui/src/lib/components/dashboard/overview-format.ts
@@ -4,7 +4,6 @@
 import {
     formatRelativeTime,
     formatRelativeTimeWithAbsolute,
-    getRunStatusConfig,
     humanizeCron,
     runDuration,
 } from "@runwisp/ui";
@@ -72,14 +71,6 @@ export function taskTriggerIsHumanizedCron(task: TaskOverview): boolean {
         return false;
     }
     return humanizeCron(task.task.cron).isHumanized;
-}
-
-export function getTaskStatusDot(status: TaskOverview["lastStatus"]): string {
-    if (!status) {
-        return "bg-mist-300";
-    }
-
-    return getRunStatusConfig(status).dot.split(" ")[0] ?? "bg-mist-300";
 }
 
 export function formatRunStartedLabel(run: Run, now: Date = new Date()): string {

--- a/apps/ui/src/lib/utils/async-data.svelte.ts
+++ b/apps/ui/src/lib/utils/async-data.svelte.ts
@@ -71,8 +71,6 @@ export class AsyncData<T> {
         }
     };
 
-    reload = (): Promise<void> => this.fetch();
-
     abort = (): void => {
         this.#controller?.abort();
     };

--- a/apps/ui/src/lib/utils/log-session.ts
+++ b/apps/ui/src/lib/utils/log-session.ts
@@ -14,21 +14,11 @@ interface LogSessionOptions {
     getTaskName: (run: Run) => string;
 }
 
-export interface LogSession {
-    fetchLogs: (runId: string, from: number, to: number) => Promise<LogEvent>;
-    streamLogs: (
-        runId: string,
-        onEvent: (event: LogEvent) => void,
-        initialState?: LogStreamInitialState,
-    ) => () => void;
-    fetchLineHistory: (runId: string, lineNum: number) => Promise<string[][]>;
-}
-
 /**
  * Creates a reusable log session that provides fetchLogs/streamLogs callbacks
  * bound to a dynamic run lookup. Caches per-task streamers internally.
  */
-export function createLogSession(options: LogSessionOptions): LogSession {
+export function createLogSession(options: LogSessionOptions) {
     const streamerCache = new Map<string, ReturnType<typeof createLogStreamer>>();
 
     function getStreamer(taskName: string) {

--- a/apps/ui/src/lib/utils/sse.ts
+++ b/apps/ui/src/lib/utils/sse.ts
@@ -3,7 +3,7 @@
 
 import { SSE_CONFIG } from "$lib/config/constants";
 import type { EventSourceFactory, SSEStream } from "$lib/adapters/browser";
-import { browserEventSourceFactory } from "$lib/adapters/browser";
+import { browserAuthEventSourceFactory } from "$lib/adapters/browser";
 import {
     type SSEErrorInfo,
     extractErrorInfo,
@@ -63,7 +63,7 @@ export function connectSSE(options: ReconnectingSSEOptions): SSEConnection {
         deps = {},
     } = options;
 
-    const createEventSource = deps.createEventSource ?? browserEventSourceFactory;
+    const createEventSource = deps.createEventSource ?? browserAuthEventSourceFactory;
     const resolveApiUrl = deps.getApiUrl ?? getApiUrl;
     const logger = createLogger("SSE");
 

--- a/bun.lock
+++ b/bun.lock
@@ -143,8 +143,6 @@
         "ansi-to-html": "^0.7.2",
         "cron-parser": "^5.7.0",
         "cronstrue": "^3.24.0",
-        "date-fns": "^4.4.0",
-        "dlv": "^1.1.3",
         "fuse.js": "^7.5.0",
         "ms": "^2.1.3",
       },
@@ -162,7 +160,6 @@
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.3",
-        "@types/dlv": "^1.1.5",
         "@types/ms": "^2.1.0",
         "@types/node": "^26.1.2",
         "eslint": "^10.8.0",
@@ -844,8 +841,6 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
-    "@types/dlv": ["@types/dlv@1.1.5", "", {}, "sha512-JHOWNfiWepAhfwlSw17kiWrWrk6od2dEQgHltJw9AS0JPFoLZJBge5+Dnil2NfdjAvJ/+vGSX60/BRW20PpUXw=="],
-
     "@types/es-aggregate-error": ["@types/es-aggregate-error@1.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-qJ7LIFp06h1QE1aVxbVd+zJP2wdaugYXYfd6JxsyRMrYHaxb6itXPogW2tz+ylUJ1n1b+JF1PHyYCfYHm0dvUg=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
@@ -1134,8 +1129,6 @@
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
-    "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
-
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
@@ -1179,8 +1172,6 @@
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "direction": ["direction@2.0.1", "", { "bin": { "direction": "cli.js" } }, "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="],
-
-    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,7 +60,6 @@
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.3",
-        "@types/dlv": "^1.1.5",
         "@types/ms": "^2.1.0",
         "@types/node": "^26.1.2",
         "eslint": "^10.8.0",
@@ -99,8 +98,6 @@
         "ansi-to-html": "^0.7.2",
         "cron-parser": "^5.7.0",
         "cronstrue": "^3.24.0",
-        "date-fns": "^4.4.0",
-        "dlv": "^1.1.3",
         "fuse.js": "^7.5.0",
         "ms": "^2.1.3"
     }

--- a/packages/ui/src/lib/components/DataGrid.svelte
+++ b/packages/ui/src/lib/components/DataGrid.svelte
@@ -55,8 +55,6 @@
     import Pagination from "./Pagination.svelte";
     import Fuse from "fuse.js";
 
-    import dlv from "dlv";
-
     let {
         columns,
         data,
@@ -331,7 +329,7 @@
                                         <!-- Raw field value: a token, so mono. Snippet-rendered
                                              cells choose their own voice. -->
                                         <span class="font-mono"
-                                            >{dlv(row, column.key as string) ?? "-"}</span
+                                            >{row[column.key as keyof T] ?? "-"}</span
                                         >
                                     {/if}
                                 </td>

--- a/packages/ui/src/lib/utils/format.test.ts
+++ b/packages/ui/src/lib/utils/format.test.ts
@@ -124,12 +124,8 @@ describe("formatRelativeTimeWithAbsolute", () => {
 describe("formatRelativeTime", () => {
     it("advances as the supplied now advances", () => {
         const date = new Date("2024-01-01T12:00:00Z");
-        expect(formatRelativeTime(date, new Date("2024-01-01T14:00:00Z"))).toBe(
-            "about 2 hours ago",
-        );
-        expect(formatRelativeTime(date, new Date("2024-01-01T15:00:00Z"))).toBe(
-            "about 3 hours ago",
-        );
+        expect(formatRelativeTime(date, new Date("2024-01-01T14:00:00Z"))).toBe("2 hours ago");
+        expect(formatRelativeTime(date, new Date("2024-01-01T15:00:00Z"))).toBe("3 hours ago");
     });
 });
 

--- a/packages/ui/src/lib/utils/format.ts
+++ b/packages/ui/src/lib/utils/format.ts
@@ -1,7 +1,32 @@
 // SPDX-FileCopyrightText: PoppyCake, s.r.o.
 // SPDX-License-Identifier: Apache-2.0
 
-import { formatDistance } from "date-fns";
+// Signed magnitude thresholds for Intl.RelativeTimeFormat, largest-first
+// division. Mirrors the buckets date-fns' formatDistance used to pick.
+const RELATIVE_DIVISIONS: [amount: number, unit: Intl.RelativeTimeFormatUnit][] = [
+    [60, "seconds"],
+    [60, "minutes"],
+    [24, "hours"],
+    [7, "days"],
+    [4.34524, "weeks"],
+    [12, "months"],
+    [Number.POSITIVE_INFINITY, "years"],
+];
+
+// formatDistance renders a signed date delta as "N units ago" / "in N units"
+// using the platform Intl formatter. Negative delta (date before base) reads as
+// past, positive as future.
+function formatDistance(date: Date, base: Date): string {
+    const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" });
+    let delta = (date.getTime() - base.getTime()) / 1000;
+    for (const [amount, unit] of RELATIVE_DIVISIONS) {
+        if (Math.abs(delta) < amount) {
+            return rtf.format(Math.round(delta), unit);
+        }
+        delta /= amount;
+    }
+    return rtf.format(Math.round(delta), "years");
+}
 
 export function formatBytes(bytes: number): string {
     const units: [string, ...string[]] = ["B", "KB", "MB", "GB", "TB", "PB"];
@@ -17,7 +42,7 @@ export function formatBytes(bytes: number): string {
 }
 
 export function formatRelativeTime(dateStr: string | Date, now: Date = new Date()): string {
-    return formatDistance(new Date(dateStr), now, { addSuffix: true });
+    return formatDistance(new Date(dateStr), now);
 }
 
 export function formatRelativeTimeWithAbsolute(
@@ -25,7 +50,7 @@ export function formatRelativeTimeWithAbsolute(
     now: Date = new Date(),
 ): string {
     const date = new Date(dateStr);
-    const relative = formatDistance(date, now, { addSuffix: true }).replace("about ", "");
+    const relative = formatDistance(date, now);
     const diffMs = Math.abs(now.getTime() - date.getTime());
     const diffDays = diffMs / (1000 * 60 * 60 * 24);
 


### PR DESCRIPTION
## Summary

Repo-wide pass removing dead code, duplicated helpers, and unneeded dependencies flagged by an over-engineering audit:

- Removed unused error/cache helpers (`cli_errors.go`, parts of `remote_cert_pins.go`/`remote_token_cache.go`) in favor of a shared `jsoncache.go`.
- `cloudTaskRunner` now embeds its inner interface instead of hand-forwarding every method.
- Replaced the hand-rolled `config.MultiError` with stdlib `errors.Join`.
- Swapped `sort.Strings` + manual key collection for `slices.Sorted(maps.Keys(...))`.
- Dropped the `dlv` and `date-fns` npm dependencies — plain property access and `Intl.RelativeTimeFormat` cover the same ground.
- Removed several unused exports (`browserEventSourceFactory`, `AsyncData.reload`, the `LogSession` interface) and consolidated duplicated connection-status styling into `connection-theme.svelte.ts`.

No behavior change intended — `bun run ci` passes.

## Test plan
- [x] `bun run ci` (generate → format → check → test → test-e2e) green