### PR TITLE
Follow-up security hardening: redact HTTP secrets, bound cloud dispatch, scope run actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Hardened `service install` unit generation, task-process environment isolation, config-file trust checks, privilege dropping, and outbound-request address filtering.** Internal safeguards with no configuration changes.
+- **HTTP-task run logs redact request/response credentials** — `Authorization`, `Cookie`, API-key headers, and URL passwords are shown as `[redacted]` instead of being persisted to disk.
+- **Control-plane dispatch is validated and bounded at the boundary** — peer-supplied shell `umask`/interpreter are re-validated, log-search size and the ephemeral dispatch queue are capped, and running the control-plane connection over plaintext (`RUNWISP_CLOUD_ALLOW_INSECURE`) now warns loudly at startup.
+- **Run delete/stop honor the task in the request path**, and log search runs under a request deadline. Internal safeguards with no configuration changes.
 
 ## [0.15.1] - 2026-08-12
 

--- a/apps/runwisp/internal/cloud/config.go
+++ b/apps/runwisp/internal/cloud/config.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"log/slog"
 )
 
 const (
@@ -54,8 +56,12 @@ func LoadConfig(agentVersion, tokenOverride, urlOverride, fingerprint string) (C
 		return Config{}, fmt.Errorf("invalid RUNWISP_CLOUD_URL scheme %q (expected https or http)", baseURL.Scheme)
 	}
 
-	if baseURL.Scheme == "http" && !strings.EqualFold(os.Getenv("RUNWISP_CLOUD_ALLOW_INSECURE"), "true") {
-		return Config{}, fmt.Errorf("insecure http:// cloud URL rejected; set RUNWISP_CLOUD_ALLOW_INSECURE=true to allow")
+	if baseURL.Scheme == "http" {
+		if !strings.EqualFold(os.Getenv("RUNWISP_CLOUD_ALLOW_INSECURE"), "true") {
+			return Config{}, fmt.Errorf("insecure http:// cloud URL rejected; set RUNWISP_CLOUD_ALLOW_INSECURE=true to allow")
+		}
+		slog.Warn("RUNWISP_CLOUD_ALLOW_INSECURE=true: control-plane traffic (bearer token, dispatch frames) runs over plaintext with no TLS — a network attacker can read the token and inject task dispatches; never use this outside local testing",
+			"url", baseURL.Redacted())
 	}
 
 	if baseURL.Host == "" {

--- a/apps/runwisp/internal/cloud/dispatch_resolver.go
+++ b/apps/runwisp/internal/cloud/dispatch_resolver.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/runwisp/runwisp/internal/config"
 	"github.com/runwisp/runwisp/internal/generated/protocol"
 	"github.com/runwisp/runwisp/internal/model"
 )
@@ -84,6 +85,10 @@ func buildDynamicCloudTask(dispatch *protocol.Execution, execDef model.Execution
 		ExecutionDef:  execDef,
 		MaxConcurrent: 1,
 		OnOverlap:     model.PolicyQueue,
+		// Cloud dynamic tasks bypass config defaulting, so set the same bound a
+		// TOML queue task gets — otherwise QueueMax stays 0 (unbounded) and a
+		// stream of dispatches to one slow name grows the queue without limit.
+		QueueMax: config.DefaultQueueMax,
 		// One-shot cloud dispatch: the run manager reaps this task (and its
 		// queue-drain goroutine) once the run retires, so a long-running daemon
 		// doesn't leak state per distinct dispatched name.

--- a/apps/runwisp/internal/executor/http.go
+++ b/apps/runwisp/internal/executor/http.go
@@ -176,9 +176,9 @@ func (b *HTTPBackend) execute(ctx context.Context, def *model.HTTPExecution, out
 		req.Header.Set(h.Key, h.Value)
 	}
 
-	fmt.Fprintf(out, "%s %s\n", def.Method, def.URL)
+	fmt.Fprintf(out, "%s %s\n", def.Method, redactURL(def.URL))
 	for _, h := range def.Headers {
-		fmt.Fprintf(out, "> %s: %s\n", h.Key, h.Value)
+		fmt.Fprintf(out, "> %s: %s\n", h.Key, redactHeaderValue(h.Key, h.Value))
 	}
 	if contentType != "" {
 		fmt.Fprintf(out, "> Content-Type: %s\n", contentType)
@@ -198,7 +198,7 @@ func (b *HTTPBackend) execute(ctx context.Context, def *model.HTTPExecution, out
 	fmt.Fprintf(out, "< %s (%s)\n", resp.Status, elapsed.Round(time.Millisecond))
 	for key, vals := range resp.Header {
 		for _, v := range vals {
-			fmt.Fprintf(out, "< %s: %s\n", key, v)
+			fmt.Fprintf(out, "< %s: %s\n", key, redactHeaderValue(key, v))
 		}
 	}
 	fmt.Fprintln(out)
@@ -232,6 +232,39 @@ func (b *HTTPBackend) buildBody(body *model.HTTPBody) (io.Reader, string, error)
 	default:
 		return nil, "", fmt.Errorf("unsupported body kind: %q", body.Kind)
 	}
+}
+
+// redactURL blanks any userinfo password before the request line is written to
+// the run log (net/url.Redacted keeps the username but replaces the password
+// with "xxxxx"). The URL was already validated by validateHTTPURL, so a parse
+// error here is unreachable; returning the raw string on error would leak, so
+// on the impossible error we blank the whole URL instead.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "[redacted]"
+	}
+	return u.Redacted()
+}
+
+// redactHeaderValue hides the values of headers that commonly carry
+// credentials, so request/response header dumps in the run log don't persist
+// bearer tokens, cookies, or API keys to disk (viewable over API/SSE).
+func redactHeaderValue(key, value string) string {
+	if isSensitiveHeader(key) {
+		return "[redacted]"
+	}
+	return value
+}
+
+func isSensitiveHeader(key string) bool {
+	k := strings.ToLower(key)
+	switch k {
+	case "authorization", "proxy-authorization", "cookie", "set-cookie":
+		return true
+	}
+	return strings.Contains(k, "token") || strings.Contains(k, "secret") ||
+		strings.Contains(k, "api-key") || strings.Contains(k, "apikey")
 }
 
 func (b *HTTPBackend) httpClient() *http.Client {

--- a/apps/runwisp/internal/logsearch/scan.go
+++ b/apps/runwisp/internal/logsearch/scan.go
@@ -71,9 +71,10 @@ type Cursor struct {
 // the previous page already returned. more=true means the run still has
 // unscanned bytes — the caller can resume from hits[last].N+1.
 func ScanRun(ctx context.Context, run RunRef, m Matcher, maxHits int, startAfterN int64) (hits []Hit, more bool, err error) {
-	if maxHits <= 0 {
-		maxHits = DefaultMaxHits
-	}
+	// Clamp here (not only in ScanTask) so direct callers — the cloud
+	// log-search path reaches ScanRun without going through ScanTask — cannot
+	// ask for an unbounded in-memory result set.
+	maxHits = clampMaxHits(maxHits)
 	tsMs := run.CreatedAt.UnixMilli()
 	hits = make([]Hit, 0, min(maxHits, 16))
 	err = logutil.ScanLines(ctx, run.LogPath, func(rec logutil.LogLineRecord) bool {

--- a/apps/runwisp/internal/logutil/logutil.go
+++ b/apps/runwisp/internal/logutil/logutil.go
@@ -25,7 +25,7 @@ const LogIndexInterval = 1024
 func ResolveRunLogPath(logDir, taskName, runID string, createdAt time.Time) string {
 	sanitized := model.SanitizeTaskName(taskName)
 	ts := createdAt.UTC().Format("20060102_150405")
-	suffix := runID[len(runID)-4:]
+	suffix := runID[max(0, len(runID)-4):]
 	return filepath.Join(logDir, sanitized, fmt.Sprintf("%s_%s.log", ts, suffix))
 }
 

--- a/apps/runwisp/internal/model/execution.go
+++ b/apps/runwisp/internal/model/execution.go
@@ -6,8 +6,16 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+// shellUmaskPattern mirrors config.umaskPattern. The TOML path validates umask
+// at config load; this is the matching guard for the cloud-dispatch JSON
+// boundary, which deserializes peer-supplied bytes straight into ShellExecution
+// and whose Umask/Shell values reach a shell wrapper unquoted (executor.wrapScriptUmask).
+var shellUmaskPattern = regexp.MustCompile(`^[0-7]{3,4}$`)
 
 // ExecutionDef is a sealed-type discriminant; ExecType() identifies the concrete
 // subtype for JSON deserialization. The single-method interface is intentional —
@@ -211,7 +219,28 @@ func ParseExecutionDef(data json.RawMessage) (ExecutionDef, error) {
 	if err := json.Unmarshal(data, def); err != nil {
 		return nil, fmt.Errorf("invalid %s execution: %w", envelope.Type, err)
 	}
+	if err := validateExecutionDef(def); err != nil {
+		return nil, err
+	}
 	return def, nil
+}
+
+// validateExecutionDef enforces the shell-safety invariants the executor relies
+// on for fields that are interpolated into a shell wrapper unquoted (umask) or
+// used as the interpreter path (shell). Only ShellExecution carries these; other
+// types have no equivalent unquoted surface.
+func validateExecutionDef(def ExecutionDef) error {
+	sh, ok := def.(*ShellExecution)
+	if !ok {
+		return nil
+	}
+	if sh.Umask != "" && !shellUmaskPattern.MatchString(sh.Umask) {
+		return fmt.Errorf("invalid shell umask %q: must be 3 or 4 octal digits", sh.Umask)
+	}
+	if sh.Shell != "" && !filepath.IsAbs(sh.Shell) {
+		return fmt.Errorf("invalid shell %q: must be an absolute path", sh.Shell)
+	}
+	return nil
 }
 
 // MarshalExecutionDef serializes an ExecutionDef to JSON, including the type discriminator.

--- a/apps/runwisp/internal/server/log_search.go
+++ b/apps/runwisp/internal/server/log_search.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"log/slog"
 
@@ -33,6 +34,13 @@ const (
 	// through the cursor rather than spending an unbounded scan budget on
 	// one call.
 	LogSearchRunPageSize = 50
+
+	// LogSearchTimeout caps the wall time one search request may spend
+	// scanning. Without it a low-match query keeps the scan goroutine and its
+	// I/O busy long after the HTTP write timeout has already failed the client
+	// response. Generous enough that a normal paginated page (bounded by
+	// LogSearchRunPageSize / the hit budget) never trips it.
+	LogSearchTimeout = 60 * time.Second
 )
 
 // LogSearchInput is the input to GET /api/tasks/{taskName}/log/search.
@@ -70,6 +78,9 @@ type LogSearchOutput struct {
 }
 
 func (srv *Server) humaSearchLogs(ctx context.Context, input *LogSearchInput) (*LogSearchOutput, error) {
+	ctx, cancel := context.WithTimeout(ctx, LogSearchTimeout)
+	defer cancel()
+
 	matcherFactory, err := buildMatcherFactory(input.Q, input.Regex, input.CaseSensitive)
 	if err != nil {
 		return nil, err

--- a/apps/runwisp/internal/server/runs.go
+++ b/apps/runwisp/internal/server/runs.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -298,6 +299,9 @@ func (srv *Server) humaGetRun(ctx context.Context, input *RunIDInput) (*RunOutpu
 }
 
 func (srv *Server) humaDeleteRun(ctx context.Context, input *TaskRunInput) (*struct{}, error) {
+	if err := srv.requireRunInTask(ctx, input.TaskName, input.RunID); err != nil {
+		return nil, err
+	}
 	if err := srv.runService.DeleteRun(ctx, input.RunID); err != nil {
 		return nil, mapDomainError(ctx, err, "Failed to delete run")
 	}
@@ -305,10 +309,27 @@ func (srv *Server) humaDeleteRun(ctx context.Context, input *TaskRunInput) (*str
 }
 
 func (srv *Server) humaStopRun(ctx context.Context, input *TaskRunInput) (*struct{}, error) {
+	if err := srv.requireRunInTask(ctx, input.TaskName, input.RunID); err != nil {
+		return nil, err
+	}
 	if err := srv.runService.StopRun(ctx, input.RunID); err != nil {
 		return nil, mapDomainError(ctx, err, "Failed to stop run")
 	}
 	return nil, nil
+}
+
+// requireRunInTask rejects a run that does not belong to the taskName in the
+// URL, so DELETE/POST /api/tasks/{taskName}/runs/{runId} cannot act on another
+// task's run just because the run ID is known. Mirrors the 400/404 contract the
+// per-run log endpoints use.
+func (srv *Server) requireRunInTask(ctx context.Context, taskName, runID string) error {
+	if _, err := srv.getRunForTask(ctx, taskName, runID); err != nil {
+		if errors.Is(err, errInvalidRunID) {
+			return huma.Error400BadRequest("Invalid run ID")
+		}
+		return huma.Error404NotFound("Run not found")
+	}
+	return nil
 }
 
 func (srv *Server) humaBulkDeleteRuns(ctx context.Context, input *BulkRunSelectorInput) (*BulkAffectedOutput, error) {

--- a/apps/runwisp/internal/tui/views/logsearch/view.go
+++ b/apps/runwisp/internal/tui/views/logsearch/view.go
@@ -76,7 +76,7 @@ func (m *Model) renderHits(b *strings.Builder, width int) {
 		if len(runShort) > 6 {
 			runShort = runShort[len(runShort)-6:]
 		}
-		line := fmt.Sprintf("%s  L%-6d  %s", runShort, h.N, h.Text)
+		line := fmt.Sprintf("%s  L%-6d  %s", runShort, h.N, uikit.SanitizeControls(h.Text))
 		if w := width - 6; len(line) > w {
 			line = line[:w-1] + "…"
 		}


### PR DESCRIPTION
## Summary
- Redacts `Authorization`/`Cookie`/API-key headers and URL passwords from HTTP-task run logs instead of persisting them to disk.
- Re-validates peer-supplied shell `umask`/interpreter at the cloud-dispatch JSON boundary, bounds log-search result size and the ephemeral cloud-dispatch queue, and warns loudly at startup when the control-plane connection runs over plaintext (`RUNWISP_CLOUD_ALLOW_INSECURE`).
- `DELETE`/stop run requests now require the run to belong to the task named in the URL; log search requests run under a request deadline.

## Test plan
- [x] `bun run ci` passes locally