### PR TITLE
Literal secret files, log-stream reconnect replay, notification cadence, retention sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`env_file` and `secrets_file` values are read literally**, so passwords and tokens containing `$`, `${...}`, or `#` are passed to the task exactly as written. See [Tasks](https://docs.runwisp.com/configuration/tasks/).
+- **A log stream resumed after a disconnect replays the most recent missed lines**, keeping a reconnecting browser continuous with the live tail even across a large gap. See [Web UI](https://docs.runwisp.com/getting-started/web-ui-tour/).
+- **Outbound notification channels (Slack, Telegram) send periodic check-ins during a sustained incident** on the default `occurrence_ring` cadence. See [Notification model](https://docs.runwisp.com/notifications/model/).
+- **`storage.max_size` enforcement accounts for rotated log segments** when trimming run history to the configured cap. See [Storage](https://docs.runwisp.com/configuration/storage/).
+
 ## [0.15.1] - 2026-08-12
 
 ### Fixed

--- a/apps/runwisp/internal/config/config_env_test.go
+++ b/apps/runwisp/internal/config/config_env_test.go
@@ -330,6 +330,29 @@ func TestValidateTaskEnvCombinedCap(t *testing.T) {
 	assert.Contains(t, err.Error(), "exceeds the cap")
 }
 
+func TestLoadEnvFileTakesValuesLiterally(t *testing.T) {
+	dir := writeFilesInDir(t, map[string]string{
+		"runwisp.toml": `
+[tasks.t]
+run = "/bin/true"
+secrets_file = "secrets.env"
+`,
+		// $XYZ, ${ABC} and a trailing # must all survive verbatim: godotenv
+		// would expand the first two to "" and strip the "#comment".
+		"secrets.env": "# a comment line\nexport DOLLAR=Tr0ub4dour$XYZ\nBRACE=pre${ABC}post\nHASH=pass#word\nSINGLE='literal$XYZ'\nDOUBLE=\"a b c\"\n",
+	})
+	cfg, err := Load(filepath.Join(dir, "runwisp.toml"))
+	require.NoError(t, err)
+	require.Len(t, cfg.Tasks, 1)
+	assert.Equal(t, map[string]string{
+		"DOLLAR": "Tr0ub4dour$XYZ",
+		"BRACE":  "pre${ABC}post",
+		"HASH":   "pass#word",
+		"SINGLE": "literal$XYZ",
+		"DOUBLE": "a b c",
+	}, cfg.Tasks[0].Secrets)
+}
+
 func itoa(n int) string {
 	if n == 0 {
 		return "0"

--- a/apps/runwisp/internal/config/envfile.go
+++ b/apps/runwisp/internal/config/envfile.go
@@ -4,28 +4,74 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
-
-	"github.com/joho/godotenv"
+	"io"
+	"os"
+	"strings"
 )
 
-// loadEnvFile resolves path relative to baseDir, parses it with godotenv, and
-// runs the same key/value validation rules as inline `env` blocks. The
-// returned map is suitable for direct merging into Task.Env / Task.Secrets.
+// loadEnvFile resolves path relative to baseDir, parses it literally, and runs
+// the same key/value validation rules as inline `env` blocks. The returned map
+// is suitable for direct merging into Task.Env / Task.Secrets.
 //
-// godotenv.Read returns the file's KEY=VALUE pairs as a map without touching
-// os.Environ; there is no shell-style expansion or interpolation. Operators
-// who want a value to look like a shell variable should write it literally.
+// Values are taken literally: no shell-style expansion, interpolation, or
+// inline-comment stripping. This matters for secrets_file — a password like
+// `Tr0ub4dour$XYZ` or `pass#word` must reach the process unchanged. (godotenv,
+// the obvious library choice, silently expands `$VAR`/`${VAR}` and strips
+// trailing `#` comments, which would corrupt such secrets with no error.)
 func loadEnvFile(baseDir, path string) (map[string]string, error) {
 	resolved, err := resolvePath(baseDir, path)
 	if err != nil {
 		return nil, err
 	}
-	values, err := godotenv.Read(resolved)
+	f, err := os.Open(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("read env_file %s: %w", resolved, err)
+	}
+	defer f.Close()
+
+	values, err := parseEnvFile(f)
 	if err != nil {
 		return nil, fmt.Errorf("read env_file %s: %w", resolved, err)
 	}
 	if err := validateEnvMap(fmt.Sprintf("env_file %s", resolved), values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// parseEnvFile reads KEY=VALUE lines literally. Blank lines and lines whose
+// first non-blank rune is '#' are skipped; an optional `export ` prefix on the
+// key is ignored. Surrounding whitespace is trimmed, and one pair of matching
+// surrounding quotes (single or double) is stripped — everything inside is kept
+// byte-for-byte, with no expansion or escape processing.
+func parseEnvFile(r io.Reader) (map[string]string, error) {
+	values := make(map[string]string)
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNum := 0
+	for sc.Scan() {
+		lineNum++
+		line := strings.TrimLeft(sc.Text(), " \t")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("line %d: missing '=' separator", lineNum)
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		if len(val) >= 2 {
+			if q := val[0]; (q == '"' || q == '\'') && val[len(val)-1] == q {
+				val = val[1 : len(val)-1]
+			}
+		}
+		values[key] = val
+	}
+	if err := sc.Err(); err != nil {
 		return nil, err
 	}
 	return values, nil

--- a/apps/runwisp/internal/config/notify_schema.go
+++ b/apps/runwisp/internal/config/notify_schema.go
@@ -31,6 +31,11 @@ const (
 	// defaultHistoryKeepFor is the age limit applied when
 	// notify.history_keep_for is omitted from TOML.
 	defaultHistoryKeepFor = 90 * 24 * time.Hour
+	// defaultOccurrenceRing is the coalescing ring size applied when
+	// notify.occurrence_ring is omitted. It drives both the in-app occurrence
+	// ring and the outbound "check-in every N events" cadence, so it must be
+	// resolved here rather than left 0 (outbound treats 0 as "never check in").
+	defaultOccurrenceRing = 10
 )
 
 // parseNotifyToken splits a notify destination token into its parent notifier
@@ -60,6 +65,9 @@ func (t *tomlConfig) toNotifyConfig(taskNames []string, taskWires map[string]*ta
 	}
 	if out.HistoryKeep == 0 {
 		out.HistoryKeep = defaultHistoryKeep
+	}
+	if out.OccurrenceRing == 0 {
+		out.OccurrenceRing = defaultOccurrenceRing
 	}
 
 	if err := t.applyNotifyDurations(&out); err != nil {

--- a/apps/runwisp/internal/config/notify_schema_test.go
+++ b/apps/runwisp/internal/config/notify_schema_test.go
@@ -487,6 +487,15 @@ history_keep_for = "720h"
 	assert.NotZero(t, cfg.Notify.HistoryKeepFor)
 }
 
+func TestDecode_NotifyOccurrenceRingDefault(t *testing.T) {
+	// Omitted occurrence_ring must resolve to the documented default (10), not
+	// 0. The outbound coalescer treats 0 as "never check in", so a missing
+	// default silently disables the periodic check-in cadence.
+	cfg, err := decode([]byte(schedulerTZHeader+"\n[notify]\n"), "")
+	require.NoError(t, err)
+	assert.Equal(t, defaultOccurrenceRing, cfg.Notify.OccurrenceRing)
+}
+
 func TestDecode_NotifyDefaultTimeout_Invalid(t *testing.T) {
 	src := schedulerTZHeader + `
 [notify]

--- a/apps/runwisp/internal/runtime/retention.go
+++ b/apps/runwisp/internal/runtime/retention.go
@@ -164,6 +164,12 @@ func (cleaner *RetentionCleaner) deleteRunBatch(ctx context.Context, runs []mode
 		if info, statErr := os.Stat(logutil.MetaPath(logPath)); statErr == nil {
 			*totalSize -= info.Size()
 		}
+		// RemoveLogFiles also deletes the rotated-away .prev segment, and the
+		// initial dirSize counted it — subtract it too or the tracked total
+		// stays high and the loop over-deletes runs.
+		if info, statErr := os.Stat(logutil.PrevPath(logPath)); statErr == nil {
+			*totalSize -= info.Size()
+		}
 		logutil.RemoveLogFiles(logPath)
 		logutil.RemoveEmptyParents(logPath, cleaner.logDir)
 		if err := cleaner.db.DeleteRun(ctx, run.ID); err != nil {

--- a/apps/runwisp/internal/runtime/retention_test.go
+++ b/apps/runwisp/internal/runtime/retention_test.go
@@ -76,6 +76,45 @@ func TestEnforceMaxTotalSize_UnderLimit(t *testing.T) {
 	repo.AssertNotCalled(t, "QueryRuns")
 }
 
+// A run's rotated-away .prev segment is deleted alongside its .log and counted
+// by the initial dirSize, so its size must be subtracted from the running
+// total too. Otherwise the tracker stays high and prunes more runs than the
+// cap requires. Regression: two runs, each 100B log + 100B prev (400B total,
+// 250B cap) — deleting the oldest run frees 200B and drops under the cap, so
+// the second run must survive.
+func TestEnforceMaxTotalSize_SubtractsPrevSegment(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	logDir := t.TempDir()
+	now := time.Now()
+
+	makeRun := func(createdAt time.Time) model.Run {
+		id := ulid.Make().String()
+		logPath := logutil.ResolveRunLogPath(logDir, "task1", id, createdAt)
+		require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0755))
+		require.NoError(t, os.WriteFile(logPath, make([]byte, 100), 0644))
+		require.NoError(t, os.WriteFile(logutil.PrevPath(logPath), make([]byte, 100), 0644))
+		return model.Run{ID: id, TaskName: "task1", CreatedAt: createdAt, Status: model.PhaseEnded}
+	}
+
+	oldest := makeRun(now.Add(-time.Hour))
+	newest := makeRun(now)
+
+	enforceQuery := storage.RunQuery{
+		Limit:         100,
+		Offset:        0,
+		SortField:     storage.SortColumnCreatedAt,
+		SortDirection: storage.SortAsc,
+	}
+	repo.On("QueryRuns", mock.Anything, enforceQuery).Return([]model.Run{oldest, newest}, nil)
+	repo.On("DeleteRun", mock.Anything, oldest.ID).Return(nil)
+
+	cleaner := NewRetentionCleaner(repo, NewTaskRegistry(nil), time.Hour, logDir, 250)
+	cleaner.enforceMaxTotalSize(context.Background())
+
+	repo.AssertCalled(t, "DeleteRun", mock.Anything, oldest.ID)
+	repo.AssertNotCalled(t, "DeleteRun", mock.Anything, newest.ID)
+}
+
 func TestEnforceMaxTotalSize_PrunesOldestTerminalRun(t *testing.T) {
 	repo := new(testutil.MockRunRepository)
 	logDir := t.TempDir()

--- a/apps/runwisp/internal/server/logstream/logstream.go
+++ b/apps/runwisp/internal/server/logstream/logstream.go
@@ -301,6 +301,15 @@ func (s *streamer) streamLoop(ctx context.Context, runID string, bus *events.Bus
 		slog.Warn("SSE: backfill read failed", "runID", runID, "err", err)
 	}
 	resolvedAnchor := resolveBackfillAnchor(anchorFrom, replayLimit, totalLines, firstAvailable)
+	// ReadLineRange read a forward window starting at anchorFrom, but when the
+	// gap exceeds replayLimit the anchor is advanced to the tail. Re-read from
+	// the resolved anchor so the freshest missed lines are replayed instead of
+	// the oldest slice (which emitBackfill would otherwise drop entirely).
+	if len(backfill) > 0 && resolvedAnchor > backfill[0].LineNum {
+		if reBackfill, reFirst, reTotal, reErr := logutil.ReadLineRange(s.logPath, resolvedAnchor, replayLimit); reErr == nil {
+			backfill, firstAvailable, totalLines = reBackfill, reFirst, reTotal
+		}
+	}
 	// Stamp frame-history availability onto backfilled anchor lines so a
 	// finished run loaded fresh (not just the live path) keeps its rewind
 	// affordance. Read once per connection, mirroring humaGetLogPage.

--- a/apps/runwisp/internal/server/logstream/logstream_test.go
+++ b/apps/runwisp/internal/server/logstream/logstream_test.go
@@ -4,7 +4,12 @@
 package logstream
 
 import (
+	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -271,6 +276,32 @@ func TestEmitBackfill_StampsFrameCount(t *testing.T) {
 	require.Len(t, m.lines, 2)
 	assert.Equal(t, 0, m.lines[0].FrameCount, "non-anchor line carries no frame count")
 	assert.Equal(t, 3, m.lines[1].FrameCount, "anchor line is stamped with its frame count")
+}
+
+// streamLoop backfill: a positive resume anchor whose gap to the live cursor
+// exceeds the replay budget must replay the freshest lines (the tail), not a
+// stale leading slice. Regression for the window mismatch between
+// ReadLineRange (forward from anchorFrom) and resolveBackfillAnchor (tail).
+func TestStreamLoop_LargePositiveGapReplaysTail(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "test.log")
+	var b strings.Builder
+	for i := 0; i < 8000; i++ {
+		b.WriteString("line")
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString("\n")
+	}
+	require.NoError(t, os.WriteFile(logPath, []byte(b.String()), 0o600))
+
+	m := &mockSender{}
+	s := newStreamer(m, logPath)
+	bus := events.NewEventBus()
+	// Resume from line 0 with a 5000-line replay budget against 8000 lines.
+	s.streamLoop(context.Background(), "run1", bus, nil, 0, 5000, true)
+
+	require.Len(t, m.lines, 5000, "exactly the replay budget of lines is backfilled")
+	assert.Equal(t, int64(3000), m.lines[0].N, "backfill starts at the tail anchor")
+	assert.Equal(t, int64(7999), m.lines[len(m.lines)-1].N, "newest line is replayed")
 }
 
 // --- sendTerminalEvents ---


### PR DESCRIPTION
Four fixes, each with a regression test.

### `env_file` / `secrets_file` values are read literally
Passwords and tokens containing `$`, `${...}`, or `#` are passed to the task exactly as written — no quoting workaround needed.

### Log-stream reconnect replays the most recent missed lines
A browser that reconnects after a gap larger than the replay budget backfills the newest missed lines and stays continuous with the live tail.

### Notification check-ins on the default cadence
With `occurrence_ring` left unset, outbound channels (Slack, Telegram) send periodic check-ins during a sustained incident, on the documented default cadence.

### `storage.max_size` accounts for rotated log segments
Size enforcement counts rotated `.prev` segments when trimming run history, so it keeps exactly to the configured cap.