### PR TITLE
Fail fast when no runwisp.toml in non-interactive TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Outbound notification channels (Slack, Telegram) send periodic check-ins during a sustained incident** on the default `keep_occurrences` cadence. See [Notification model](https://docs.runwisp.com/notifications/model/).
 - **`storage.max_size` enforcement accounts for rotated log segments** when trimming run history to the configured cap. See [Storage](https://docs.runwisp.com/configuration/storage/).
 - **Starting the daemon no longer reprints the startup log a second time after a successful start.** The log was already streamed live during startup; only a failed or timed-out start now prints the tail for diagnosis.
+- **Running `runwisp` with no `runwisp.toml` in the current directory now fails immediately with a clear error**, instead of hanging for the full 10-second startup timeout before reporting a generic "health check timed out". See [Configuration](https://docs.runwisp.com/configuration/overview/).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Outbound notification channels (Slack, Telegram) send periodic check-ins during a sustained incident** on the default `keep_occurrences` cadence. See [Notification model](https://docs.runwisp.com/notifications/model/).
 - **`storage.max_size` enforcement accounts for rotated log segments** when trimming run history to the configured cap. See [Storage](https://docs.runwisp.com/configuration/storage/).
 - **Starting the daemon no longer reprints the startup log a second time after a successful start.** The log was already streamed live during startup; only a failed or timed-out start now prints the tail for diagnosis.
-- **Running `runwisp` with no `runwisp.toml` in the current directory now fails immediately with a clear error**, instead of hanging for the full 10-second startup timeout before reporting a generic "health check timed out". See [Configuration](https://docs.runwisp.com/configuration/overview/).
+- **Running `runwisp` with no `runwisp.toml` in the current directory now fails immediately with a clear error**.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Outbound notification channels (Slack, Telegram) send periodic check-ins during a sustained incident** on the default `keep_occurrences` cadence. See [Notification model](https://docs.runwisp.com/notifications/model/).
 - **`storage.max_size` enforcement accounts for rotated log segments** when trimming run history to the configured cap. See [Storage](https://docs.runwisp.com/configuration/storage/).
 - **Starting the daemon no longer reprints the startup log a second time after a successful start.** The log was already streamed live during startup; only a failed or timed-out start now prints the tail for diagnosis.
-- **Running `runwisp` with no `runwisp.toml` in the current directory now fails immediately with a clear error**.
+- **Running `runwisp` non-interactively with no `runwisp.toml` in the current directory now fails immediately with a clear error**.
 
 ### Security
 

--- a/apps/runwisp/cmd/runwisp/cli_errors.go
+++ b/apps/runwisp/cmd/runwisp/cli_errors.go
@@ -268,6 +268,21 @@ func remoteAPITriggerDisabledError(taskName string) error {
 	}
 }
 
+// noConfigError is returned when the daemon can't find runwisp.toml and isn't
+// running under `runwisp cloud` (which tolerates an absent config and relies
+// on ad-hoc dispatch instead). It never substitutes a fallback config — a
+// missing file that silently ran something else would hide the operator's
+// actual mistake, so the daemon fails loudly and points at the two ways
+// forward: write one, or explore without one via the explicit demo command.
+func noConfigError(path string) error {
+	return &userFacingError{
+		title: fmt.Sprintf("no runwisp.toml found at %s", configLocation(path)),
+		details: "Create one to define your tasks:\n" +
+			"  - See https://docs.runwisp.com/configuration/overview/ for the format\n" +
+			"  - Or run `runwisp demo` to explore a fully-populated instance without writing one",
+	}
+}
+
 // authRateLimitedError is returned when the daemon's auth rate limiter
 // rejects our login attempt. The window and limit are exported constants in
 // the server package, but we avoid importing them here to keep this file

--- a/apps/runwisp/cmd/runwisp/daemon_config.go
+++ b/apps/runwisp/cmd/runwisp/daemon_config.go
@@ -213,5 +213,5 @@ func loadConfigFile(path string, cloudEnabled bool) (*config.Config, bool, error
 		return cfg, false, nil
 	}
 
-	return nil, false, fmt.Errorf("no runwisp.toml found at %s — create one to define your tasks (docs: https://docs.runwisp.com/configuration/overview/)", path)
+	return nil, false, noConfigError(path)
 }

--- a/apps/runwisp/cmd/runwisp/daemon_config_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_config_test.go
@@ -39,6 +39,13 @@ func TestLoadConfigFile_MissingWithoutCloudErrors(t *testing.T) {
 	_, _, err := loadConfigFile("/this/does/not/exist/runwisp.toml", false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no runwisp.toml")
+
+	// It never silently swaps in a fallback config — the operator gets a
+	// userFacingError naming both ways forward instead.
+	ufe, ok := isUserFacing(err)
+	require.True(t, ok, "expected a *userFacingError")
+	assert.Contains(t, ufe.details, "runwisp demo")
+	assert.Contains(t, ufe.details, "docs.runwisp.com")
 }
 
 // loadDaemonConfig integrates loadConfigFile + fingerprint resolution +

--- a/apps/runwisp/cmd/runwisp/daemon_spawn.go
+++ b/apps/runwisp/cmd/runwisp/daemon_spawn.go
@@ -209,6 +209,14 @@ type daemonLogDrainer struct {
 	reader *bufio.Reader
 }
 
+// drain reads every newly-appended line, echoing non-fatal ones to stderr live
+// so a slow-but-healthy startup shows real progress. Once a fatal line is
+// found, echoing stops and every remaining line already on disk is folded
+// into fatalMsg instead — the CLI error renderer writes its title followed by
+// blank-line-separated bullet details in one burst, and by the time this
+// polls, a daemon that died that fast has already flushed all of it. The
+// caller re-renders fatalMsg as the one polished error box; echoing the same
+// lines raw first would just print the failure twice.
 func (d *daemonLogDrainer) drain() (fatalMsg string, fatal bool) {
 	if d.reader == nil {
 		f, err := os.Open(d.path)
@@ -218,18 +226,28 @@ func (d *daemonLogDrainer) drain() (fatalMsg string, fatal bool) {
 		d.file = f
 		d.reader = bufio.NewReader(f)
 	}
+	var fatalLines []string
 	for {
 		line, err := d.reader.ReadString('\n')
 		if line != "" {
 			line = strings.TrimRight(line, "\n\r")
-			fmt.Fprintf(os.Stderr, "  %s\n", line)
-			if msg, isFatal := classifyDaemonLogLine(line); isFatal {
-				return msg, true
+			switch {
+			case fatalLines != nil:
+				fatalLines = append(fatalLines, line)
+			default:
+				if msg, isFatal := classifyDaemonLogLine(line); isFatal {
+					fatalLines = []string{msg}
+				} else {
+					fmt.Fprintf(os.Stderr, "  %s\n", line)
+				}
 			}
 		}
 		if err != nil {
 			// Reset so next drain picks up writes appended after EOF.
 			d.reader.Reset(d.file)
+			if fatalLines != nil {
+				return strings.Join(fatalLines, "\n"), true
+			}
 			return "", false
 		}
 	}
@@ -333,6 +351,20 @@ func classifyDaemonLogLine(line string) (string, bool) {
 		strings.Contains(line, "Server failed"),
 		strings.Contains(line, "address already in use"),
 		strings.Contains(line, "bind: permission denied"):
+		return line, true
+	// handleCLIError/renderError print an unbracketed "ERROR" badge right
+	// before the process exits on any fatal top-level command error (missing
+	// config, bad TLS cert, ...) — unlike slog's routine "[ERROR]" lines, which
+	// don't mean the process is dying. Catching it generically here lets
+	// waitForDaemonLoop report the real cause immediately instead of waiting
+	// out the full health-check timeout. The badge itself is stripped: the
+	// caller wraps this message in its own "daemon failed to start" error,
+	// which then goes through the same renderer and would otherwise print two
+	// "ERROR" badges back to back.
+	case strings.Contains(line, "ERROR") && !strings.Contains(line, "[ERROR]"):
+		if _, title, ok := strings.Cut(line, "ERROR"); ok {
+			return strings.TrimSpace(title), true
+		}
 		return line, true
 	}
 	return "", false

--- a/apps/runwisp/cmd/runwisp/daemon_spawn.go
+++ b/apps/runwisp/cmd/runwisp/daemon_spawn.go
@@ -230,17 +230,7 @@ func (d *daemonLogDrainer) drain() (fatalMsg string, fatal bool) {
 	for {
 		line, err := d.reader.ReadString('\n')
 		if line != "" {
-			line = strings.TrimRight(line, "\n\r")
-			switch {
-			case fatalLines != nil:
-				fatalLines = append(fatalLines, line)
-			default:
-				if msg, isFatal := classifyDaemonLogLine(line); isFatal {
-					fatalLines = []string{msg}
-				} else {
-					fmt.Fprintf(os.Stderr, "  %s\n", line)
-				}
-			}
+			fatalLines = d.handleLine(strings.TrimRight(line, "\n\r"), fatalLines)
 		}
 		if err != nil {
 			// Reset so next drain picks up writes appended after EOF.
@@ -251,6 +241,19 @@ func (d *daemonLogDrainer) drain() (fatalMsg string, fatal bool) {
 			return "", false
 		}
 	}
+}
+
+// handleLine echoes a non-fatal line live, or — once a fatal line has been
+// seen — folds it into fatalLines instead (see drain's doc comment for why).
+func (d *daemonLogDrainer) handleLine(line string, fatalLines []string) []string {
+	if fatalLines != nil {
+		return append(fatalLines, line)
+	}
+	if msg, isFatal := classifyDaemonLogLine(line); isFatal {
+		return []string{msg}
+	}
+	fmt.Fprintf(os.Stderr, "  %s\n", line)
+	return fatalLines
 }
 
 func (d *daemonLogDrainer) close() {

--- a/apps/runwisp/cmd/runwisp/daemon_spawn_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_spawn_test.go
@@ -33,6 +33,13 @@ func TestClassifyDaemonLogLine(t *testing.T) {
 		{"bind_perm_denied", "bind: permission denied", true, "bind: permission denied"},
 		{"benign_info", "INFO: daemon listening on :9477", false, ""},
 		{"empty", "", false, ""},
+		{
+			"cli_error_badge",
+			" ERROR  no runwisp.toml found at /tmp/x — create one to define your tasks",
+			true,
+			"no runwisp.toml found at /tmp/x — create one to define your tasks",
+		},
+		{"routine_slog_error_bracket", "[ERROR] notify delivery failed, retrying", false, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -220,6 +227,43 @@ func TestWaitForDaemonLoop_ReturnsFatalFromLog(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Fatal error")
 	assert.False(t, timedOut)
+}
+
+// TestWaitForDaemonLoop_ReturnsFatalFromRenderedCLIErrorBadge reproduces the
+// real daemon.log content a spawned `runwisp daemon` writes when
+// loadDaemonConfig fails (e.g. no runwisp.toml): fang's handleCLIError renders
+// an unbracketed "ERROR" badge and the process exits immediately. Before
+// classifyDaemonLogLine recognized that badge, this fell through to the full
+// health-check timeout instead of surfacing the real cause right away.
+func TestWaitForDaemonLoop_ReturnsFatalFromRenderedCLIErrorBadge(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "daemon.log")
+	rendered := " ERROR  no runwisp.toml found at " + dir + "\n\n" +
+		"Create one to define your tasks:\n" +
+		"  • See https://docs.runwisp.com/configuration/overview/ for the format\n" +
+		"  • Or run `runwisp demo` to explore a fully-populated instance without writing one\n"
+	require.NoError(t, os.WriteFile(logPath, []byte(rendered), 0o600))
+	drainer := &daemonLogDrainer{path: logPath}
+	defer drainer.close()
+
+	pidPath := filepath.Join(dir, "daemon.pid")
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	client := apiclient.New("http://127.0.0.1:1", "")
+	start := time.Now()
+	err, timedOut := waitForDaemonLoop(client, drainer, pidPath, time.Now().Add(10*time.Second), ticker, dir)
+	require.Error(t, err)
+	// The badge is stripped (the caller re-renders through the same "ERROR"
+	// badge machinery, so keeping it would print two badges back to back),
+	// but the rest of the operator's guidance survives intact.
+	assert.NotContains(t, err.Error(), "ERROR")
+	assert.Contains(t, err.Error(), "no runwisp.toml found at "+dir)
+	assert.Contains(t, err.Error(), "runwisp demo")
+	assert.False(t, timedOut)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("expected a fast fail, took %v", elapsed)
+	}
 }
 
 func TestWaitForDaemonLoop_TimesOut(t *testing.T) {

--- a/apps/runwisp/cmd/runwisp/firstrun.go
+++ b/apps/runwisp/cmd/runwisp/firstrun.go
@@ -23,8 +23,11 @@ import (
 // scaffoldIfMissing checks for a runwisp.toml at f.CfgFile. If it is absent and
 // stdin is attached to a terminal, prompts the operator to create a starter
 // config and writes one on confirmation. Non-TTY callers (background daemon,
-// systemd, Docker) are a no-op — the daemon falls back to the built-in demo
-// task and emits a warning.
+// systemd, Docker) are a no-op — the daemon then fails fast with noConfigError,
+// which points at writing a config or running `runwisp demo` instead. It never
+// substitutes a fallback config on its own: doing so headless would hide a
+// misconfiguration (e.g. a wrong Docker volume mount) behind a daemon that
+// looks like it started fine.
 //
 // installed reports that the first run also installed and started the system
 // service (the cron cutover), so the caller must attach to that daemon rather


### PR DESCRIPTION
## Summary
- A headless daemon with no `runwisp.toml` now exits immediately with a clear error pointing at the docs and `runwisp demo`, instead of silently falling back to a demo config.
- The CLI's daemon-spawn log drainer recognizes fang's rendered `ERROR` badge as fatal, so `runwisp` surfaces that failure right away instead of waiting out the full 10-second health-check timeout — this is what made `npx`-style first runs with no config in the cwd appear to hang.

## Test plan
- [x] `go test ./cmd/runwisp/...` (new cases: `TestLoadConfigFile_MissingWithoutCloudErrors`, `TestClassifyDaemonLogLine/cli_error_badge`, `TestWaitForDaemonLoop_ReturnsFatalFromRenderedCLIErrorBadge`)
- [x] `gofmt -l` clean on touched files
- [ ] CI