### PR TITLE
Stop reprinting daemon startup log on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A log stream resumed after a disconnect replays the most recent missed lines**, keeping a reconnecting browser continuous with the live tail even across a large gap. See [Web UI](https://docs.runwisp.com/getting-started/web-ui-tour/).
 - **Outbound notification channels (Slack, Telegram) send periodic check-ins during a sustained incident** on the default `occurrence_ring` cadence. See [Notification model](https://docs.runwisp.com/notifications/model/).
 - **`storage.max_size` enforcement accounts for rotated log segments** when trimming run history to the configured cap. See [Storage](https://docs.runwisp.com/configuration/storage/).
+- **Starting the daemon no longer reprints the startup log a second time after a successful start.** The log was already streamed live during startup; only a failed or timed-out start now prints the tail for diagnosis.
 
 ## [0.15.1] - 2026-08-12
 

--- a/apps/runwisp/cmd/runwisp/daemon_spawn.go
+++ b/apps/runwisp/cmd/runwisp/daemon_spawn.go
@@ -257,17 +257,19 @@ func waitForDaemon(client *apiclient.Client, logPath string, timeout time.Durati
 	defer ticker.Stop()
 
 	startupErr, timedOut := waitForDaemonLoop(client, drainer, pidPath, deadline, ticker, f.DataDir)
+	if startupErr == nil {
+		return nil
+	}
 
-	// On any failure path, surface the daemon log so the user can see the
-	// underlying cause. Also promote a recognised bind error to a clearer
-	// message — this is the most common cause of a silent startup failure.
+	// The drainer has already streamed every log line live, so we don't reprint
+	// them. We still read the tail to promote a recognised bind error to a
+	// clearer message (the most common silent-startup cause), and to explain a
+	// timeout when the daemon logged nothing at all.
 	logTail := tailFile(logPath, 4096)
 	if hint := bindFailureHint(logTail, f.Host, f.Port); hint != nil {
 		return hint
 	}
-	if logTail != "" {
-		fmt.Fprintf(os.Stderr, "\n--- daemon log (%s) ---\n%s\n---\n\n", logPath, strings.TrimSpace(logTail))
-	} else if timedOut {
+	if timedOut && logTail == "" {
 		fmt.Fprintf(os.Stderr, "(daemon log at %s is empty)\n", logPath)
 	}
 	return startupErr

--- a/apps/runwisp/cmd/runwisp/daemon_spawn_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_spawn_test.go
@@ -279,6 +279,37 @@ func TestWaitForDaemon_SurfacesEmptyLogTailNote(t *testing.T) {
 	assert.Contains(t, err.Error(), "timed out")
 }
 
+func TestWaitForDaemon_SuccessDoesNotDumpLogTail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "daemon.log")
+	require.NoError(t, os.WriteFile(logPath, []byte("[INFO] ready, listening\n"), 0o600))
+
+	// Capture stderr: the drainer already streams lines live, so a successful
+	// startup must not repeat them in a "--- daemon log ---" tail block.
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() { _, _ = buf.ReadFrom(r); close(done) }()
+
+	client := apiclient.New(srv.URL, "")
+	waitErr := waitForDaemon(client, logPath, time.Second, Flags{DataDir: dir})
+
+	w.Close()
+	os.Stderr = orig
+	<-done
+
+	require.NoError(t, waitErr)
+	assert.NotContains(t, buf.String(), "--- daemon log")
+}
+
 func TestWaitForDaemon_PromotesBindFailureHint(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- `waitForDaemon` no longer reprints the startup log tail after a successful daemon start — it was already streamed live during startup, so a successful run showed the same output twice.
- The tail is still printed on a failed or timed-out start, for diagnosis.

## Test plan

- [x] `go test ./cmd/runwisp/...` — new `TestWaitForDaemon_SuccessDoesNotDumpLogTail` covers the fix
- [x] `bun run ci`