### PR TITLE
fix(cloud): resolve the execution type for run-defined services

### DIFF
--- a/apps/runwisp/internal/cloud/client_test.go
+++ b/apps/runwisp/internal/cloud/client_test.go
@@ -998,6 +998,29 @@ func TestHandleInboundPayloadDispatchMissingExecution(t *testing.T) {
 	}
 }
 
+// The nil guards above cover the frame shapes we know about. This covers the
+// next one: whatever panics below the dispatch funnel must come back as an
+// error, because handleInboundPayload runs on the read-loop goroutine and an
+// unrecovered panic there takes down the daemon — every supervised service with
+// it — over one frame from an optional integration. A nil handler stands in for
+// an arbitrary panicking handler.
+func TestHandleInboundPayloadRecoversFromPanic(t *testing.T) {
+	sr := &sessionRunner{}
+	session := &wsSession{outbound: make(chan []byte, 16)}
+	payload := []byte(`{"type":"service:apply","service":{"taskId":"web","taskName":"web"}}`)
+
+	err := sr.handleInboundPayload(context.Background(), session, payload)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "panic handling inbound message")
+
+	select {
+	case out := <-session.outbound:
+		assert.Contains(t, string(out), "message could not be processed")
+	default:
+		t.Fatal("expected a validation error frame after the recovered panic")
+	}
+}
+
 func TestHandleInboundPayloadAuthResultSuccess(t *testing.T) {
 	env := newTestEnv(t, func(conn *websocket.Conn) {
 		conn.Close(websocket.StatusNormalClosure, "")

--- a/apps/runwisp/internal/cloud/service_handler.go
+++ b/apps/runwisp/internal/cloud/service_handler.go
@@ -296,11 +296,26 @@ func (h *InboundHandler) mergeServiceApply(task *model.Task, svc *protocol.Servi
 // Only env is gated. The instances/restart/log knobs are what the cloud
 // legitimately re-asserts on every reconnect, so gating those would break sync
 // on a dispatch-off daemon.
+//
+// The type comes from ResolvedExecutionDef, not the ExecutionDef field: the
+// config loader only populates that field for compose-backed units, so an
+// ordinary `[services.web] run = "..."` carries its command in Run with a nil
+// ExecutionDef. Reading the field directly meant the one shape this gate exists
+// to protect was also the one shape that dereferenced nil — a peer-triggerable
+// crash instead of a verdict. A service with no resolvable definition at all
+// can't be checked, so it is refused rather than waved through.
 func (h *InboundHandler) checkEnvOverrideAllowed(task *model.Task, cfg *protocol.ServiceTaskConfig) error {
 	if cfg == nil || len(cfg.Env) == 0 {
 		return nil
 	}
-	if status := h.availability.ForType(task.ExecutionDef.ExecType()); !status.Available {
+	execDef := task.ResolvedExecutionDef()
+	if execDef == nil {
+		return &CloudError{
+			Kind:    CloudErrorKindConflict,
+			Message: fmt.Sprintf("env override for service %q not available: it has no resolvable execution definition", task.Name),
+		}
+	}
+	if status := h.availability.ForType(execDef.ExecType()); !status.Available {
 		return &CloudError{
 			Kind:    CloudErrorKindConflict,
 			Message: fmt.Sprintf("env override for service %q not available: %s", task.Name, status.Reason),

--- a/apps/runwisp/internal/cloud/service_handler_test.go
+++ b/apps/runwisp/internal/cloud/service_handler_test.go
@@ -409,6 +409,12 @@ func TestHandleServiceApply_MergeUnavailableBackendRejected(t *testing.T) {
 // gate as a script override. Before the fix the gate was only consulted when the
 // payload carried a script — and the cloud sends script: null for synced TOML
 // services — so taskConfig.env sailed straight through.
+//
+// The fixture carries Run, not ExecutionDef, because that is what config.Load
+// produces for a plain `[services.web] run = "..."` — the loader only fills
+// ExecutionDef for compose-backed units. An ExecutionDef fixture hid a nil
+// dereference in the gate: the one shape it exists to protect was the one shape
+// that crashed the daemon instead of returning a verdict.
 func TestHandleServiceApply_MergeEnvGatedOnAvailability(t *testing.T) {
 	existing := &model.Task{
 		Name:          "web",
@@ -417,7 +423,7 @@ func TestHandleServiceApply_MergeEnvGatedOnAvailability(t *testing.T) {
 		Instances:     1,
 		MaxConcurrent: 1,
 		Env:           map[string]string{"NODE_ENV": "production"},
-		ExecutionDef:  &model.ShellExecution{Script: "node server.js"},
+		Run:           "node server.js",
 	}
 	h := newDispatchHandler(executor.Availability{}, map[string]*model.Task{"web": existing})
 	runner := h.taskManager.(*fakeTaskRunner)
@@ -450,7 +456,7 @@ func TestHandleServiceApply_MergeEnvAppliedWhenAvailable(t *testing.T) {
 		Restart:       model.RestartAlways,
 		Instances:     1,
 		MaxConcurrent: 1,
-		ExecutionDef:  &model.ShellExecution{Script: "node server.js"},
+		Run:           "node server.js",
 	}
 	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"web": existing})
 	runner := h.taskManager.(*fakeTaskRunner)
@@ -494,6 +500,35 @@ func TestHandleServiceApply_MergeWithoutEnvNotGated(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, runner.upserted, 1)
 	assert.Equal(t, 2, runner.upserted[0].Instances)
+}
+
+// A service with neither Run nor ExecutionDef has nothing to check the env
+// override against, so the gate refuses it rather than waving it through on the
+// absence of a type to gate.
+func TestHandleServiceApply_MergeEnvRefusedWithoutExecutionDefinition(t *testing.T) {
+	existing := &model.Task{
+		Name:          "web",
+		Kind:          model.KindService,
+		Restart:       model.RestartAlways,
+		Instances:     1,
+		MaxConcurrent: 1,
+	}
+	h := newDispatchHandler(shellAvailable(), map[string]*model.Task{"web": existing})
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{
+			TaskID:     "web",
+			TaskName:   "web",
+			Script:     json.RawMessage("null"),
+			TaskConfig: &protocol.ServiceTaskConfig{Env: map[string]string{"NODE_OPTIONS": "--inspect"}},
+		},
+	})
+	require.Error(t, err)
+	var ce *CloudError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, CloudErrorKindConflict, ce.Kind)
+	assert.Empty(t, runner.upserted)
 }
 
 // Regression (Bug 1): a service:apply addressed by the bare name of a

--- a/apps/runwisp/internal/cloud/session_dispatch.go
+++ b/apps/runwisp/internal/cloud/session_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -160,7 +161,24 @@ func (sr *sessionRunner) watchdogLoop(ctx context.Context, session *wsSession) e
 	}
 }
 
-func (sr *sessionRunner) handleInboundPayload(ctx context.Context, session *wsSession, payload []byte) error {
+// handleInboundPayload decodes one inbound frame and dispatches it. It is the
+// single funnel every peer-supplied message passes through, which is why the
+// panic guard lives here rather than at each handler: the read loop runs on its
+// own goroutine, so an unrecovered panic anywhere below takes down the entire
+// daemon — every supervised service with it — over one malformed frame from an
+// optional integration. The nil guards on the required pointer fields
+// (Execution, Service, Action) are still the real fix for the shapes we know
+// about; this makes the next one a logged error instead of an outage.
+func (sr *sessionRunner) handleInboundPayload(ctx context.Context, session *wsSession, payload []byte) (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Error("recovered from panic handling inbound cloud message",
+				"err", rec, "stack", string(debug.Stack()))
+			sr.sendProtocolError(session, CloudErrorKindValidation, "message could not be processed", "", "")
+			err = fmt.Errorf("panic handling inbound message: %v", rec)
+		}
+	}()
+
 	decoded, err := DecodeInboundMessage(payload)
 	if err != nil {
 		if errors.Is(err, ErrUnsupportedMessageType) {

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -862,18 +862,19 @@ func (m *defaultTaskManager) startRun(task *model.Task, run *model.Run, restartA
 // three phases are split out so each reads as one concern and can be tested
 // without driving a full run.
 func (m *defaultTaskManager) execute(ctx context.Context, task *model.Task, run *model.Run, active *ActiveRun) {
+	// Under the manager lock: GetActiveRuns takes an RLock and copies these same
+	// run fields, so writing them unlocked races with a concurrent snapshot.
+	m.mu.Lock()
 	run.Status = model.PhaseRunning
 	run.StartAt = &active.StartedAt
 	if task.Kind.IsService() {
 		// Stamp the live-readiness clock the moment the instance is running so
-		// dependents gating on this service measure uptime from here. Under the
-		// manager lock since the supervisor is not internally synchronised.
-		m.mu.Lock()
+		// dependents gating on this service measure uptime from here.
 		if ts := m.tasks[task.Name]; ts != nil && ts.supervisor != nil {
 			ts.supervisor.MarkLive(run.InstanceIndex)
 		}
-		m.mu.Unlock()
 	}
+	m.mu.Unlock()
 	m.persistence.PersistExisting(run)
 	m.publishRun(events.EventRunStarted, run)
 


### PR DESCRIPTION
The optional control-plane integration can push an `env` override for a service it syncs. That override is checked against the daemon's execution backend, but the check only recognised compose-backed services — a service defined with a plain `run = "..."` had no type to match, so the request couldn't reach a verdict. It's now resolved the same way the run manager resolves it, and applies with `allow_cloud_dispatch = true` or is refused with it off (the default). Compose-defined services were unaffected.

Inbound control-plane frames that the handlers don't expect are now logged and reported back to the peer as a protocol error, leaving the session and the daemon running.

No config or TOML changes, and no behaviour change when the integration is disabled.
