### PR TITLE
ci: ship the repo README on the npm package page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,6 +341,12 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
           sparse-checkout: npm/runwisp
 
+      # Ship the repo README as the package's npm page. Relative image paths
+      # resolve against the repo root because package.json sets no repository
+      # `directory`, so npm rewrites them to raw.githubusercontent at root.
+      - name: Use repo README for the npm page
+        run: cp README.md npm/runwisp/README.md
+
       - uses: actions/setup-node@v6
         with:
           node-version: "24"


### PR DESCRIPTION
## Summary
- `npm/runwisp` had no README, so the npmjs.com package page rendered blank.
- Copy the repo `README.md` into `npm/runwisp/` during the publish job, right after the sparse checkout.

## Test plan
- [ ] Confirmed all relative links/images in `README.md` (LICENSE, CHANGELOG.md, CONTRIBUTING.md, SECURITY.md, screenshot images) are repo-root relative, matching `npm/runwisp/package.json`'s lack of a `repository.directory`, so npm's README renderer resolves them correctly.
- [ ] Next release publish to npm will carry the README — verify the rendered page on npmjs.com/package/runwisp after the next release.