### PR TITLE
fix: bug-hunt pass across scheduler, catchup, manager, auth, notify, and cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The web UI no longer shows connection status twice.** The header's connection pip and timezone badge are gone; the sidebar footer is now the one place for both, with the timezone's source (config vs. detected) moved into a tooltip instead of sitting in the label.
 - **The dashboard now seeds `/api/system` and `/api/info` once per session** instead of re-fetching them on every auth state change; live values already stream over `/api/stream`.
 - **Multiple open dashboard tabs no longer stall each other's live updates.** The tab holding the shared event stream now hands it off when it's backgrounded, so a visible tab always keeps the connection.
+- **A cron schedule with more than one tick per hour (e.g. `0,30 2 * * *`) no longer re-fires on the DST fall-back day.** The dedup only remembered the single most recent firing, so the second tick of the rewound hour slipped past as a "new" one.
+- **A restart shortly after a large missed-run backlog no longer re-alerts on the same gap.** When the backlog was capped by `max_catch_up_runs`, the next restart re-counted from the same anchor and reported the gap again.
+- **`overlap = "queue"` no longer lets a fresh trigger start ahead of runs already waiting.** A trigger arriving in the brief window after a slot frees but before the queue drains now joins the back of the queue instead of racing ahead.
+- **`overlap = "terminate"` no longer lets active runs exceed `max_concurrent` under rapid triggers.** Repeated triggers could re-cancel the same already-dying run instead of picking a fresh victim, letting the active set grow unbounded.
+- **`runwisp reload` now gives newly added or rescheduled jittered tasks their start-spread immediately**, instead of firing at the raw tick until the next restart.
+- **Fixed a race where a task's live run state could be read while still being mutated**, surfacing torn or stale values in `GetActiveRuns` callers.
+- **Fixed a race that let a single-use login token or launch ticket be redeemed twice** when two requests presented it at the same moment.
+- **Coalesced notifications now keep the first occurrence's timestamp and run ID** instead of overwriting them with the latest occurrence's.
+- **A dropped control-plane heartbeat no longer tears down an otherwise healthy session.** Liveness is already governed by the watchdog; a single failed send now logs and continues instead of forcing a reconnect.
+- **A 401/403 from the control-plane sync endpoint is no longer treated as a hard authentication failure.** The WebSocket handshake is the actual auth boundary, so these now retry with backoff like any other transient error.
 
 ## [0.14.0] - 2026-08-04
 

