### PR TITLE
cloud: validate the execution field on inbound dispatch frames

### DIFF
--- a/apps/runwisp/internal/cloud/client_test.go
+++ b/apps/runwisp/internal/cloud/client_test.go
@@ -974,6 +974,30 @@ func TestHandleInboundPayloadProtocolError(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// A dispatch frame that omits the required `execution` field decodes to a nil
+// pointer (decodeStrict validates JSON syntax, not `binding:"required"`). The
+// handler must reject it with a validation frame, never deref nil — an
+// unrecovered panic here runs in the read-loop goroutine and would crash the
+// entire daemon, not just the cloud session.
+func TestHandleInboundPayloadDispatchMissingExecution(t *testing.T) {
+	env := newTestEnv(t, func(conn *websocket.Conn) {
+		conn.Close(websocket.StatusNormalClosure, "")
+	})
+	defer env.close()
+
+	session := &wsSession{outbound: make(chan []byte, 16)}
+	payload := []byte(`{"type":"execution:dispatch"}`)
+	err := env.client.sessions.handleInboundPayload(context.Background(), session, payload)
+	assert.NoError(t, err, "missing execution must not tear down the session")
+
+	select {
+	case out := <-session.outbound:
+		assert.Contains(t, string(out), "execution is required")
+	default:
+		t.Fatal("expected a validation error frame for the missing execution field")
+	}
+}
+
 func TestHandleInboundPayloadAuthResultSuccess(t *testing.T) {
 	env := newTestEnv(t, func(conn *websocket.Conn) {
 		conn.Close(websocket.StatusNormalClosure, "")

--- a/apps/runwisp/internal/cloud/session_dispatch.go
+++ b/apps/runwisp/internal/cloud/session_dispatch.go
@@ -181,6 +181,15 @@ func (sr *sessionRunner) handleInboundPayload(ctx context.Context, session *wsSe
 		slog.Info("cloud protocol error", "code", message.Code, "message", message.Message, "requestId", message.RequestID, "executionId", message.ExecutionID)
 		return nil
 	case protocol.ExecutionDispatchMessage:
+		// `execution` is a required pointer field, but decodeStrict only checks
+		// JSON syntax — a frame that omits it (or sends null) decodes to nil.
+		// Guard before the deref: an unrecovered panic in the read-loop goroutine
+		// would take down the whole daemon, not just the cloud session. Mirrors
+		// the nil guards on ServiceApply.Service / ServiceControl.Action.
+		if message.Execution == nil {
+			sr.sendProtocolError(session, CloudErrorKindValidation, "execution is required", "", "")
+			return nil
+		}
 		executionID := strings.TrimSpace(message.Execution.ExecutionID)
 		ack := func() {
 			if ackErr := sendMessage(session, NewExecutionAckMessage(executionID)); ackErr != nil {

--- a/apps/runwisp/internal/cloud/session_dispatch.go
+++ b/apps/runwisp/internal/cloud/session_dispatch.go
@@ -181,25 +181,7 @@ func (sr *sessionRunner) handleInboundPayload(ctx context.Context, session *wsSe
 		slog.Info("cloud protocol error", "code", message.Code, "message", message.Message, "requestId", message.RequestID, "executionId", message.ExecutionID)
 		return nil
 	case protocol.ExecutionDispatchMessage:
-		// `execution` is a required pointer field, but decodeStrict only checks
-		// JSON syntax — a frame that omits it (or sends null) decodes to nil.
-		// Guard before the deref: an unrecovered panic in the read-loop goroutine
-		// would take down the whole daemon, not just the cloud session. Mirrors
-		// the nil guards on ServiceApply.Service / ServiceControl.Action.
-		if message.Execution == nil {
-			sr.sendProtocolError(session, CloudErrorKindValidation, "execution is required", "", "")
-			return nil
-		}
-		executionID := strings.TrimSpace(message.Execution.ExecutionID)
-		ack := func() {
-			if ackErr := sendMessage(session, NewExecutionAckMessage(executionID)); ackErr != nil {
-				slog.Info("failed to send execution ack", "executionId", executionID, "error", ackErr.Error())
-			}
-		}
-		if dispatchErr := sr.handler.HandleExecutionDispatch(ctx, message, ack); dispatchErr != nil {
-			sr.sendProtocolError(session, classifyErrorKind(dispatchErr), dispatchErr.Error(), "", executionID)
-		}
-		return nil
+		return sr.handleExecutionDispatch(ctx, session, message)
 	case protocol.ExecutionStopMessage:
 		return sr.reportIfErr(session, sr.handler.HandleExecutionStop(ctx, message), strings.TrimSpace(message.ExecutionID))
 	case protocol.LogReplayRequestMessage:
@@ -245,6 +227,28 @@ func (sr *sessionRunner) handleInboundPayload(ctx context.Context, session *wsSe
 		slog.Warn("decoded message type has no dispatch case", "type", fmt.Sprintf("%T", decoded))
 		return nil
 	}
+}
+
+// handleExecutionDispatch guards the required `execution` pointer field before
+// dispatching: decodeStrict only checks JSON syntax, so a frame that omits
+// `execution` (or sends null) decodes to nil. An unrecovered panic in the
+// read-loop goroutine would take down the whole daemon, not just the cloud
+// session. Mirrors the nil guards on ServiceApply.Service / ServiceControl.Action.
+func (sr *sessionRunner) handleExecutionDispatch(ctx context.Context, session *wsSession, message protocol.ExecutionDispatchMessage) error {
+	if message.Execution == nil {
+		sr.sendProtocolError(session, CloudErrorKindValidation, "execution is required", "", "")
+		return nil
+	}
+	executionID := strings.TrimSpace(message.Execution.ExecutionID)
+	ack := func() {
+		if ackErr := sendMessage(session, NewExecutionAckMessage(executionID)); ackErr != nil {
+			slog.Info("failed to send execution ack", "executionId", executionID, "error", ackErr.Error())
+		}
+	}
+	if dispatchErr := sr.handler.HandleExecutionDispatch(ctx, message, ack); dispatchErr != nil {
+		sr.sendProtocolError(session, classifyErrorKind(dispatchErr), dispatchErr.Error(), "", executionID)
+	}
+	return nil
 }
 
 func (sr *sessionRunner) sendProtocolError(session *wsSession, kind CloudErrorKind, message, requestID, executionID string) {


### PR DESCRIPTION
Inbound `execution:dispatch` control-plane messages carry a required `execution` object, but the JSON decoder does not enforce `required`, so a frame that omits it reached the handler as a nil pointer.

This adds an explicit nil check: such a frame is now answered with a validation protocol error and the session continues, matching the guards the service-apply and service-control handlers already have. Includes a regression test for a dispatch frame with no `execution` field.

No user-facing configuration or behaviour changes.