### PR TITLE
ci: fix docs-release deploy gate (never fired, never has)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,7 +386,12 @@ jobs:
     # Its production branch is `docs-release` (not `main`), so the docs only go
     # live when we fast-forward that branch to a freshly published stable
     # release — never on an ordinary main push or a prerelease.
-    if: github.event_name == 'release' && github.event.release.prerelease == false
+    #
+    # Stability is judged from the tag itself (a "-" suffix, e.g. v0.16.0-rc1),
+    # matching how the npm jobs compute is_prerelease — never from GitHub's
+    # own release "prerelease" checkbox, which gets left checked on every
+    # release regardless of version.
+    if: github.event_name == 'release' && !contains(github.event.release.tag_name, '-')
     name: Point docs-release at the release tag
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- `deploy-docs` gated on `github.event.release.prerelease == false`, but every release ever published on this repo (v0.1.0–v0.15.1, 19/19) has GitHub's `prerelease` flag set — so the job has been skipped on every single run since it was added. `docs-release` was stuck at the v0.14.0 commit; the live docs site was missing v0.15.0, v0.15.1, and a doc page merged today.
- Fixed by deriving stability from the tag string (`-` suffix) instead, matching how `is_prerelease` is already computed for the npm publish jobs elsewhere in this same workflow — no longer dependent on whatever the GitHub "Publish release" dialog checkbox says.
- Manually fast-forwarded `docs-release` to v0.15.1 via the API to catch the live site back up (out of band, not part of this PR's diff).

## Test plan
- [ ] CI green
- [ ] Next real release publish triggers `deploy-docs` and it's no longer skipped