### PR TITLE
sonar: reduce cognitive complexity, drop duplicate test, fix shell/CSS smells

### DIFF
--- a/apps/runwisp/internal/cronspec/cronspec.go
+++ b/apps/runwisp/internal/cronspec/cronspec.go
@@ -220,6 +220,13 @@ func dowTerm(term string) string {
 	// into day 0 *after* expanding the range, so `1-7` is the whole week — clamping
 	// it to `1-0` would be an inverted range robfig rejects, and `0-7` clamped to
 	// `0-0` would silently shrink every day to Sunday.
+	return expandDowRangeTo7(term, lo, step, hasStep)
+}
+
+// expandDowRangeTo7 expands a day-of-week range that ends at 7 (Sunday) into an
+// explicit comma list, folding day 7 to day 0. It returns term unchanged if lo
+// or the step can't be parsed.
+func expandDowRangeTo7(term, lo, step string, hasStep bool) string {
 	from, err := strconv.Atoi(lo)
 	if err != nil {
 		return term

--- a/apps/runwisp/internal/importer/cron.go
+++ b/apps/runwisp/internal/importer/cron.go
@@ -445,31 +445,7 @@ type cronJobLine struct {
 // @reboot line and handed a command argument to `user =` on a long one.
 func splitCronJobLine(line string, system bool) (cronJobLine, bool) {
 	if strings.HasPrefix(line, "@") {
-		tok, rest, ok := splitFields(line, 1)
-		if !ok {
-			return cronJobLine{}, false
-		}
-		j := cronJobLine{command: rest}
-		switch strings.ToLower(tok[0]) {
-		case "@reboot":
-			j.runOnStart = true
-		case "@annually":
-			j.schedule = "@yearly"
-		case "@midnight":
-			j.schedule = "@daily"
-		default:
-			j.schedule = tok[0]
-		}
-		if system {
-			userTok, command, ok := splitFields(rest, 1)
-			if !ok || command == "" {
-				return cronJobLine{}, false // a user column with no command isn't a job
-			}
-			j.user, j.command = userTok[0], command
-		} else if rest == "" {
-			return cronJobLine{}, false // a descriptor with no command isn't a job
-		}
-		return j, true
+		return splitCronDescriptorLine(line, system)
 	}
 
 	nFields := 5
@@ -483,6 +459,36 @@ func splitCronJobLine(line string, system bool) (cronJobLine, bool) {
 	j := cronJobLine{schedule: strings.Join(tok[:5], " "), command: rest}
 	if system {
 		j.user = tok[5]
+	}
+	return j, true
+}
+
+// splitCronDescriptorLine handles the `@keyword command` shorthand form of a
+// crontab job line. See splitCronJobLine for the system-mode user-column rules.
+func splitCronDescriptorLine(line string, system bool) (cronJobLine, bool) {
+	tok, rest, ok := splitFields(line, 1)
+	if !ok {
+		return cronJobLine{}, false
+	}
+	j := cronJobLine{command: rest}
+	switch strings.ToLower(tok[0]) {
+	case "@reboot":
+		j.runOnStart = true
+	case "@annually":
+		j.schedule = "@yearly"
+	case "@midnight":
+		j.schedule = "@daily"
+	default:
+		j.schedule = tok[0]
+	}
+	if system {
+		userTok, command, ok := splitFields(rest, 1)
+		if !ok || command == "" {
+			return cronJobLine{}, false // a user column with no command isn't a job
+		}
+		j.user, j.command = userTok[0], command
+	} else if rest == "" {
+		return cronJobLine{}, false // a descriptor with no command isn't a job
 	}
 	return j, true
 }

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -994,8 +994,15 @@ func (m *defaultTaskManager) retireRun(task *model.Task, run *model.Run, runDura
 	if ts.cond != nil {
 		ts.cond.Signal()
 	}
-	// A reload removed this task while runs were draining; once the last one
-	// retires the taskState has no further owner, so delete it here.
+	m.reapRetiredTaskState(task, ts)
+	return nextRestartAttempt, serviceFatal, fatalAttempts
+}
+
+// reapRetiredTaskState drops a taskState from the registry once its last run has
+// retired, for the two cases where nothing else will: a reload-removed task
+// whose runs were still draining, and an ephemeral cloud-inline task that never
+// entered the TOML registry. Caller must hold m.mu.
+func (m *defaultTaskManager) reapRetiredTaskState(task *model.Task, ts *taskState) {
 	if ts.removed && len(ts.active) == 0 {
 		delete(m.tasks, task.Name)
 	} else if ts.task != nil && ts.task.Ephemeral && len(ts.active) == 0 && len(ts.queue) == 0 {
@@ -1010,7 +1017,6 @@ func (m *defaultTaskManager) retireRun(task *model.Task, run *model.Run, runDura
 		}
 		delete(m.tasks, task.Name)
 	}
-	return nextRestartAttempt, serviceFatal, fatalAttempts
 }
 
 // scheduleFollowup spawns the retry or restart goroutine dictated by the task's

--- a/apps/runwisp/internal/server/server_test.go
+++ b/apps/runwisp/internal/server/server_test.go
@@ -466,21 +466,6 @@ func TestGetLogRaw(t *testing.T) {
 	assert.Equal(t, "log content\n", w.Body.String())
 }
 
-func TestGetRunNotFound(t *testing.T) {
-	s, repo, _, _ := setupServer(t)
-
-	id := ulid.Make().String()
-	repo.On("GetRun", mock.Anything, id).Return(nil, storage.ErrNotFound)
-
-	req := httptest.NewRequest("GET", "/api/runs/"+id, nil)
-	w := httptest.NewRecorder()
-
-	addAuth(req, s)
-	s.router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusNotFound, w.Code)
-}
-
 func TestInvalidRunID(t *testing.T) {
 	s, _, _, _ := setupServer(t)
 

--- a/apps/runwisp/internal/tui/views/home/header.go
+++ b/apps/runwisp/internal/tui/views/home/header.go
@@ -125,22 +125,7 @@ func RenderHeader(info uikit.StartupInfo, hasLaunchTicket bool, w, homeCursor, h
 
 	fieldsStartY := lineCount
 
-	for i, f := range fields {
-		selected := i == homeCursor
-		hovered := i == homeHover && !selected
-		switch f {
-		case FieldOpenWebUI:
-			renderActionRow(&b, "Open Web UI", uikit.ColorSecondary, w, selected, hovered)
-		case FieldWebUI:
-			renderFieldRow(&b, "Web UI", info.WebURL(), uikit.ColorText, w, selected, hovered)
-		case FieldPassword:
-			masked := strings.Repeat("•", PasswordMaskWidth)
-			if selected {
-				masked += "  (press Enter to copy)"
-			}
-			renderFieldRow(&b, "Password", masked, uikit.ColorWarning, w, selected, hovered)
-		}
-	}
+	writeFieldRows(&b, fields, info, w, homeCursor, homeHover)
 
 	// Auth disabled: render a static, non-focusable Password row so the
 	// operator sees the security state at a glance instead of a masked value.
@@ -154,6 +139,27 @@ func RenderHeader(info uikit.StartupInfo, hasLaunchTicket bool, w, homeCursor, h
 	}
 
 	return b.String(), fieldsStartY
+}
+
+// writeFieldRows renders each focusable field row, applying the cursor/hover
+// highlight for the currently selected and hovered indices.
+func writeFieldRows(b *strings.Builder, fields []Field, info uikit.StartupInfo, w, homeCursor, homeHover int) {
+	for i, f := range fields {
+		selected := i == homeCursor
+		hovered := i == homeHover && !selected
+		switch f {
+		case FieldOpenWebUI:
+			renderActionRow(b, "Open Web UI", uikit.ColorSecondary, w, selected, hovered)
+		case FieldWebUI:
+			renderFieldRow(b, "Web UI", info.WebURL(), uikit.ColorText, w, selected, hovered)
+		case FieldPassword:
+			masked := strings.Repeat("•", PasswordMaskWidth)
+			if selected {
+				masked += "  (press Enter to copy)"
+			}
+			renderFieldRow(b, "Password", masked, uikit.ColorWarning, w, selected, hovered)
+		}
+	}
 }
 
 // renderFieldRow renders a single focusable field row with optional selection highlight.

--- a/apps/runwisp/scripts/tests/package-all_test.sh
+++ b/apps/runwisp/scripts/tests/package-all_test.sh
@@ -20,11 +20,12 @@ failed=0
 
 # Mode of the `runwisp` member inside a tarball, e.g. "-rwxr-xr-x".
 member_mode() {
-  tar tzvf "$1" | awk '$NF == "runwisp" { print $1 }'
+  local tarball="$1"
+  tar tzvf "${tarball}" | awk '$NF == "runwisp" { print $1 }'
 }
 
-pass() { passed=$((passed + 1)); printf 'ok   - %s\n' "$1"; }
-fail() { failed=$((failed + 1)); printf 'FAIL - %s\n' "$1" >&2; }
+pass() { local name="$1"; passed=$((passed + 1)); printf 'ok   - %s\n' "${name}"; }
+fail() { local name="$1"; failed=$((failed + 1)); printf 'FAIL - %s\n' "${name}" >&2; }
 
 # --- packs a 0644 binary as an executable member (the actual v0.14.0 bug) ---
 work=$(mktemp -d)

--- a/docker/tests/entrypoint_test.sh
+++ b/docker/tests/entrypoint_test.sh
@@ -53,11 +53,14 @@ failed=0
 expect() {
 	name=$1 want_exit=$2 want_text=$3
 	shift 3
-	[ "$1" = "--" ] && shift
+	sep=${1:-}
+	[ "$sep" = "--" ] && shift
 
 	env_args=""
-	while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
-		env_args="$env_args $1"
+	while [ "$#" -gt 0 ]; do
+		arg=$1
+		[ "$arg" = "--" ] && break
+		env_args="$env_args $arg"
 		shift
 	done
 	[ "${1:-}" = "--" ] && shift

--- a/docker/tests/smoke.sh
+++ b/docker/tests/smoke.sh
@@ -38,13 +38,15 @@ passed=0
 failed=0
 
 pass() {
+	local name="$1"
 	passed=$((passed + 1))
-	printf '  ok   %s\n' "$1"
+	printf '  ok   %s\n' "${name}"
 }
 fail() {
+	local name="$1" detail="${2:-}"
 	failed=$((failed + 1))
-	printf '  FAIL %s\n' "$1"
-	[[ $# -gt 1 ]] && printf '       %s\n' "$2"
+	printf '  FAIL %s\n' "${name}"
+	[[ $# -gt 1 ]] && printf '       %s\n' "${detail}"
 }
 
 # run_image <expected exit> <expected substring> <name> -- <docker run args...>

--- a/packages/ui/src/lib/theme-tokens.css
+++ b/packages/ui/src/lib/theme-tokens.css
@@ -35,9 +35,7 @@
     --rw-font-sans: "TASA Orbiter", system-ui, -apple-system, sans-serif;
     --rw-font-mono:
         "Geist Mono Variable", "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-}
 
-:root {
     /* Primary — Wisp Teal (brand = #0E7C86, the artifact's deep teal). Deeper
      * and less cyan than Aurora (running/info) so the two stay distinct. */
     --rw-color-wisp-50: oklch(0.97 0.02 205);


### PR DESCRIPTION
## Summary
- Extracts helper functions out of oversized branches flagged for cognitive complexity: `cronspec` day-of-week expansion, `importer` `@descriptor` line parsing, `runtime` taskState reaping, TUI header field rows.
- Removes `TestGetRunNotFound`, a duplicate of `TestGetRunByID_NotFound`.
- Adds missing `local` declarations in `docker/tests/entrypoint_test.sh`, `docker/tests/smoke.sh`, and `apps/runwisp/scripts/tests/package-all_test.sh`.
- Merges a duplicate `:root` block in `packages/ui/src/lib/theme-tokens.css`.

No behavior changes.

## Test plan
- [x] `go build ./...` / `go vet ./...` for touched packages
- [x] `go test` for `cronspec`, `importer`, `runtime`, `server`, `tui/...`
- [x] Shell scripts pass `bash -n` syntax check