### PR TITLE
fix(npm): make global install and npx resolve the runwisp command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`npm install -g runwisp`, `bun add -g runwisp`, and `npx runwisp` now install and run the `runwisp` command.** The npm package now ships a small launcher that execs the bundled platform binary directly (no resident wrapper process), so every documented install path works — not just `bunx`.
 - **Release tarballs now package `runwisp` as an executable (mode 0755).**
 - **CPU and memory stats now report real host values on macOS.** The system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system` and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%. macOS now reads host RAM and load average directly (via `sysctl` and a mach VM-statistics call), matching the Linux figures.
 - **The TUI's shutdown command now targets the daemon it's connected to via `--socket`, and surfaces an error if the shutdown fails.**

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -10,9 +10,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "bin": {
-    "runwisp": "runwisp"
-  },
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -10,9 +10,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "bin": {
-    "runwisp": "runwisp"
-  },
   "os": [
     "darwin"
   ],

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -10,9 +10,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "bin": {
-    "runwisp": "runwisp"
-  },
   "os": [
     "linux"
   ],

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -10,9 +10,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "bin": {
-    "runwisp": "runwisp"
-  },
   "os": [
     "linux"
   ],

--- a/npm/runwisp/bin/runwisp
+++ b/npm/runwisp/bin/runwisp
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Locate the platform-specific binary that ships as an optional dependency
+# (@runwisp/<os>-<arch>) and exec into it. `exec` replaces this shell with the
+# Go binary, so there is no wrapper process or extra memory left behind — and
+# signals reach the daemon directly. No postinstall step is involved, which
+# also keeps it working under package managers that block lifecycle scripts.
+
+# Resolve this script's real path, following symlinks (npm/bun link the global
+# `runwisp` command to here). Portable: no `readlink -f`, which BSD/macOS lacks.
+target=$0
+while [ -L "$target" ]; do
+  link=$(readlink "$target")
+  case $link in
+    /*) target=$link ;;
+    *) target=$(dirname "$target")/$link ;;
+  esac
+done
+dir=$(CDPATH= cd -- "$(dirname -- "$target")" && pwd)
+
+os=$(uname -s)
+arch=$(uname -m)
+case $os in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+esac
+case $arch in
+  x86_64 | amd64) arch=x64 ;;
+  arm64 | aarch64) arch=arm64 ;;
+esac
+pkg="@runwisp/$os-$arch"
+
+# Covers both install layouts: npm nests deps under the package, bun hoists them
+# alongside it.
+for bin in "$dir/../node_modules/$pkg/runwisp" "$dir/../../$pkg/runwisp"; do
+  if [ -x "$bin" ]; then
+    exec "$bin" "$@"
+  fi
+done
+
+echo "runwisp: no binary found for $os-$arch." >&2
+echo "The optional dependency $pkg was not installed — is this platform supported?" >&2
+exit 1

--- a/npm/runwisp/package.json
+++ b/npm/runwisp/package.json
@@ -21,6 +21,9 @@
     "task-runner",
     "supervisord"
   ],
+  "bin": {
+    "runwisp": "bin/runwisp"
+  },
   "optionalDependencies": {
     "@runwisp/linux-x64": "0.0.0",
     "@runwisp/linux-arm64": "0.0.0",


### PR DESCRIPTION
## What

Fixes installing RunWisp from npm. Previously only `bunx runwisp` worked — `bun add -g runwisp`, `npm install -g runwisp`, and `npx runwisp` all installed the package but exposed no `runwisp` command.

The universal `runwisp` package now ships a small launcher that execs the bundled platform binary directly. It uses `exec`, so no wrapper process stays resident and signals pass straight through to the daemon — no per-invocation Node.js overhead. The redundant `bin` entry on the per-platform packages (which collided with the launcher and broke `npx`) is removed.

All four documented install paths now work:

```
bunx runwisp
npx runwisp
bun add -g runwisp
npm install -g runwisp
```

Verified against the real published binary on a fresh Linux VM (both npm-nested and bun-hoisted layouts).