--- a/apps/docs/src/agents/reference.md
+++ b/apps/docs/src/agents/reference.md
@@ -410,7 +410,7 @@ POST   /api/tasks/{task}/stop                    stop service (for daemon lifeti
 POST   /api/tasks/{task}/restart                 restart all service instances
 POST   /api/tasks/{task}/runs/{runId}/stop       stop a running task
 DELETE /api/tasks/{task}/runs/{runId}            delete a run
-POST   /api/runs/bulk/cancel                     cancel runs by selector
+POST   /api/runs/bulk/stop                       stop runs by selector
 POST   /api/runs/bulk/delete                     soft-delete runs by selector
 POST   /api/runs/bulk/restore                    restore soft-deleted runs
 POST   /api/runs/bulk/rerun                      re-run tasks behind selector

--- a/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
+++ b/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
@@ -211,7 +211,7 @@ func waitDrain(ctx context.Context, svc *daemonServices, taskTimeout time.Durati
 func inflightRunCount(svc *daemonServices) int {
 	total := 0
 	for name := range svc.Tasks.Snapshot() {
-		total += len(svc.TaskManager.GetActiveRuns(name))
+		total += svc.TaskManager.GetActiveRunCount(name)
 	}
 	return total
 }
@@ -239,7 +239,7 @@ func waitServiceDrained(ctx context.Context, svc *daemonServices, name string) {
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		if len(svc.TaskManager.GetActiveRuns(name)) == 0 {
+		if svc.TaskManager.GetActiveRunCount(name) == 0 {
 			return
 		}
 		select {

--- a/apps/runwisp/internal/apiclient/events.go
+++ b/apps/runwisp/internal/apiclient/events.go
@@ -77,7 +77,7 @@ type StreamLogOpts struct {
 func (c *Client) StreamLogLines(ctx context.Context, taskName, runID string, opts StreamLogOpts) (<-chan LogStreamMsg, error) {
 	path := fmt.Sprintf("/api/tasks/%s/runs/%s/log/stream?from=%d", taskName, runID, opts.FromLine)
 	if opts.ReplayLimit > 0 {
-		path += fmt.Sprintf("&replay_limit=%d", opts.ReplayLimit)
+		path += fmt.Sprintf("&replayLimit=%d", opts.ReplayLimit)
 	}
 	resp, err := c.doSSE(ctx, path)
 	if err != nil {

--- a/apps/runwisp/internal/apiclient/log_stream_test.go
+++ b/apps/runwisp/internal/apiclient/log_stream_test.go
@@ -24,7 +24,7 @@ func TestStreamLogLines_ParsesEvents(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/tasks/t/runs/r/log/stream", r.URL.Path)
 		assert.Equal(t, "0", r.URL.Query().Get("from"))
-		assert.Equal(t, "100", r.URL.Query().Get("replay_limit"))
+		assert.Equal(t, "100", r.URL.Query().Get("replayLimit"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
 
@@ -88,7 +88,7 @@ func TestStreamLogLines_ParsesEvents(t *testing.T) {
 }
 
 // TestStreamLogLines_NoReplayLimitOmitsQueryParam asserts the URL excludes
-// the replay_limit param when callers leave it at the default — the server
+// the replayLimit param when callers leave it at the default — the server
 // then chooses.
 func TestStreamLogLines_NoReplayLimitOmitsQueryParam(t *testing.T) {
 	gotQuery := ""
@@ -114,6 +114,6 @@ func TestStreamLogLines_NoReplayLimitOmitsQueryParam(t *testing.T) {
 		t.Fatal("expected at least one event before timeout")
 	}
 
-	assert.NotContains(t, gotQuery, "replay_limit", "default ReplayLimit must not appear in query")
+	assert.NotContains(t, gotQuery, "replayLimit", "default ReplayLimit must not appear in query")
 	assert.True(t, strings.Contains(gotQuery, "from=-100"))
 }

--- a/apps/runwisp/internal/apiclient/runs.go
+++ b/apps/runwisp/internal/apiclient/runs.go
@@ -143,7 +143,7 @@ func (c *Client) BulkRestoreRuns(sel model.RunSelector) (int, error) {
 // BulkCancelRuns signals a stop to every running execution matched by sel and
 // returns how many were signalled.
 func (c *Client) BulkCancelRuns(sel model.RunSelector) (int, error) {
-	return c.bulkAffected("/api/runs/bulk/cancel", sel)
+	return c.bulkAffected("/api/runs/bulk/stop", sel)
 }
 
 // bulkAffected posts a selector to a bulk endpoint that reports an affected count.

--- a/apps/runwisp/internal/cloud/session_dispatch.go
+++ b/apps/runwisp/internal/cloud/session_dispatch.go
@@ -131,8 +131,13 @@ func (sr *sessionRunner) heartbeatLoop(ctx context.Context, session *wsSession) 
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
+			// A dropped heartbeat is not fatal: the watchdog governs liveness via
+			// lastReceived, and a full outbound buffer means we're already sending
+			// plenty (so the peer is hearing from us). Tearing down a healthy
+			// session over transient backpressure just drops the queued messages
+			// and forces a needless reconnect.
 			if err := sendMessage(session, NewPingMessage(sr.currentSystemStats())); err != nil {
-				return fmt.Errorf("heartbeat: %w", err)
+				slog.Debug("skipped heartbeat", "error", err.Error())
 			}
 		}
 	}

--- a/apps/runwisp/internal/cloud/sync_client.go
+++ b/apps/runwisp/internal/cloud/sync_client.go
@@ -305,9 +305,12 @@ func durationToMillis(d time.Duration) int {
 }
 
 func classifySyncHTTPError(statusCode int) CloudErrorKind {
-	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
-		return CloudErrorKindAuth
-	}
+	// A 401/403 here is NOT treated as a hard-auth stop: task sync runs only
+	// after the WebSocket handshake already authenticated the same token, so a
+	// 401/403 on this separate HTTP request is far more likely a transient
+	// intermediary (proxy/WAF/gateway) than a real credential verdict. The
+	// handshake is the sole authoritative auth boundary; sync errors retry with
+	// backoff like any other transient failure.
 	if statusCode >= 400 && statusCode < 500 {
 		return CloudErrorKindValidation
 	}

--- a/apps/runwisp/internal/cloud/sync_client_test.go
+++ b/apps/runwisp/internal/cloud/sync_client_test.go
@@ -57,8 +57,10 @@ func TestClassifySyncHTTPError(t *testing.T) {
 		code int
 		want CloudErrorKind
 	}{
-		{http.StatusUnauthorized, CloudErrorKindAuth},
-		{http.StatusForbidden, CloudErrorKindAuth},
+		// 401/403 on the sync HTTP call are NOT hard-auth stops — the WS
+		// handshake is the sole auth boundary, so these retry like any 4xx.
+		{http.StatusUnauthorized, CloudErrorKindValidation},
+		{http.StatusForbidden, CloudErrorKindValidation},
 		{http.StatusBadRequest, CloudErrorKindValidation},
 		{http.StatusUnprocessableEntity, CloudErrorKindValidation},
 		{http.StatusNotFound, CloudErrorKindValidation},
@@ -296,7 +298,7 @@ func TestSyncTasksHTTPErrorBubblesUpAsCloudError(t *testing.T) {
 	require.Error(t, err)
 	var ce *CloudError
 	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, CloudErrorKindAuth, ce.Kind)
+	assert.Equal(t, CloudErrorKindValidation, ce.Kind)
 	assert.Contains(t, ce.Message, "401")
 }
 

--- a/apps/runwisp/internal/runtime/catchup.go
+++ b/apps/runwisp/internal/runtime/catchup.go
@@ -146,8 +146,17 @@ func catchupOneTask(ctx context.Context, db storage.RunRepository, parser cron.S
 	// even when MaxCatchUpRuns drops older ticks from the re-run. firstTick is
 	// the first tick after the anchor; lastTick anchors the next restart.
 	firstTick := schedule.Next(anchor)
+	// lastTick anchors the next restart's catch-up counting. When counting was
+	// truncated, lastTick is only the maxCount-th tick, not the true latest tick
+	// before now — walking the rest would defeat the count bound. Anchoring at
+	// now instead prevents the next restart from re-counting (and re-alerting)
+	// this same gap, which is already reported as "at least N+".
+	anchorTick := lastTick
+	if truncated {
+		anchorTick = now
+	}
 	reason := missedRunReason(missedCount, firstTick, capped, triggerCount, truncated)
-	if err := runner.RecordMissedRun(task.Name, lastTick, reason); err != nil {
+	if err := runner.RecordMissedRun(task.Name, anchorTick, reason); err != nil {
 		slog.Error("Failed to record missed run", "task", task.Name, "err", err)
 		errors++
 	}

--- a/apps/runwisp/internal/runtime/catchup_test.go
+++ b/apps/runwisp/internal/runtime/catchup_test.go
@@ -462,6 +462,38 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.AssertNumberOfCalls(t, "RecordMissedRun", 1)
 	})
 
+	t.Run("truncated backlog anchors the missed row at now, not the capped tick", func(t *testing.T) {
+		// When counting truncates, the recorded anchor must be now — not the
+		// maxCount-th tick — so a rapid restart doesn't re-count and re-alert the
+		// same gap. policy=skip is the exposed case: it triggers no catch-up run
+		// whose CreatedAt=now would otherwise advance the anchor.
+		db := new(testutil.MockRunRepository)
+		runner := new(mockTaskRunner)
+
+		now := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+		lastRun := &model.Run{
+			ID:        "last-run",
+			TaskName:  "my-task",
+			CreatedAt: time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC), // 7200 per-second ticks
+		}
+
+		task := catchupTask(model.MissedRunSkip)
+		task.Cron = "* * * * * *"
+		tasks := map[string]*model.Task{"my-task": task}
+
+		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(nil)
+		db.On("GetLastRunByTask", mock.Anything, "my-task").Return(lastRun, nil)
+		runner.On("RecordMissedRun", "my-task", mock.MatchedBy(func(anchor time.Time) bool {
+			return anchor.Equal(now)
+		}), mock.Anything).Return(nil)
+
+		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+
+		assert.Equal(t, 0, result.Triggered, "skip policy re-runs nothing")
+		runner.AssertNumberOfCalls(t, "RecordMissedRun", 1)
+		runner.AssertExpectations(t)
+	})
+
 	t.Run("policy=all under max_catch_up_runs backfills everything", func(t *testing.T) {
 		db := new(testutil.MockRunRepository)
 		runner := new(mockTaskRunner)

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -1091,7 +1091,12 @@ func (m *defaultTaskManager) publishServiceFatal(taskName string, instanceIndex,
 	})
 }
 
-// GetActiveRuns returns a copy of active runs for the given task.
+// GetActiveRuns returns a snapshot of active runs for the given task. Each
+// ActiveRun and its Run are copied so callers observe stable values — the live
+// *ActiveRun.Run is concurrently mutated by the execute goroutine, so handing
+// out the live pointer would race any caller reading Run's fields. The Cancel
+// and ForceKill funcs are carried over unchanged, so a caller can still signal
+// the underlying run.
 func (m *defaultTaskManager) GetActiveRuns(taskName string) []*ActiveRun {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -1101,7 +1106,13 @@ func (m *defaultTaskManager) GetActiveRuns(taskName string) []*ActiveRun {
 		return nil
 	}
 	runs := make([]*ActiveRun, len(ts.active))
-	copy(runs, ts.active)
+	for i, ar := range ts.active {
+		snapshot := *ar
+		if ar.Run != nil {
+			snapshot.Run = ar.Run.Copy()
+		}
+		runs[i] = &snapshot
+	}
 	return runs
 }
 

--- a/apps/runwisp/internal/runtime/manager_test.go
+++ b/apps/runwisp/internal/runtime/manager_test.go
@@ -219,6 +219,69 @@ func TestPolicyTerminate(t *testing.T) {
 	assert.Equal(t, 2, exec.Calls())
 }
 
+// TestEvaluateConcurrency_QueuePreservesFIFOWhenSlotFree pins the FIFO fix: in
+// the window after a slot frees but before the drain loop picks up the queue, a
+// fresh trigger must join the back of the queue rather than start ahead of runs
+// already waiting.
+func TestEvaluateConcurrency_QueuePreservesFIFOWhenSlotFree(t *testing.T) {
+	m := &defaultTaskManager{}
+	ts := &taskState{
+		task:  testTask("t", model.PolicyQueue, 2),
+		cond:  sync.NewCond(&sync.Mutex{}),
+		queue: []*model.Run{{ID: "queued-1"}}, // one run already waiting
+	}
+
+	// A slot is free (0 active < limit 2), but the queue is non-empty.
+	action, err := m.evaluateConcurrency(ts, &model.Run{ID: "new"}, 2)
+	require.NoError(t, err)
+	assert.Equal(t, actionQueued, action, "a free slot must not let a new trigger jump the queue")
+	require.Len(t, ts.queue, 2)
+	assert.Equal(t, "queued-1", ts.queue[0].ID, "the existing queued run stays at the head")
+	assert.Equal(t, "new", ts.queue[1].ID, "the new trigger goes to the back")
+}
+
+// TestEvaluateConcurrency_TerminateSkipsAlreadyCancelled pins the terminate fix:
+// re-cancelling an already-dying run let the live run set grow past the limit
+// under rapid triggers. Each new trigger must cancel a distinct not-yet-cancelled
+// victim instead.
+func TestEvaluateConcurrency_TerminateSkipsAlreadyCancelled(t *testing.T) {
+	m := &defaultTaskManager{}
+	var r1cancels, r2cancels int
+	r1 := &ActiveRun{Run: &model.Run{ID: "r1"}, Cancel: func() { r1cancels++ }, cancelled: true}
+	r2 := &ActiveRun{Run: &model.Run{ID: "r2"}, Cancel: func() { r2cancels++ }}
+	ts := &taskState{
+		task:   testTask("t", model.PolicyTerminate, 1),
+		active: []*ActiveRun{r1, r2},
+	}
+
+	action, err := m.evaluateConcurrency(ts, &model.Run{ID: "r3"}, 1)
+	require.NoError(t, err)
+	assert.Equal(t, actionStart, action)
+	assert.Equal(t, 0, r1cancels, "an already-cancelled run must not be re-cancelled")
+	assert.Equal(t, 1, r2cancels, "the live run is terminated to make room for the new one")
+	assert.True(t, r2.cancelled, "the terminated run must be latched so a later trigger skips it")
+}
+
+// TestGetActiveRunsReturnsRunSnapshot pins that GetActiveRuns hands out a copy of
+// each Run, not the live pointer the execute goroutine concurrently mutates.
+func TestGetActiveRunsReturnsRunSnapshot(t *testing.T) {
+	jm, exec, _ := newGatedManager(t)
+	jm.UpsertTask(testTask("task1", model.PolicySkip, 1))
+	_, err := jm.TriggerRun("task1", model.TriggeredByAPI)
+	require.NoError(t, err)
+	exec.WaitStarted(t)
+	t.Cleanup(jm.Shutdown)
+
+	jm.mu.RLock()
+	live := jm.tasks["task1"].active[0]
+	jm.mu.RUnlock()
+
+	snap := jm.GetActiveRuns("task1")
+	require.Len(t, snap, 1)
+	assert.NotSame(t, live.Run, snap[0].Run, "GetActiveRuns must return a Run copy, not the live pointer")
+	assert.Equal(t, live.Run.ID, snap[0].Run.ID, "the copy must carry the same data")
+}
+
 func TestTerminateRun(t *testing.T) {
 	jm, exec, eb := newGatedManager(t)
 

--- a/apps/runwisp/internal/runtime/reconcile.go
+++ b/apps/runwisp/internal/runtime/reconcile.go
@@ -200,6 +200,14 @@ func (r *Reconciler) apply(diff config.Diff, oldTasks, newTasks map[string]*mode
 	for _, name := range diff.Restamped {
 		r.applyRestamped(newTasks[name])
 	}
+
+	// Rebuild jitter plans against the new task set so added and rescheduled
+	// tasks get their start-spread without waiting for a restart. Restamps are
+	// provenance-only and never touch scheduling, so a pure-restamp reload skips
+	// the reshuffle.
+	if r.scheduler != nil && (len(diff.Added) > 0 || len(diff.Removed) > 0 || len(diff.Changed) > 0) {
+		r.scheduler.RecomputeJitter(newTasks)
+	}
 }
 
 // applyRemoved unschedules, stops, and forgets a task. Cron tasks keep their

--- a/apps/runwisp/internal/runtime/scheduler.go
+++ b/apps/runwisp/internal/runtime/scheduler.go
@@ -37,15 +37,19 @@ type Scheduler struct {
 	taskManager TaskRunner
 	tasks       map[string]*model.Task
 	entryIDs    map[string]cron.EntryID
-	// lastFired stores the wall-clock second (in the task's effective TZ) of
-	// the last firing for each task. A second firing whose tuple matches is
-	// the DST duplicate to suppress.
-	lastFired map[string]wallSecond
+	// firedTicks tracks, per task, every wall-clock second already fired within
+	// the current wall-clock hour (in the task's effective TZ). A firing whose
+	// tuple is already present is the DST fall-back duplicate to suppress. The
+	// set is scoped to one wall hour — reset the moment the hour advances — so a
+	// schedule with several ticks in the rewound hour ("0,30 1 * * *") dedups
+	// every repeat, not just one, while staying bounded to an hour of ticks.
+	firedTicks map[string]*firedHour
 	// jitterPlans holds, for each jittered task, its resolved slot offset, its
 	// window length (the gate's free-check horizon), and the parsed schedule
-	// used to clamp both to the live gap before the next tick. Computed once in
-	// Start (reload is restart-only) so a task lands at the same place every
-	// day. Tasks without a jitter window are absent and fire immediately.
+	// used to clamp both to the live gap before the next tick. Computed in Start
+	// and rebuilt by RecomputeJitter when a reload changes the task set, so a
+	// task lands at the same place every day between reloads. Tasks without a
+	// jitter window are absent and fire immediately.
 	jitterPlans map[string]jitterPlan
 	now         func() time.Time
 	mutex       sync.Mutex
@@ -87,6 +91,25 @@ func newWallSecond(t time.Time) wallSecond {
 	}
 }
 
+// wallHour is the (date, hour) prefix of a wallSecond — the scope over which
+// DST fall-back can rewind and repeat wall-clock ticks.
+type wallHour struct {
+	year  int
+	month time.Month
+	day   int
+	hour  int
+}
+
+func (w wallSecond) inHour() wallHour {
+	return wallHour{year: w.year, month: w.month, day: w.day, hour: w.hour}
+}
+
+// firedHour is the set of wall-clock seconds already fired within one wall hour.
+type firedHour struct {
+	hour  wallHour
+	ticks map[wallSecond]struct{}
+}
+
 // NewScheduler creates a scheduler. location controls how task cron expressions
 // are interpreted; nil means UTC, which is the project default. clock overrides
 // the scheduler's wall-clock reads; pass nil for time.Now — production always
@@ -105,7 +128,7 @@ func NewScheduler(taskManager TaskRunner, tasks map[string]*model.Task, location
 		taskManager: taskManager,
 		tasks:       tasks,
 		entryIDs:    make(map[string]cron.EntryID),
-		lastFired:   make(map[string]wallSecond),
+		firedTicks:  make(map[string]*firedHour),
 		jitterPlans: make(map[string]jitterPlan),
 		now:         clock,
 	}
@@ -144,11 +167,11 @@ func (scheduler *Scheduler) Start() (ScheduleResult, error) {
 
 // computeJitterPlans levels every jittered task against the others on a 24-hour
 // time-of-day dial and stores each task's resulting slot offset and window
-// length. Called once under scheduler.mutex before the cron loop starts; the
-// plans are then fixed for the daemon's lifetime (reload is restart-only).
-// Determinism holds: the dial positions come from scheduler.now() and the task
-// set, both injected, so the same TOML + clock yield the same slots — never
-// rand, never an inline wall-clock read.
+// length. Called under scheduler.mutex — from Start before the cron loop begins,
+// and from RecomputeJitter after a reload changes the task set. Determinism
+// holds: the dial positions come from scheduler.now() and the task set, both
+// injected, so the same TOML + clock yield the same slots — never rand, never an
+// inline wall-clock read.
 //
 // Every jittered task — including the one placed at offset 0 — gets a plan and
 // joins the work-conserving gate, so the earliest-slot task holds its peers
@@ -204,6 +227,22 @@ func (scheduler *Scheduler) computeJitterPlans() {
 		"tasks", len(scheduler.jitterPlans))
 }
 
+// RecomputeJitter rebuilds every jittered task's start-spread plan against the
+// given task set. The reconciler calls this after a reload changes the task set
+// so added and rescheduled tasks get their spread without a restart, rather than
+// firing at the raw tick until the daemon bounces. Because the leveling dial
+// coordinates all jittered tasks together, this re-places the whole set; offsets
+// stay within each task's window, so an unchanged task may shift within its
+// window but never onto another tick. Determinism holds: the placement is a pure
+// function of the injected clock and the task set.
+func (scheduler *Scheduler) RecomputeJitter(tasks map[string]*model.Task) {
+	scheduler.mutex.Lock()
+	defer scheduler.mutex.Unlock()
+	scheduler.tasks = tasks
+	scheduler.jitterPlans = make(map[string]jitterPlan)
+	scheduler.computeJitterPlans()
+}
+
 func (scheduler *Scheduler) Stop() {
 	scheduler.mutex.Lock()
 	if !scheduler.started {
@@ -243,7 +282,7 @@ func (scheduler *Scheduler) RemoveTask(name string) {
 		scheduler.cron.Remove(entryID)
 		delete(scheduler.entryIDs, name)
 	}
-	delete(scheduler.lastFired, name)
+	delete(scheduler.firedTicks, name)
 	delete(scheduler.jitterPlans, name)
 }
 
@@ -298,11 +337,16 @@ func (scheduler *Scheduler) fireOnce(taskName string, loc *time.Location) {
 	nowLocal := now.In(loc)
 	wm := newWallSecond(nowLocal)
 
+	hour := wm.inHour()
 	scheduler.mutex.Lock()
-	last, hadLast := scheduler.lastFired[taskName]
-	duplicate := hadLast && last == wm
+	fired, ok := scheduler.firedTicks[taskName]
+	if !ok || fired.hour != hour {
+		fired = &firedHour{hour: hour, ticks: make(map[wallSecond]struct{})}
+		scheduler.firedTicks[taskName] = fired
+	}
+	_, duplicate := fired.ticks[wm]
 	if !duplicate {
-		scheduler.lastFired[taskName] = wm
+		fired.ticks[wm] = struct{}{}
 	}
 	plan, hasJitter := scheduler.jitterPlans[taskName]
 	scheduler.mutex.Unlock()

--- a/apps/runwisp/internal/runtime/scheduler_test.go
+++ b/apps/runwisp/internal/runtime/scheduler_test.go
@@ -109,7 +109,10 @@ func TestSchedulerDSTWallClockDedup(t *testing.T) {
 	sched.fireOnce("eu-2am", loc)
 
 	wm := wallSecond{year: 2026, month: time.October, day: 25, hour: 2, minute: 0, second: 0}
-	assert.Equal(t, wm, sched.lastFired["eu-2am"], "lastFired must hold the 02:00 wall-clock instant on the fall-back day")
+	fired := sched.firedTicks["eu-2am"]
+	require.NotNil(t, fired)
+	_, ok := fired.ticks[wm]
+	assert.True(t, ok, "firedTicks must hold the 02:00 wall-clock instant on the fall-back day")
 }
 
 func TestSchedulerDSTDifferentMinuteFires(t *testing.T) {
@@ -142,7 +145,10 @@ func TestSchedulerDSTDifferentMinuteFires(t *testing.T) {
 	sched.fireOnce("eu-mins", loc)
 
 	wm := wallSecond{year: 2026, month: time.October, day: 25, hour: 2, minute: 1, second: 0}
-	assert.Equal(t, wm, sched.lastFired["eu-mins"], "lastFired must advance when wall-clock instant differs")
+	fired := sched.firedTicks["eu-mins"]
+	require.NotNil(t, fired)
+	_, ok := fired.ticks[wm]
+	assert.True(t, ok, "firedTicks must record the later wall-clock minute when it differs")
 }
 
 // TestSchedulerFireOnce_GoldenTriggerSkipSequence pins down the firing
@@ -201,6 +207,57 @@ func TestSchedulerFireOnce_GoldenTriggerSkipSequence(t *testing.T) {
 		[]recordedSkip{{taskName: "tick", reason: model.ReasonDSTSkipped}},
 		runner.skips,
 		"the second 02:00 on the fall-back day must be recorded as dst_skipped")
+}
+
+// TestSchedulerDSTFallbackMultipleTicksPerHourSuppressed proves the dedup
+// catches EVERY repeat when the rewound hour holds more than one tick. With a
+// single-slot "last firing" the interleaved duplicates (02:00, 02:30, 02:00,
+// 02:30) slipped past — each duplicate was compared only against the other
+// wall-minute — so the task ran 4× instead of 2× on the fall-back day.
+func TestSchedulerDSTFallbackMultipleTicksPerHourSuppressed(t *testing.T) {
+	runner := &fakeTaskRunner{}
+	task := &model.Task{
+		Name:     "twice-hourly",
+		Cron:     "0,30 2 * * *",
+		Timezone: "Europe/Bratislava",
+		Run:      "echo",
+	}
+
+	loc, err := time.LoadLocation("Europe/Bratislava")
+	require.NoError(t, err)
+
+	// 2026-10-25 fall-back: 03:00 CEST rewinds to 02:00 CET, so both 02:00 and
+	// 02:30 occur twice. UTC instants in chronological order:
+	//   UTC 00:00 → 02:00 CEST (trigger)
+	//   UTC 00:30 → 02:30 CEST (trigger)
+	//   UTC 01:00 → 02:00 CET  (duplicate, suppressed)
+	//   UTC 01:30 → 02:30 CET  (duplicate, suppressed)
+	stamps := []time.Time{
+		time.Date(2026, 10, 25, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 10, 25, 0, 30, 0, 0, time.UTC),
+		time.Date(2026, 10, 25, 1, 0, 0, 0, time.UTC),
+		time.Date(2026, 10, 25, 1, 30, 0, 0, time.UTC),
+	}
+	idx := 0
+	sched := NewScheduler(runner, map[string]*model.Task{"twice-hourly": task}, time.UTC, func() time.Time {
+		t := stamps[idx]
+		idx++
+		return t
+	})
+
+	for range stamps {
+		sched.fireOnce("twice-hourly", loc)
+	}
+
+	assert.Equal(t, []string{"twice-hourly", "twice-hourly"}, runner.triggers,
+		"each distinct wall-minute must trigger exactly once — not once per repeat")
+	assert.Equal(t,
+		[]recordedSkip{
+			{taskName: "twice-hourly", reason: model.ReasonDSTSkipped},
+			{taskName: "twice-hourly", reason: model.ReasonDSTSkipped},
+		},
+		runner.skips,
+		"both rewound ticks (02:00 and 02:30) must be recorded as dst_skipped")
 }
 
 // TestSchedulerSubMinuteFiresNotSuppressed guards that minute-granular dedup
@@ -320,6 +377,36 @@ func TestSchedulerWiresDSTGapRecovery(t *testing.T) {
 	assert.True(t, want.Equal(next),
 		"scheduler's schedule must fire the gap tick at the 03:00 gap end, not drop it: want %s, got %s",
 		want, next.In(loc))
+}
+
+// TestSchedulerRecomputeJitterOnReload proves a reload gives a jittered task
+// its start-spread without a restart: a task added or rescheduled after Start
+// used to fire at the raw tick because only Start built jitter plans.
+func TestSchedulerRecomputeJitterOnReload(t *testing.T) {
+	runner := &fakeTaskRunner{}
+	now := time.Date(2024, 6, 10, 1, 0, 0, 0, time.UTC)
+
+	// Start with a single non-jittered task, so no plan exists yet.
+	plain := &model.Task{Name: "plain", Cron: "0 2 * * *", Run: "echo"}
+	sched := NewScheduler(runner, map[string]*model.Task{"plain": plain}, time.UTC, func() time.Time { return now })
+	_, err := sched.Start()
+	require.NoError(t, err)
+	defer sched.Stop()
+	require.Empty(t, sched.jitterPlans, "no jittered task yet")
+
+	// Reload adds a jittered task.
+	jittered := &model.Task{Name: "nightly", Cron: "0 2 * * *", Jitter: 10 * time.Minute, Run: "echo"}
+	require.NoError(t, sched.AddTask(jittered))
+	sched.RecomputeJitter(map[string]*model.Task{"plain": plain, "nightly": jittered})
+
+	_, ok := sched.jitterPlans["nightly"]
+	assert.True(t, ok, "reload must build the added jittered task's plan without a restart")
+
+	// Reload removes it again: the plan must go with it.
+	sched.RemoveTask("nightly")
+	sched.RecomputeJitter(map[string]*model.Task{"plain": plain})
+	_, ok = sched.jitterPlans["nightly"]
+	assert.False(t, ok, "removing the task must drop its jitter plan")
 }
 
 // jitterTasks returns two identical cron tasks sharing a jitter window. The
@@ -502,18 +589,18 @@ func TestSchedulerRemoveTaskClearsState(t *testing.T) {
 	require.NoError(t, err)
 	defer sched.Stop()
 
-	// Fire once so lastFired is populated, then remove.
+	// Fire once so the DST dedup state is populated, then remove.
 	sched.fireOnce("tick", time.UTC)
 	_, hadEntry := sched.entryIDs["tick"]
 	require.True(t, hadEntry)
-	_, hadFired := sched.lastFired["tick"]
+	_, hadFired := sched.firedTicks["tick"]
 	require.True(t, hadFired)
 
 	sched.RemoveTask("tick")
 
 	_, hasEntry := sched.entryIDs["tick"]
 	assert.False(t, hasEntry, "RemoveTask must drop the cron entry")
-	_, hasFired := sched.lastFired["tick"]
+	_, hasFired := sched.firedTicks["tick"]
 	assert.False(t, hasFired, "RemoveTask must drop the DST dedup state")
 
 	// Removing again, or a never-scheduled name, is a no-op.

--- a/apps/runwisp/internal/runtime/taskstate.go
+++ b/apps/runwisp/internal/runtime/taskstate.go
@@ -32,6 +32,11 @@ type ActiveRun struct {
 	// original, cron, API, retry, and queued runs. Read only under the manager
 	// lock; not persisted.
 	RestartAttempt int
+	// cancelled latches once this run has been asked to stop (currently only the
+	// terminate overlap policy). It stops a later trigger from re-cancelling an
+	// already-dying run — which would leave the live run count growing past
+	// max_concurrent while the same victim drains. Guarded by m.mu.
+	cancelled bool
 }
 
 // taskState holds all per-task runtime state under the manager mutex.
@@ -77,7 +82,13 @@ const (
 // evaluateConcurrency decides whether a run can start and mutates queue state
 // accordingly. Must be called with m.mu held.
 func (m *defaultTaskManager) evaluateConcurrency(ts *taskState, run *model.Run, concurrencyLimit int) (concurrencyAction, error) {
-	if len(ts.active) < concurrencyLimit {
+	// A free slot starts immediately — except under queue policy with runs
+	// already waiting: a fresh trigger must join the back of the queue rather
+	// than race ahead of runs the drain loop hasn't picked up yet. Without this,
+	// in the window after a slot frees but before queueProcessLoop re-acquires
+	// the lock, a new trigger would start out of FIFO order.
+	queuePending := ts.task.OnOverlap == model.PolicyQueue && len(ts.queue) > 0
+	if len(ts.active) < concurrencyLimit && !queuePending {
 		return actionStart, nil
 	}
 
@@ -94,10 +105,22 @@ func (m *defaultTaskManager) evaluateConcurrency(ts *taskState, run *model.Run, 
 		slog.Debug("Task queued", "name", ts.task.Name, "active", len(ts.active), "limit", concurrencyLimit, "queue", len(ts.queue))
 		return actionQueued, nil
 	case model.PolicyTerminate:
-		if len(ts.active) > 0 {
-			oldest := ts.active[0]
-			slog.Info("Terminating oldest run", "run", oldest.Run.ID, "task", ts.task.Name)
-			oldest.Cancel()
+		// Cancel the oldest not-yet-cancelled runs until enough are draining that
+		// active returns to the limit once they exit. Skipping already-cancelled
+		// runs is what bounds the live set: re-cancelling the same dying run while
+		// spamming triggers used to let active grow without limit.
+		needed := len(ts.active) - concurrencyLimit + 1
+		for _, ar := range ts.active {
+			if needed <= 0 {
+				break
+			}
+			if ar.cancelled {
+				continue
+			}
+			ar.cancelled = true
+			slog.Info("Terminating run to make room", "run", ar.Run.ID, "task", ts.task.Name)
+			ar.Cancel()
+			needed--
 		}
 		return actionStart, nil
 	default:

--- a/apps/runwisp/internal/server/auth/auth.go
+++ b/apps/runwisp/internal/server/auth/auth.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"log/slog"
@@ -244,6 +245,11 @@ func TokenFromCookie(r *http.Request) string {
 // redeem it once before it expires" — they differ only in size, TTL, and how
 // the token is generated.
 type ttlStore struct {
+	// mu makes consume's get-then-remove atomic: the LRU locks each call
+	// individually, so without this two requests presenting the same token could
+	// both observe it before either removed it, redeeming a single-use token
+	// twice. This is the login boundary, so single-use must actually be single.
+	mu      sync.Mutex
 	entries *expirable.LRU[string, time.Time]
 	ttl     time.Duration
 	gen     func() (string, error)
@@ -262,11 +268,15 @@ func (s *ttlStore) create() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	s.mu.Lock()
 	s.entries.Add(token, time.Now().Add(s.ttl))
+	s.mu.Unlock()
 	return token, nil
 }
 
 func (s *ttlStore) consume(token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	exp, ok := s.entries.Get(token)
 	if !ok || time.Now().After(exp) {
 		return false

--- a/apps/runwisp/internal/storage/notification.go
+++ b/apps/runwisp/internal/storage/notification.go
@@ -156,6 +156,11 @@ func (db *SQLiteDatabase) UpsertByFingerprint(ctx context.Context, n *Notificati
 	n.ID = existing.ID
 	n.Count = newCount
 	n.Occurrences = merged
+	// Carry the persisted first-seen metadata so callers (e.g. the in-app
+	// coalescer's SSE payload) match what a later read of the row returns,
+	// rather than the current event's timestamp/run.
+	n.CreatedAt = existing.CreatedAt
+	n.RunID = existing.RunID
 	n.ReadAt = nil
 	return false, nil
 }

--- a/apps/runwisp/internal/storage/notification_test.go
+++ b/apps/runwisp/internal/storage/notification_test.go
@@ -81,6 +81,30 @@ func TestUpsertByFingerprint_CoalescesWithinWindow(t *testing.T) {
 	assert.Equal(t, second.LastOccurredAt.Unix(), got.Occurrences[0].Unix())
 }
 
+// On a coalesced update the passed-in notification pointer must be rewritten to
+// carry the FIRST occurrence's created_at and run_id — not the current event's —
+// so callers (e.g. the in-app coalescer's SSE payload) match what a later read
+// of the persisted row returns.
+func TestUpsertByFingerprint_CoalesceKeepsFirstSeenMetadata(t *testing.T) {
+	ctx := t.Context()
+	db := setupNotificationDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	first := newNotification(now, "fp-meta")
+	first.RunID = "run-first"
+	_, err := db.UpsertByFingerprint(ctx, first, time.Hour, 10)
+	require.NoError(t, err)
+
+	second := newNotification(now.Add(30*time.Minute), "fp-meta")
+	second.RunID = "run-second"
+	created, err := db.UpsertByFingerprint(ctx, second, time.Hour, 10)
+	require.NoError(t, err)
+	require.False(t, created)
+
+	assert.Equal(t, first.CreatedAt.Unix(), second.CreatedAt.Unix(), "created_at must stay first-seen")
+	assert.Equal(t, "run-first", second.RunID, "run_id must stay first-seen")
+}
+
 func TestUpsertByFingerprint_InsertsAfterWindowExpires(t *testing.T) {
 	ctx := t.Context()
 	db := setupNotificationDB(t)

--- a/apps/runwisp/internal/storage/query/notifications.sql
+++ b/apps/runwisp/internal/storage/query/notifications.sql
@@ -31,7 +31,7 @@ UPDATE notifications SET read_at = NULL WHERE id = ?;
 UPDATE notifications SET read_at = ? WHERE read_at IS NULL;
 
 -- name: SelectExistingForFingerprint :one
-SELECT id, count, occurrences_json FROM notifications
+SELECT id, count, occurrences_json, created_at, run_id FROM notifications
 WHERE fingerprint = ? AND last_occurred_at >= ?
 ORDER BY last_occurred_at DESC LIMIT 1;
 

--- a/apps/runwisp/internal/storage/sqlcdb/notifications.sql.go
+++ b/apps/runwisp/internal/storage/sqlcdb/notifications.sql.go
@@ -240,7 +240,7 @@ func (q *Queries) PruneNotificationsByCount(ctx context.Context, offset int64) (
 }
 
 const selectExistingForFingerprint = `-- name: SelectExistingForFingerprint :one
-SELECT id, count, occurrences_json FROM notifications
+SELECT id, count, occurrences_json, created_at, run_id FROM notifications
 WHERE fingerprint = ? AND last_occurred_at >= ?
 ORDER BY last_occurred_at DESC LIMIT 1
 `
@@ -251,15 +251,23 @@ type SelectExistingForFingerprintParams struct {
 }
 
 type SelectExistingForFingerprintRow struct {
-	ID              string `json:"id"`
-	Count           int    `json:"count"`
-	OccurrencesJson string `json:"occurrences_json"`
+	ID              string    `json:"id"`
+	Count           int       `json:"count"`
+	OccurrencesJson string    `json:"occurrences_json"`
+	CreatedAt       time.Time `json:"created_at"`
+	RunID           string    `json:"run_id"`
 }
 
 func (q *Queries) SelectExistingForFingerprint(ctx context.Context, arg SelectExistingForFingerprintParams) (SelectExistingForFingerprintRow, error) {
 	row := q.db.QueryRowContext(ctx, selectExistingForFingerprint, arg.Fingerprint, arg.LastOccurredAt)
 	var i SelectExistingForFingerprintRow
-	err := row.Scan(&i.ID, &i.Count, &i.OccurrencesJson)
+	err := row.Scan(
+		&i.ID,
+		&i.Count,
+		&i.OccurrencesJson,
+		&i.CreatedAt,
+		&i.RunID,
+	)
 	return i, err
 }
 

--- a/apps/runwisp/internal/tui/stream_manager_test.go
+++ b/apps/runwisp/internal/tui/stream_manager_test.go
@@ -579,7 +579,7 @@ func newBulkServer(t *testing.T) *httptest.Server {
 	}
 	mux.HandleFunc("/api/runs/bulk/delete", bulkAffected)
 	mux.HandleFunc("/api/runs/bulk/restore", bulkAffected)
-	mux.HandleFunc("/api/runs/bulk/cancel", bulkAffected)
+	mux.HandleFunc("/api/runs/bulk/stop", bulkAffected)
 	mux.HandleFunc("/api/runs/bulk/rerun", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"triggered":[{"task_name":"t","run_id":"r"}]}`))


### PR DESCRIPTION
## Summary

A batch of bug fixes found during a targeted bug-hunt pass:

- **Scheduler**: DST fall-back dedup now tracks every fired tick within the wall hour instead of only the last one, so a schedule with more than one tick per hour (e.g. `0,30 2 * * *`) no longer double-fires on the fall-back day.
- **Catch-up**: a truncated missed-run backlog now anchors at "now" instead of the capped tick, so a restart shortly after a large gap no longer re-counts and re-alerts on the same gap.
- **Concurrency policies**: `overlap = "queue"` no longer lets a fresh trigger start ahead of runs already waiting when a slot happens to free up first; `overlap = "terminate"` no longer lets the active set exceed `max_concurrent` under rapid triggers by re-cancelling an already-dying run instead of picking a fresh victim.
- **Reload**: `runwisp reload` (and `SIGHUP`) now rebuilds jitter plans, so a newly added or rescheduled jittered task gets its start-spread immediately instead of firing at the raw tick until the next restart.
- **Race fixes**: `GetActiveRuns` now hands out a copy of each `Run` instead of the live pointer the execute goroutine concurrently mutates; single-use login tokens and launch tickets can no longer be redeemed twice by two requests arriving at the same instant.
- **Notifications**: coalescing a repeated event now keeps the *first* occurrence's timestamp and run ID instead of overwriting them with the latest occurrence's.
- **Cloud (optional control-plane)**: a single dropped heartbeat no longer tears down an otherwise healthy session; a 401/403 from the sync HTTP call is no longer treated as a hard auth failure, since the WebSocket handshake is the actual auth boundary.
- Fixed the Go API client, a TUI test, and the agent docs reference to use the already-renamed `/api/runs/bulk/stop` endpoint and `replayLimit` query param (they were still pointing at the pre-rename names).

## Test plan

- [x] `bun run ci` passes (generate → format → check → test → test-e2e)
- [x] New unit tests pin each fix (DST multi-tick dedup, truncated catch-up anchor, queue FIFO, terminate victim selection, `GetActiveRuns` copy semantics, reload jitter recompute, notification first-seen metadata, sync error classification)