### PR TITLE
fix: bug-hunt pass across runtime, executor, logutil, datadir, notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`npm install -g runwisp`, `bun add -g runwisp`, and `npx runwisp` now install and run the `runwisp` command.** The npm package now ships a small launcher that execs the bundled platform binary directly (no resident wrapper process), so every documented install path works — not just `bunx`.
+- **A task removed by `runwisp reload` now finalizes any run still waiting in its queue**, recording it with a terminal status so the run history and API never show it as perpetually pending.
+- **`min_free_space` keeps enforcing free-disk headroom across log rotations**, so the safeguard stays active for the full duration of a long-running task whose output rotates. See [`min_free_space`](https://docs.runwisp.com/configuration/storage/#what-min_free_space-actually-does).
+- **Log line numbers stay continuous after a run's output rotates more than once**, keeping log-search results and paging anchors pointing at the right lines.
+- **The data directory is always created with `0700` permissions**, including when it already exists (for example a pre-created Docker volume), so its contents stay private to the daemon's user.
+- **Notification log excerpts are always valid UTF-8** — trimming a captured-output tail to fit a message no longer cuts through a multi-byte character.
 - **Release tarballs now package `runwisp` as an executable (mode 0755).**
 - **CPU and memory stats now report real host values on macOS.** The system-resource collector only understood Linux `/proc`, so on macOS the dashboard, TUI, `/api/system` and `/metrics` showed the daemon's own Go heap as "total memory" with CPU stuck at 0%. macOS now reads host RAM and load average directly (via `sysctl` and a mach VM-statistics call), matching the Linux figures.
 - **The TUI's shutdown command now targets the daemon it's connected to via `--socket`, and surfaces an error if the shutdown fails.**

--- a/apps/runwisp/internal/datadir/datadir.go
+++ b/apps/runwisp/internal/datadir/datadir.go
@@ -20,7 +20,14 @@ import (
 // EnsureDir creates dir (and parents) with mode 0700 so that secrets stored
 // inside are not exposed to other local users via directory traversal.
 func EnsureDir(dir string) error {
-	return os.MkdirAll(dir, 0700)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	// MkdirAll leaves a pre-existing directory's mode untouched, so a data dir
+	// created out-of-band (e.g. a Docker bind-mount at 0755) would silently keep
+	// looser perms and expose the SQLite DB and other non-secret-file artifacts.
+	// Enforce 0700 unconditionally to hold the guarantee this function promises.
+	return os.Chmod(dir, 0700)
 }
 
 // WriteSecretFile writes data to path with mode 0600, refusing to follow

--- a/apps/runwisp/internal/datadir/datadir_test.go
+++ b/apps/runwisp/internal/datadir/datadir_test.go
@@ -11,6 +11,27 @@ import (
 	"testing"
 )
 
+// TestEnsureDir_TightensPreExistingPerms guards the regression where EnsureDir
+// relied solely on os.MkdirAll, which never chmods an already-existing directory
+// — so a data dir created out-of-band at 0755 (e.g. a Docker bind-mount) kept
+// looser perms and exposed the SQLite DB to other local users.
+func TestEnsureDir_TightensPreExistingPerms(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "data")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0700 {
+		t.Fatalf("expected 0700 on pre-existing dir, got %o", perm)
+	}
+}
+
 func TestGeneratePassword_Base62Alphabet(t *testing.T) {
 	const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 

--- a/apps/runwisp/internal/executor/log_writer.go
+++ b/apps/runwisp/internal/executor/log_writer.go
@@ -58,6 +58,7 @@ type LogWriter struct {
 	diskCheckInterval int64  // bytes between probes; defaults to defaultDiskCheckInterval
 	diskPressureHit   bool   // set once after the first threshold crossing
 	onDiskPressure    func(free, min int64, killedTask bool)
+	freeDisk          func(dir string) int64 // injected for tests; defaults to freeDiskSpace
 
 	// State
 	currentOffset  int64
@@ -70,6 +71,10 @@ type LogWriter struct {
 	// Rotation bookkeeping: cumulative counts from rotated-away files
 	rotatedLines int64
 	rotatedBytes int64
+	// prevSegmentStart is the global line number the segment currently sitting in
+	// the .prev slot started at (rotatedLines just before the most recent
+	// rotation). Persisted so readers number .prev correctly after 2+ rotations.
+	prevSegmentStart int64
 
 	now func() time.Time // injected wall-clock; never call time.Now() inline
 }
@@ -125,6 +130,7 @@ func NewLogWriter(opts LogWriterOpts) (*LogWriter, error) {
 		logDir:            opts.LogDir,
 		onDiskPressure:    opts.OnDiskPressure,
 		diskCheckInterval: defaultDiskCheckInterval,
+		freeDisk:          freeDiskSpace,
 		now:               now,
 	}, nil
 }
@@ -226,7 +232,7 @@ func (w *LogWriter) checkDiskPressure() bool {
 		return false
 	}
 	w.lastDiskCheck = w.currentOffset
-	free := freeDiskSpace(w.logDir)
+	free := w.freeDisk(w.logDir)
 	if free < 0 || free >= w.minFreeDisk {
 		return false
 	}
@@ -359,6 +365,9 @@ func (w *LogWriter) writeSystemLine(msg string) {
 // the segment-scoped line index; the new segment re-records its index lazily if
 // and when it crosses the threshold. Caller must hold mu.
 func (w *LogWriter) rotateTail() error {
+	// The segment about to move into .prev started at the current cumulative
+	// count; capture it before folding this segment's lines into the total.
+	w.prevSegmentStart = w.rotatedLines
 	w.rotatedLines += w.lineCount
 	w.rotatedBytes += w.currentOffset
 
@@ -392,6 +401,10 @@ func (w *LogWriter) rotateTail() error {
 	w.file = f
 	w.currentOffset = 0
 	w.lineCount = 0
+	// currentOffset just reset to 0; lastDiskCheck tracks it, so reset too or the
+	// (currentOffset - lastDiskCheck) throttle stays negative forever and disk-
+	// pressure checks never fire again for the rest of the run.
+	w.lastDiskCheck = 0
 	w.truncated = true
 
 	// Rewrite the container: keep frame history, reset the index, persist the
@@ -436,6 +449,7 @@ func (w *LogWriter) rewriteContainerForRotation() error {
 	w.metaFile.Write(logutil.MetaRecord(logutil.LogMeta{
 		RotatedLines: w.rotatedLines,
 		RotatedBytes: w.rotatedBytes,
+		PrevStart:    w.prevSegmentStart,
 	}))
 	return nil
 }

--- a/apps/runwisp/internal/executor/log_writer_test.go
+++ b/apps/runwisp/internal/executor/log_writer_test.go
@@ -171,6 +171,47 @@ func TestLogWriter_DiskPressure_KillTask_CancelsContext(t *testing.T) {
 	assert.True(t, w.truncated)
 }
 
+// TestLogWriter_DiskPressure_SurvivesRotation guards the regression where the
+// disk-pressure throttle (currentOffset - lastDiskCheck) went permanently
+// negative after the first drop_old rotation reset currentOffset without
+// resetting lastDiskCheck — silently disabling disk-full protection for the
+// rest of the run. Disk space is reported plentiful until the first rotation,
+// then critically low; the writer must still detect the low reading afterwards.
+func TestLogWriter_DiskPressure_SurvivesRotation(t *testing.T) {
+	dir := t.TempDir()
+	opts := newTestOpts(dir)
+	opts.LogDir = dir
+	opts.MaxSize = 1000
+	opts.Overflow = "drop_old"
+	opts.MinFreeDisk = 1000
+	hits := 0
+	opts.OnDiskPressure = func(free, min int64, killedTask bool) { hits++ }
+
+	w, err := NewLogWriter(opts)
+	require.NoError(t, err)
+	// A coarse interval (relative to maxSize) is what exposes the bug: the last
+	// pre-rotation probe leaves lastDiskCheck near maxSize, so after rotation
+	// resets currentOffset the throttle stays un-crossed for the whole next
+	// segment unless lastDiskCheck is also reset.
+	w.diskCheckInterval = 250
+	w.freeDisk = func(string) int64 {
+		if w.rotatedLines > 0 {
+			return 1 // critically low once we've rotated at least once
+		}
+		return math.MaxInt64 // plenty of room before the first rotation
+	}
+
+	line := strings.Repeat("x", 100) + "\n" // 101 bytes
+	for i := 0; i < 20; i++ {
+		_, err := w.Write([]byte(line))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+
+	assert.Equal(t, 1, hits,
+		"disk pressure must still be detected after a rotation reset currentOffset")
+}
+
 func TestLogWriter_DropOldRotation(t *testing.T) {
 	opts := newTestOpts(t.TempDir())
 	opts.MaxSize = 200

--- a/apps/runwisp/internal/logutil/log_index.go
+++ b/apps/runwisp/internal/logutil/log_index.go
@@ -176,7 +176,7 @@ func ReadLineRange(logPath string, from, limit int64) (lines []LogLineRecord, fi
 func ScanLines(ctx context.Context, logPath string, visit func(LogLineRecord) bool) error {
 	meta := ReadLogMeta(logPath)
 
-	done, err := scanSegment(ctx, PrevPath(logPath), 0, visit)
+	done, err := scanSegment(ctx, PrevPath(logPath), meta.PrevStart, visit)
 	if err != nil || done {
 		return err
 	}

--- a/apps/runwisp/internal/logutil/log_index_test.go
+++ b/apps/runwisp/internal/logutil/log_index_test.go
@@ -4,6 +4,7 @@
 package logutil
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,6 +14,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestScanLines_PrevStartAfterMultipleRotations guards the regression where the
+// `.prev` segment was always numbered from 0. After 2+ rotations the .prev slot
+// holds a segment that started partway through the run, so it must be numbered
+// from meta.PrevStart. Layout: segment 1 (3 lines, already discarded) → segment
+// 2 in .prev starting at line 3 → current segment starting at line 5.
+func TestScanLines_PrevStartAfterMultipleRotations(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "task.log")
+	require.NoError(t, os.WriteFile(PrevPath(logPath), []byte("p3\np4\n"), 0644))
+	require.NoError(t, os.WriteFile(logPath, []byte("c5\nc6\n"), 0644))
+	writeContainer(t, logPath, MetaRecord(LogMeta{RotatedLines: 5, PrevStart: 3}))
+
+	var got []int64
+	err := ScanLines(context.Background(), logPath, func(r LogLineRecord) bool {
+		got = append(got, r.LineNum)
+		return true
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []int64{3, 4, 5, 6}, got)
+}
 
 func tempFileWithContent(t *testing.T, content string) *os.File {
 	t.Helper()

--- a/apps/runwisp/internal/logutil/log_meta.go
+++ b/apps/runwisp/internal/logutil/log_meta.go
@@ -11,8 +11,13 @@ import "path/filepath"
 type LogMeta struct {
 	RotatedLines int64 `json:"rl"`
 	RotatedBytes int64 `json:"rb"`
-	FinalLines   int64 `json:"fl,omitempty"`
-	Finalized    bool  `json:"fin,omitempty"`
+	// PrevStart is the global line number the `.prev` segment starts at. It is 0
+	// after the first rotation but nonzero after later ones (the `.prev` slot only
+	// ever holds the most-recently-rotated segment, which by then started partway
+	// through the run). Readers must number `.prev` from here, not from 0.
+	PrevStart  int64 `json:"ps,omitempty"`
+	FinalLines int64 `json:"fl,omitempty"`
+	Finalized  bool  `json:"fin,omitempty"`
 }
 
 // MetaPath returns the consolidated sidecar container path for a log file. The

--- a/apps/runwisp/internal/notify/render/tail.go
+++ b/apps/runwisp/internal/notify/render/tail.go
@@ -5,6 +5,7 @@ package render
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/runwisp/runwisp/internal/logutil"
 )
@@ -70,5 +71,11 @@ func truncateTail(joined string, maxBytes int) string {
 	if budget <= 0 {
 		return ellipsis
 	}
-	return ellipsis + joined[len(joined)-budget:]
+	cut := joined[len(joined)-budget:]
+	// The byte cut may land mid-rune; drop leading continuation bytes so we never
+	// emit invalid UTF-8 (which renders as � in Slack/Telegram/email bodies).
+	for len(cut) > 0 && !utf8.RuneStart(cut[0]) {
+		cut = cut[1:]
+	}
+	return ellipsis + cut
 }

--- a/apps/runwisp/internal/notify/render/tail_test.go
+++ b/apps/runwisp/internal/notify/render/tail_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,4 +65,19 @@ func TestOutputTail_TruncatesToMaxBytesWithEllipsis(t *testing.T) {
 	assert.True(t, strings.HasPrefix(got, "…"), "expected ellipsis prefix, got %q", got)
 	// budget is 50-len("…")=47 (since "…" is 3 bytes in UTF-8)
 	assert.Equal(t, 50, len(got))
+}
+
+// TestOutputTail_ByteCutDoesNotSplitRune guards against the byte-offset
+// truncation slicing through a multi-byte UTF-8 rune, which would emit invalid
+// UTF-8 (rendered as � in Slack/Telegram/email). Using 3-byte runes (毎) makes
+// the cut land mid-rune for most budgets.
+func TestOutputTail_ByteCutDoesNotSplitRune(t *testing.T) {
+	line := strings.Repeat("毎", 100) // 300 bytes of 3-byte runes
+	path := writeLog(t, line)
+	tail := NewOutputTail()
+	for budget := 5; budget <= 40; budget++ {
+		got := tail(path, 1, budget)
+		assert.True(t, utf8.ValidString(got),
+			"tail must be valid UTF-8 at maxBytes=%d, got %q", budget, got)
+	}
 }

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -227,7 +227,12 @@ func (m *defaultTaskManager) RemoveTask(taskName string) {
 	ts.removed = true
 
 	// Drop anything still queued and wake the drain goroutine so it returns.
+	// Queued runs were already persisted as 'pending'; finalize them here so a
+	// reload that removes the task never leaves a permanent non-terminal row.
 	if ts.cond != nil {
+		for _, r := range ts.queue {
+			m.endOrphanedPending(r)
+		}
 		ts.queue = nil
 		ts.cond.Broadcast()
 	}
@@ -300,12 +305,22 @@ func (m *defaultTaskManager) LoadPendingRuns(runs []model.Run) PendingRunsResult
 		r := run
 		ts, exists := m.tasks[r.TaskName]
 		if !exists {
+			m.endOrphanedPending(&r)
 			result.Skipped++
 			continue
 		}
 		m.resumePendingRun(ts, &r, &result)
 	}
 	return result
+}
+
+// endOrphanedPending finalizes a still-pending run whose task no longer exists
+// (removed by a reload, or absent from the config at boot) so it never lingers
+// as a permanent non-terminal 'pending' row — retention only sweeps ended runs.
+// Caller holds m.mu.
+func (m *defaultTaskManager) endOrphanedPending(r *model.Run) {
+	r.End(model.ReasonSkipped, -1, m.clock())
+	m.persistence.PersistExisting(r)
 }
 
 // resumePendingRun applies the per-run policy from LoadPendingRuns: services

--- a/apps/runwisp/internal/runtime/manager_test.go
+++ b/apps/runwisp/internal/runtime/manager_test.go
@@ -1069,12 +1069,23 @@ func TestLoadPendingRunsFailedWhenSlotFull(t *testing.T) {
 }
 
 // TestLoadPendingRunsSkippedTaskNotFound: pending runs whose task is no
-// longer in the config are dropped as skipped.
+// longer in the config are dropped as skipped — but must still be persisted with
+// a terminal state, never left as a permanent 'pending' row (Prime Directive #1).
 func TestLoadPendingRunsSkippedTaskNotFound(t *testing.T) {
 	exec := new(testutil.MockExecutor)
 	eb := events.NewEventBus()
 	jm := NewTaskManager(exec, eb, time.Now)
 	defer jm.Shutdown()
+
+	var mu sync.Mutex
+	ended := map[string]model.EndReason{}
+	jm.BindPersistenceHook(func(_ context.Context, run *model.Run, _ bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		if run.Status == model.PhaseEnded && run.EndReason != nil {
+			ended[run.ID] = *run.EndReason
+		}
+	})
 
 	pending := []model.Run{
 		{ID: "01", TaskName: "ghost", Status: model.PhasePending},
@@ -1086,6 +1097,49 @@ func TestLoadPendingRunsSkippedTaskNotFound(t *testing.T) {
 	assert.Equal(t, 0, result.Resumed)
 	assert.Equal(t, 0, result.Queued)
 	assert.Equal(t, 0, result.Failed)
+
+	jm.(*defaultTaskManager).persistence.Flush()
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, model.ReasonSkipped, ended["01"])
+	assert.Equal(t, model.ReasonSkipped, ended["02"])
+}
+
+// TestRemoveTask_FinalizesQueuedRuns: removing a task on reload must finalize any
+// still-queued (persisted 'pending') run instead of dropping the slice and
+// leaving a permanent non-terminal row that retention never sweeps.
+func TestRemoveTask_FinalizesQueuedRuns(t *testing.T) {
+	jm, exec, _ := newGatedManager(t)
+
+	var mu sync.Mutex
+	ended := map[string]model.EndReason{}
+	jm.BindPersistenceHook(func(_ context.Context, run *model.Run, _ bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		if run.Status == model.PhaseEnded && run.EndReason != nil {
+			ended[run.ID] = *run.EndReason
+		}
+	})
+
+	// Queue-policy task at concurrency 1: first run occupies the slot, second
+	// waits in the queue.
+	task := testTask("q", model.PolicyQueue, 1)
+	jm.UpsertTask(task)
+
+	_, err := jm.TriggerRun("q", model.TriggeredByAPI)
+	require.NoError(t, err)
+	exec.WaitStarted(t)
+
+	queued, err := jm.TriggerRun("q", model.TriggeredByAPI)
+	require.NoError(t, err)
+
+	jm.RemoveTask("q")
+
+	jm.persistence.Flush()
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, model.ReasonSkipped, ended[queued.ID],
+		"queued run must be finalized when its task is removed")
 }
 
 func TestResolveRunOutcomeKilledByPolicy(t *testing.T) {


### PR DESCRIPTION
A round of correctness and hardening fixes, each with a regression test.

### Fixed
- **Removed tasks no longer leave queued runs pending.** When `runwisp reload` drops a task (or it's absent at startup), any run still waiting in that task's queue is finalized with a terminal status, so the run history and API never show it as perpetually pending.
- **`min_free_space` keeps enforcing free-disk headroom across log rotations.** The safeguard now stays active for the full duration of a long-running task whose output rotates.
- **Log line numbers stay continuous after multiple rotations.** Log-search results and paging anchors reference the correct lines even when a run's output has rotated more than once.
- **The data directory is always created with `0700` permissions**, including when it already exists (e.g. a pre-created Docker volume), keeping its contents private to the daemon's user.
- **Notification log excerpts are always valid UTF-8.** Trimming a captured-output tail to fit a message no longer cuts through a multi-byte character.

Each fix ships with a test that fails without it. `bun run ci` is green.