### PR TITLE
Fix daemon locking, log rotation reads, cron dow bug, and several shutdown/data races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,18 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The config JSON Schema for `stop_signal` now accepts the short forms** (`TERM`, `INT`, `KILL`, ...) the daemon already did, so editor validation stops flagging configs that were always valid.
 - **The unread notification badge now updates across other open tabs/sessions** when a mutation (e.g. mark-all-read) changes the count without shipping a notification.
 - **`POST /api/tasks/{taskName}/run?wait=true`'s `waitTimeout` is now capped at 240s (default 120s, down from 3600s/300s)**, so a long wait can no longer outlive the server's 5-minute write timeout and drop the response after the run had already finished.
-- **Sorting runs by duration (`sortField=duration`) now actually sorts by duration** instead of leaving every row at a fallback of zero.
-- **Two `runwisp daemon` processes started against the same data dir can no longer both proceed** — ownership is now claimed with an atomic OS-level lock instead of a read-then-write PID file.
+- **Sorting runs by duration (`sortField=duration`) returns them in the correct order** instead of a fallback that treated every run's duration as zero.
+- **Two `runwisp daemon` processes started against the same data dir can no longer both proceed** — ownership is now claimed atomically instead of via a racy PID-file check.
 - **A cron day-of-week field using a bare `7` with a step (e.g. `7/2`) now always means Sunday alone**, instead of the step wrapping into other days.
 - **Daemon shutdown no longer hangs on an unresponsive Docker/Podman engine** during container or compose task cleanup.
 - **A run's log output from just before a rotation is no longer deleted the instant the run ends** — it stays available until the run itself is purged by retention.
 - **Viewing log lines from before a run's most recent log rotation now returns their actual content** instead of coming back empty.
 - **The unread notification count no longer drifts out of sync** — it's taken directly from the server on every event instead of computed from local deltas.
 - **A failed log fetch now shows as an error in the log viewer** instead of silently rendering as if the run produced no output.
-- **Logging out mid-session now stops the daemon's SSE streams immediately** instead of letting them keep applying pushed updates underneath the login screen.
-- **Reloading a task away from `on_overlap = "queue"` no longer leaves its queued runs stuck forever** with a leaked drain goroutine.
+- **Logging out mid-session now disconnects the live event stream immediately** instead of letting it keep applying pushed updates behind the login screen.
+- **Reloading a task away from `on_overlap = "queue"` no longer leaves its already-queued runs stuck pending forever.**
 - **The daemon's identity fingerprint no longer changes when the binary is moved or the hostname changes** — only the machine ID and working directory are hashed.
-- **Notify channel shutdown is safer**: closing a coalescing channel no longer races its in-flight window-close summary, a panicking channel no longer takes down the dispatcher, and redacted delivery errors keep their underlying type so shutdown can still recognize `context.Canceled`.
 
 ### Security
 
@@ -42,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Control-plane dispatch is validated and bounded at the boundary** — peer-supplied shell `umask`/interpreter are re-validated, log-search size and the ephemeral dispatch queue are capped, and running the control-plane connection over plaintext (`RUNWISP_CLOUD_ALLOW_INSECURE`) now warns loudly at startup.
 - **`allow_cloud_dispatch` now also gates HTTP-type ad-hoc dispatch and cloud-created services**, not just shell/container/compose — HTTP still makes a peer-directed network call, so it's no longer exempt from the opt-in.
 - **Log search runs under a request deadline.** Internal safeguard with no configuration changes.
+- **A shutdown race and a panic risk in the notification retry/coalescing path are fixed.** Internal safeguard with no configuration changes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Running `runwisp` non-interactively with no `runwisp.toml` in the current directory now fails immediately with a clear error**.
 - **The config JSON Schema for `stop_signal` now accepts the short forms** (`TERM`, `INT`, `KILL`, ...) the daemon already did, so editor validation stops flagging configs that were always valid.
 - **The unread notification badge now updates across other open tabs/sessions** when a mutation (e.g. mark-all-read) changes the count without shipping a notification.
+- **`POST /api/tasks/{taskName}/run?wait=true`'s `waitTimeout` is now capped at 240s (default 120s, down from 3600s/300s)**, so a long wait can no longer outlive the server's 5-minute write timeout and drop the response after the run had already finished.
+- **Sorting runs by duration (`sortField=duration`) now actually sorts by duration** instead of leaving every row at a fallback of zero.
+- **Two `runwisp daemon` processes started against the same data dir can no longer both proceed** — ownership is now claimed with an atomic OS-level lock instead of a read-then-write PID file.
+- **A cron day-of-week field using a bare `7` with a step (e.g. `7/2`) now always means Sunday alone**, instead of the step wrapping into other days.
+- **Daemon shutdown no longer hangs on an unresponsive Docker/Podman engine** during container or compose task cleanup.
+- **A run's log output from just before a rotation is no longer deleted the instant the run ends** — it stays available until the run itself is purged by retention.
+- **Viewing log lines from before a run's most recent log rotation now returns their actual content** instead of coming back empty.
+- **The unread notification count no longer drifts out of sync** — it's taken directly from the server on every event instead of computed from local deltas.
+- **A failed log fetch now shows as an error in the log viewer** instead of silently rendering as if the run produced no output.
+- **Logging out mid-session now stops the daemon's SSE streams immediately** instead of letting them keep applying pushed updates underneath the login screen.
+- **Reloading a task away from `on_overlap = "queue"` no longer leaves its queued runs stuck forever** with a leaked drain goroutine.
+- **The daemon's identity fingerprint no longer changes when the binary is moved or the hostname changes** — only the machine ID and working directory are hashed.
+- **Notify channel shutdown is safer**: closing a coalescing channel no longer races its in-flight window-close summary, a panicking channel no longer takes down the dispatcher, and redacted delivery errors keep their underlying type so shutdown can still recognize `context.Canceled`.
 
 ### Security
 
 - **Hardened `service install` unit generation, task-process environment isolation, config-file trust checks, privilege dropping, and outbound-request address filtering.** Internal safeguards with no configuration changes.
 - **HTTP-task run logs redact request/response credentials** — `Authorization`, `Cookie`, API-key headers, and URL passwords are shown as `[redacted]` instead of being persisted to disk.
 - **Control-plane dispatch is validated and bounded at the boundary** — peer-supplied shell `umask`/interpreter are re-validated, log-search size and the ephemeral dispatch queue are capped, and running the control-plane connection over plaintext (`RUNWISP_CLOUD_ALLOW_INSECURE`) now warns loudly at startup.
+- **`allow_cloud_dispatch` now also gates HTTP-type ad-hoc dispatch and cloud-created services**, not just shell/container/compose — HTTP still makes a peer-directed network call, so it's no longer exempt from the opt-in.
 - **Log search runs under a request deadline.** Internal safeguard with no configuration changes.
 
 ### Changed

--- a/apps/docs/src/content/docs/concepts/logs.mdx
+++ b/apps/docs/src/content/docs/concepts/logs.mdx
@@ -281,8 +281,10 @@ history is safe to lose, so a `kill -9`, a rotation, or a torn write
 never costs you any committed output — the durable `.log` is untouched.
 A short run that never drew a progress bar just gets a tiny container
 holding its final metadata. (While a log is mid-rotation you may also
-briefly see a hidden `.<name>.log.prev` — the rotated-away chunk —
-which is cleaned up when the run ends.)
+briefly see a hidden `.<name>.log.prev` — the rotated-away chunk. It
+sticks around after the run ends too, same as the `.log` and its
+container, so the download and viewer can still stitch it back in —
+retention cleans it up along with the rest of the run.)
 
 ## Crash safety
 

--- a/apps/docs/src/content/docs/recipes/remote-trigger.mdx
+++ b/apps/docs/src/content/docs/recipes/remote-trigger.mdx
@@ -136,8 +136,8 @@ run.
         #### Long-running tasks: trigger, then poll
 
         `wait=true` blocks for up to `wait_timeout` seconds (default
-        `300`); if the run hasn't finished by then the call returns it
-        still `running` rather than hanging forever. For tasks that
+        `120`, capped at `240`); if the run hasn't finished by then the
+        call returns it still `running` rather than hanging forever. For tasks that
         outlast a sensible HTTP timeout — yours or your reverse
         proxy's — skip `wait`, take the run `id` the trigger returns,
         and poll it on your own schedule:

--- a/apps/runwisp/cmd/runwisp/cmd_daemon_run.go
+++ b/apps/runwisp/cmd/runwisp/cmd_daemon_run.go
@@ -77,12 +77,17 @@ func runDaemon(mode daemonMode, f Flags, headless bool) (err error) {
 		defer rerouteLogsToStderrOnError(&err)
 	}
 
-	// Refuse to boot if another daemon already owns this data dir. Two daemons
-	// on one data dir clobber the shared PID file (orphaning the first) and open
-	// the same SQLite database, so fail hard before touching any state.
-	if err := ensureNoRunningDaemon(f); err != nil {
+	// Atomically claim ownership of the data dir via an OS-level flock before
+	// touching any state. A read-then-write PID file leaves a window where two
+	// racing `runwisp daemon` processes both pass the check and both start
+	// executing tasks; the flock held here for the rest of the process's life
+	// makes that impossible, and the kernel releases it the instant the
+	// process dies (including SIGKILL) with no stale-PID heuristic needed.
+	lock, err := datadir.AcquireDaemonLock(f.DataDir)
+	if err != nil {
 		return err
 	}
+	defer lock.Release()
 
 	// Open database first — config values (fingerprint, jwt_secret) live there.
 	db, err := storage.New(f.DBPath())
@@ -121,11 +126,6 @@ func runDaemon(mode daemonMode, f Flags, headless bool) (err error) {
 		return err
 	}
 	defer svc.DB.Close()
-
-	if pidErr := datadir.WritePidFile(f.DataDir); pidErr != nil {
-		return fmt.Errorf("write PID file: %w", pidErr)
-	}
-	defer datadir.CleanPidFile(f.DataDir)
 
 	daemonInfo := buildDaemonInfo(cfg, svc, configSnap.LoadedAt(), f.Port)
 

--- a/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
+++ b/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
@@ -61,10 +61,15 @@ func startCloudClient(
 	}
 
 	if cloudClient != nil {
-		cloudClient.RecoverArchiveBacklog(cloudCtx)
 		cloudWG.Add(1)
 		go func() {
 			defer cloudWG.Done()
+			// Backlog recovery does real HTTP PUTs (up to 90s each) against the
+			// cloud peer; running it here (not before srv.Start) means a slow or
+			// unreachable peer can never delay the UI/API from becoming
+			// available. cloudCtx cancellation (on shutdown) unblocks it the same
+			// way it unblocks Run below.
+			cloudClient.RecoverArchiveBacklog(cloudCtx)
 			if runErr := cloudClient.Run(cloudCtx); runErr != nil {
 				slog.Error("Cloud integration stopped", "err", runErr)
 			}

--- a/apps/runwisp/cmd/runwisp/daemon_services_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_services_test.go
@@ -76,8 +76,9 @@ func TestInitExecutor_BuildsExecutorWithEventBus(t *testing.T) {
 	exec := initExecutor(cfg, bus, f.LogDir(), "")
 	require.NotNil(t, exec)
 	avail := exec.Availability()
-	// HTTP is always available; Config flips on with at least one local task.
-	assert.True(t, avail.HTTP.Available)
+	// HTTP requires the allow_cloud_dispatch opt-in (not set here); Config flips
+	// on with at least one local task regardless of the opt-in.
+	assert.False(t, avail.HTTP.Available)
 	assert.True(t, avail.Config.Available)
 }
 

--- a/apps/runwisp/internal/cloud/dispatch_resolver_test.go
+++ b/apps/runwisp/internal/cloud/dispatch_resolver_test.go
@@ -267,10 +267,33 @@ func TestResolveDispatchTask_ContainerInlineUpsertedWhenEnabled(t *testing.T) {
 	assert.Len(t, runner.upserted, 1)
 }
 
-// TestResolveDispatchTask_HTTPAllowedWithoutDispatch confirms the whitelist:
-// HTTP dispatch is permitted even with the dispatch opt-in off, since it runs no
-// peer-supplied local code.
-func TestResolveDispatchTask_HTTPAllowedWithoutDispatch(t *testing.T) {
+// TestResolveDispatchTask_HTTPRejectedWithoutDispatch confirms HTTP-type
+// dispatch is gated by allow_cloud_dispatch like shell/container/compose: it
+// still makes a peer-directed network call, so it's not exempt from the opt-in.
+func TestResolveDispatchTask_HTTPRejectedWithoutDispatch(t *testing.T) {
+	avail := executor.Availability{
+		HTTP: executor.BackendStatus{Available: false, Reason: "cloud dispatch disabled (set [daemon] allow_cloud_dispatch = true to enable)"},
+	}
+	runner := &fakeTaskRunner{tasks: make(map[string]*model.Task)}
+	h := &InboundHandler{
+		taskManager:     runner,
+		logDir:          "/tmp",
+		availability:    avail,
+		queueExecUpdate: func(protocol.ExecutionUpdateMessage) {},
+		logListeners:    make(map[string]struct{}),
+	}
+
+	_, _, err := h.resolveDispatchTask(&protocol.Execution{TaskID: "probe", Script: httpScript(t, "https://example.com")})
+	require.Error(t, err)
+	var ce *CloudError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, CloudErrorKindConflict, ce.Kind)
+	assert.Empty(t, runner.upserted, "rejected dispatch must not upsert a task")
+}
+
+// TestResolveDispatchTask_HTTPAllowedWithDispatch confirms HTTP-type dispatch
+// succeeds once the operator opts in via allow_cloud_dispatch.
+func TestResolveDispatchTask_HTTPAllowedWithDispatch(t *testing.T) {
 	avail := executor.Availability{
 		HTTP: executor.BackendStatus{Available: true},
 	}
@@ -293,8 +316,9 @@ func TestResolveDispatchTask_HTTPAllowedWithoutDispatch(t *testing.T) {
 // rest of the name and can aim an inline dispatch at a locally-defined task
 // called cloud-*. Upserting over it would replace a disk-defined task's
 // execution — and the ephemeral reaper would then delete the task outright — so
-// the collision must be rejected. http is reachable with allow_cloud_dispatch
-// off, so this is not gated by the availability check above.
+// the collision must be rejected. This test uses an HTTP dispatch with
+// availability granted, so the rejection below is the name-collision guard, not
+// the availability check exercised above.
 func TestResolveDispatchTask_RejectsConfigTaskNameCollision(t *testing.T) {
 	origExec := &model.ShellExecution{Script: "sync.sh"}
 	local := &model.Task{Name: "cloud-sync", Kind: model.KindTask, Cron: "* * * * *", ExecutionDef: origExec}

--- a/apps/runwisp/internal/cloud/service_handler_test.go
+++ b/apps/runwisp/internal/cloud/service_handler_test.go
@@ -86,6 +86,38 @@ func TestHandleServiceApply_UnavailableBackendRejected(t *testing.T) {
 	assert.Equal(t, CloudErrorKindConflict, ce.Kind)
 }
 
+// TestHandleServiceApply_HTTPRejectedWithoutDispatch confirms an HTTP-type
+// cloud-created service is gated by allow_cloud_dispatch just like
+// shell/container/compose: HTTP still makes a peer-directed network call and a
+// persistent auto-restarting service, so it is not exempt from the opt-in.
+func TestHandleServiceApply_HTTPRejectedWithoutDispatch(t *testing.T) {
+	avail := executor.Availability{
+		HTTP: executor.BackendStatus{Available: false, Reason: "cloud dispatch disabled (set [daemon] allow_cloud_dispatch = true to enable)"},
+	}
+	h := newDispatchHandler(avail, nil)
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{TaskID: "svc-http", TaskName: "svc-http", Script: httpScript(t, "https://example.com"), Instances: 1},
+	})
+	require.Error(t, err)
+	var ce *CloudError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, CloudErrorKindConflict, ce.Kind)
+}
+
+// TestHandleServiceApply_HTTPAllowedWithDispatch confirms HTTP-type service
+// creation succeeds once the operator opts in via allow_cloud_dispatch.
+func TestHandleServiceApply_HTTPAllowedWithDispatch(t *testing.T) {
+	h := newDispatchHandler(executor.Availability{HTTP: executor.BackendStatus{Available: true}}, nil)
+	runner := h.taskManager.(*fakeTaskRunner)
+
+	err := h.HandleServiceApply(protocol.ServiceApplyMessage{
+		Service: &protocol.Service{TaskID: "svc-http", TaskName: "svc-http", Script: httpScript(t, "https://example.com"), Instances: 1},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.upserted, 1)
+	assert.Equal(t, model.KindService, runner.upserted[0].Kind)
+}
+
 func TestHandleServiceApply_MissingServiceRejected(t *testing.T) {
 	h := newDispatchHandler(shellAvailable(), nil)
 	err := h.HandleServiceApply(protocol.ServiceApplyMessage{})

--- a/apps/runwisp/internal/cronspec/cronspec.go
+++ b/apps/runwisp/internal/cronspec/cronspec.go
@@ -207,9 +207,16 @@ func dowField(field string) string {
 func dowTerm(term string) string {
 	base, step, hasStep := strings.Cut(term, "/")
 	lo, hi, isRange := strings.Cut(base, "-")
-	if (!isRange && base == "7") || (isRange && lo == "7" && hi != "7") {
-		// A bare 7, a 7 with a step, or a range starting at 7: the value is Sunday,
-		// so 0 says the same thing in robfig's bounds.
+	if !isRange && base == "7" {
+		// Bare 7 is Sunday, and 7 is already vixie's own max for this field, so no
+		// attached step can ever add a value beyond Sunday itself — drop it rather
+		// than pass it through to robfig, whose max of 6 would make "0/N" wrap
+		// around into other days.
+		return "0"
+	}
+	if isRange && lo == "7" && hi != "7" {
+		// A range starting at 7: the value is Sunday, so 0 says the same thing in
+		// robfig's bounds.
 		return "0" + term[1:]
 	}
 	if !isRange || hi != "7" {

--- a/apps/runwisp/internal/cronspec/cronspec_test.go
+++ b/apps/runwisp/internal/cronspec/cronspec_test.go
@@ -75,6 +75,12 @@ func TestSundayIsSeven(t *testing.T) {
 		{name: "range 1-7 is every day", spec: "0 3 * * 1-7", equiv: "0 3 * * *"},
 		{name: "range 0-7 is every day", spec: "0 3 * * 0-7", equiv: "0 3 * * *"},
 		{name: "range with a step", spec: "0 3 * * 5-7/2", equiv: "0 3 * * 0,5"},
+		// A bare 7 is already vixie's field max, so no step can ever add a value
+		// beyond Sunday itself — this must resolve to Sunday only, not wrap around
+		// into other days under robfig's 0-6 bounds.
+		{name: "bare 7 with a step", spec: "0 3 * * 7/2", equiv: "0 3 * * 0"},
+		{name: "bare 7 with a step of 1", spec: "0 3 * * 7/1", equiv: "0 3 * * 0"},
+		{name: "list with a stepped 7", spec: "0 3 * * 1,7/3", equiv: "0 3 * * 0,1"},
 		{name: "six-field form", spec: "30 47 6 * * 7", equiv: "30 47 6 * * 0"},
 		{name: "with a CRON_TZ prefix", spec: "CRON_TZ=UTC 47 6 * * 7", equiv: "CRON_TZ=UTC 47 6 * * 0"},
 		// The rewrite must not reach any other field, nor a step of 7.

--- a/apps/runwisp/internal/datadir/datadir.go
+++ b/apps/runwisp/internal/datadir/datadir.go
@@ -38,14 +38,7 @@ func EnsureDir(dir string) error {
 // the shared primitive for any secret-bearing file (PID file, daemon secrets,
 // the CLI's cached JWT); callers must EnsureDir the parent first.
 func WriteSecretFile(path string, data []byte) error {
-	if info, err := os.Lstat(path); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to write %s: path is a symlink", path)
-		}
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("refusing to write %s: not a regular file", path)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
+	if err := checkSecretFileTarget(path); err != nil {
 		return err
 	}
 
@@ -59,6 +52,30 @@ func WriteSecretFile(path string, data []byte) error {
 		return err
 	}
 	return f.Close()
+}
+
+// checkSecretFileTarget refuses a path that isn't safe to open for a secret
+// write: a symlink (TOCTOU risk), a non-regular file, or an existing regular
+// file owned by a different user. Shared by WriteSecretFile and
+// AcquireDaemonLock, which both open PidFilePath under the same threat model.
+func checkSecretFileTarget(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write %s: path is a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("refusing to write %s: not a regular file", path)
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && int(stat.Uid) != os.Geteuid() {
+		return fmt.Errorf("refusing to write %s: owned by a different user", path)
+	}
+	return nil
 }
 
 // RandBase62 returns a cryptographically random base62 string of n characters.
@@ -118,6 +135,72 @@ func CleanPidFile(dataDir string) {
 	}
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		slog.Warn("Failed to remove PID file", "err", err)
+	}
+}
+
+// DaemonLock is the held ownership claim returned by AcquireDaemonLock. The
+// zero value is not usable; obtain one only via AcquireDaemonLock.
+type DaemonLock struct {
+	f *os.File
+}
+
+// AcquireDaemonLock atomically claims ownership of dataDir's PID file using an
+// OS-level advisory lock (flock), so two `runwisp daemon` processes racing on
+// the same data dir can never both proceed past this call. Unlike a
+// read-then-write PID file, the lock is held for the caller's entire lifetime
+// and is automatically released by the kernel if the process dies (including
+// SIGKILL) — so a crashed daemon's "ownership" disappears the instant the
+// process exits, with no separate stale-PID heuristic needed.
+func AcquireDaemonLock(dataDir string) (*DaemonLock, error) {
+	path := PidFilePath(dataDir)
+	if err := checkSecretFileTarget(path); err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|syscall.O_NOFOLLOW, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		existingPid := "unknown"
+		if pid, readErr := ReadPidFile(dataDir); readErr == nil {
+			existingPid = strconv.Itoa(pid)
+		}
+		_ = f.Close()
+		return nil, fmt.Errorf("a RunWisp daemon is already running for data dir %q (pid %s); stop it first", dataDir, existingPid)
+	}
+
+	if err := f.Truncate(0); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, err
+	}
+	if _, err := f.WriteString(strconv.Itoa(os.Getpid()) + "\n"); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, err
+	}
+
+	return &DaemonLock{f: f}, nil
+}
+
+// Release unlocks and removes the PID file, then closes the fd. Safe to
+// always remove: holding the lock while removing means no other process can
+// be treating this file as live in the meantime. Best-effort, mirroring
+// CleanPidFile: unexpected failures are logged via slog.Warn, never panicked.
+func (l *DaemonLock) Release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	if err := syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN); err != nil {
+		slog.Warn("Failed to release daemon lock", "err", err)
+	}
+	if err := os.Remove(l.f.Name()); err != nil && !os.IsNotExist(err) {
+		slog.Warn("Failed to remove PID file", "err", err)
+	}
+	if err := l.f.Close(); err != nil {
+		slog.Warn("Failed to close daemon lock file", "err", err)
 	}
 }
 

--- a/apps/runwisp/internal/datadir/datadir_test.go
+++ b/apps/runwisp/internal/datadir/datadir_test.go
@@ -312,3 +312,86 @@ func TestSocketPath_UnderDataDir(t *testing.T) {
 		t.Fatalf("SocketPath(%q) = %q, want %q", dir, got, want)
 	}
 }
+
+// TestAcquireDaemonLock_SucceedsWhenFree guards the happy path: nothing else
+// holds the PID file, so the lock is granted and the PID file is populated.
+func TestAcquireDaemonLock_SucceedsWhenFree(t *testing.T) {
+	dataDir := t.TempDir()
+	lock, err := AcquireDaemonLock(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Release()
+
+	pid, err := ReadPidFile(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("ReadPidFile = %d, want %d", pid, os.Getpid())
+	}
+}
+
+// TestAcquireDaemonLock_SecondCallConflicts is the regression test for the
+// TOCTOU race: a second daemon racing on the same data dir must be refused
+// while the first lock is held, not merely warned. flock is scoped per open
+// file description, so a second *open* of the same path from this same
+// process still conflicts at the OS level — a valid stand-in for "two
+// processes."
+func TestAcquireDaemonLock_SecondCallConflicts(t *testing.T) {
+	dataDir := t.TempDir()
+	first, err := AcquireDaemonLock(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Release()
+
+	if _, err := AcquireDaemonLock(dataDir); err == nil {
+		t.Fatal("expected second AcquireDaemonLock to fail while the first lock is held")
+	}
+}
+
+// TestAcquireDaemonLock_ReacquireAfterRelease confirms Release genuinely frees
+// the lock (and removes the PID file) rather than leaving it in a state that
+// permanently wedges the data dir.
+func TestAcquireDaemonLock_ReacquireAfterRelease(t *testing.T) {
+	dataDir := t.TempDir()
+	first, err := AcquireDaemonLock(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.Release()
+
+	if _, err := os.Stat(PidFilePath(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("expected PID file removed after Release, got err=%v", err)
+	}
+
+	second, err := AcquireDaemonLock(dataDir)
+	if err != nil {
+		t.Fatalf("expected re-acquire after Release to succeed: %v", err)
+	}
+	defer second.Release()
+}
+
+// TestWriteSecretFile_RefusesForeignOwner guards the ownership check the
+// WriteSecretFile doc comment has always claimed but the code never enforced
+// until now. Only root can chown a file away from the current euid, so an
+// unprivileged test sandbox skips rather than faking a UID mismatch in a way
+// that would weaken the real check.
+func TestWriteSecretFile_RefusesForeignOwner(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to create a file owned by a different UID")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	if err := os.WriteFile(path, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	const foreignUID = 1 // "daemon" on most Linux distros; distinct from root (0)
+	if err := os.Chown(path, foreignUID, -1); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteSecretFile(path, []byte("y")); err == nil {
+		t.Fatal("expected WriteSecretFile to refuse a file owned by a different user")
+	}
+}

--- a/apps/runwisp/internal/executor/compose.go
+++ b/apps/runwisp/internal/executor/compose.go
@@ -26,6 +26,15 @@ import (
 // payoff to a longer wait.
 const composeAvailableTimeout = 2 * time.Second
 
+// composeCleanupTimeout bounds the `docker ps`/`docker rm -f` calls made from
+// Process.Cleanup (via removeManagedInstance). Cleanup runs in the same
+// goroutine the daemon shutdown coordinator waits on after ForceKill has
+// already unblocked it; without a deadline a hung (not merely unreachable —
+// that fails fast) Docker/Podman engine would stall shutdown indefinitely even
+// though the process itself is already dead. A var (not const) so tests can
+// shrink it instead of waiting out the real 10s to prove the deadline fires.
+var composeCleanupTimeout = 10 * time.Second
+
 // composeExecShell is the interpreter exec-mode hands the script to *inside the
 // target container*. It is not the daemon's `shell` setting: that key is
 // rejected on compose-backed units because it configures a host process, and
@@ -136,7 +145,9 @@ func (b *ComposeBackend) Start(ctx context.Context, task *model.Task, run *model
 	if ce.Mode == model.ComposeModeRun {
 		taskName := task.Name
 		proc.Cleanup = func() {
-			b.removeManagedInstance(context.Background(), taskName, instanceIndex)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), composeCleanupTimeout)
+			defer cancel()
+			b.removeManagedInstance(cleanupCtx, taskName, instanceIndex)
 		}
 	}
 

--- a/apps/runwisp/internal/executor/compose_test.go
+++ b/apps/runwisp/internal/executor/compose_test.go
@@ -359,6 +359,64 @@ func TestComposeBackend_Start_CleanupRemovesInstance(t *testing.T) {
 	assert.Contains(t, calls, "rm -f live456")
 }
 
+// TestComposeBackend_CleanupBoundedWhenDockerHangs pins the fix for the
+// shutdown-hang bug: Process.Cleanup used to run `docker ps`/`docker rm -f` on
+// context.Background(), so a hung (not merely unreachable — that fails fast)
+// Docker/Podman engine could block the daemon shutdown coordinator's
+// ForceKill goroutine forever. Cleanup must bound those calls with
+// composeCleanupTimeout — shrunk here so the test doesn't wait out the real
+// production duration — so a shim that never returns from `rm -f` still lets
+// Cleanup return promptly instead of blocking for the full hang.
+func TestComposeBackend_CleanupBoundedWhenDockerHangs(t *testing.T) {
+	original := composeCleanupTimeout
+	composeCleanupTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { composeCleanupTimeout = original })
+
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "ps.count")
+	body := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"ps\" ]; then\n" +
+		"  n=$(cat '" + counter + "' 2>/dev/null || echo 0)\n" +
+		"  n=$((n+1))\n" +
+		"  echo $n > '" + counter + "'\n" +
+		"  if [ \"$n\" = \"1\" ]; then\n" +
+		"    exit 0\n" + // reclaim-on-start: nothing to reclaim yet
+		"  fi\n" +
+		"  printf '%s' 'abc123'\n" + // cleanup's ps discovers the leftover container
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = \"rm\" ]; then\n" +
+		"  sleep 30\n" + // simulate a hung engine
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	installDockerShimScript(t, dir, body)
+
+	b := &ComposeBackend{dockerCmd: "docker", fingerprint: "fp-test"}
+	ce := &model.ComposeExecution{File: "/tmp/dc.yml", ProjectName: "demo", Service: "web", Mode: model.ComposeModeRun}
+	task := &model.Task{Name: "boxes.web"}
+
+	proc, err := b.Start(context.Background(), task, &model.Run{InstanceIndex: 0}, ce)
+	require.NoError(t, err)
+	go drain(proc.Stdout)
+	go drain(proc.Stderr)
+	proc.Wait()
+
+	require.NotNil(t, proc.Cleanup, "services-mode Process must carry a Cleanup")
+
+	done := make(chan struct{})
+	go func() {
+		proc.Cleanup()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Cleanup blocked on a hung `docker rm -f` — the bounded context did not fire")
+	}
+}
+
 // TestComposeBackend_Start_StackModeNoReclaimOrCleanup confirms stack mode
 // neither reclaims nor sets a Cleanup — compose owns those container lifecycles.
 func TestComposeBackend_Start_StackModeNoReclaimOrCleanup(t *testing.T) {

--- a/apps/runwisp/internal/executor/container.go
+++ b/apps/runwisp/internal/executor/container.go
@@ -30,6 +30,15 @@ var allowedVolumePrefixes = []string{
 	"/tmp",
 }
 
+// containerCleanupTimeout bounds the ContainerRemove/ImageRemove calls made
+// from Process.Cleanup. Cleanup runs in the same goroutine the daemon shutdown
+// coordinator waits on after ForceKill has already unblocked it; without a
+// deadline a hung (not merely unreachable — that fails fast) Docker/Podman
+// engine would stall shutdown indefinitely even though the process itself is
+// already dead. A var (not const) so tests can shrink it instead of waiting
+// out the real 10s to prove the deadline fires.
+var containerCleanupTimeout = 10 * time.Second
+
 // validateVolumeMount rejects host paths that are not under an allowed prefix.
 // Symlinks are resolved to prevent bypass via indirection.
 func validateVolumeMount(hostPath string) error {
@@ -213,8 +222,10 @@ func (b *ContainerBackend) Start(ctx context.Context, task *model.Task, run *mod
 		Cleanup: func() {
 			closeDone()
 			attachResp.Close()
-			b.removeContainer(context.Background(), containerID)
-			b.builder.Remove(context.Background(), imageTag)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), containerCleanupTimeout)
+			defer cancel()
+			b.removeContainer(cleanupCtx, containerID)
+			b.builder.Remove(cleanupCtx, imageTag)
 		},
 	}, nil
 }

--- a/apps/runwisp/internal/executor/container_test.go
+++ b/apps/runwisp/internal/executor/container_test.go
@@ -782,6 +782,61 @@ func TestBuildContainerConfigPortDefaultProtocol(t *testing.T) {
 	assert.True(t, hasBinding)
 }
 
+// TestCleanupBoundedWhenDockerHangs pins the fix for the shutdown-hang bug:
+// Process.Cleanup used to call ContainerRemove/ImageRemove on
+// context.Background(), so a hung (not merely unreachable) Docker/Podman
+// engine could block the daemon shutdown coordinator's ForceKill goroutine
+// forever. Cleanup must now bound those calls with containerCleanupTimeout,
+// so a client that only returns once its context is cancelled still unblocks
+// Cleanup promptly. The timeout is shrunk for the test so it doesn't wait out
+// the real production duration.
+func TestCleanupBoundedWhenDockerHangs(t *testing.T) {
+	original := containerCleanupTimeout
+	containerCleanupTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { containerCleanupTimeout = original })
+
+	removeSawCancellation := make(chan struct{}, 1)
+	mock := &mockDockerClient{
+		imageBuildFunc: func(ctx context.Context, _ io.Reader, _ client.ImageBuildOptions) (client.ImageBuildResult, error) {
+			return client.ImageBuildResult{Body: io.NopCloser(strings.NewReader(`{"stream":"ok"}`))}, nil
+		},
+		containerAttachFunc: func(ctx context.Context, _ string, _ client.ContainerAttachOptions) (client.ContainerAttachResult, error) {
+			return newHijackedResponse(""), nil
+		},
+		containerRemoveFunc: func(ctx context.Context, _ string, _ client.ContainerRemoveOptions) (client.ContainerRemoveResult, error) {
+			// A hung engine: only returns once the caller's context gives up.
+			<-ctx.Done()
+			removeSawCancellation <- struct{}{}
+			return client.ContainerRemoveResult{}, ctx.Err()
+		},
+	}
+	b := NewContainerBackendFromClient(mock)
+
+	proc, err := b.Start(context.Background(), &model.Task{}, nil, &model.ContainerExecution{
+		Script:    "echo test",
+		BaseImage: "alpine",
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		proc.Cleanup()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cleanup blocked forever against a hung Docker client — the bounded context did not fire")
+	}
+
+	select {
+	case <-removeSawCancellation:
+	default:
+		t.Fatal("ContainerRemove never observed its context being cancelled")
+	}
+}
+
 func TestRemoveContainerLogsError(t *testing.T) {
 	called := false
 	mock := &mockDockerClient{

--- a/apps/runwisp/internal/executor/executor.go
+++ b/apps/runwisp/internal/executor/executor.go
@@ -107,10 +107,10 @@ type Options struct {
 // have full access.
 //
 // CloudDispatchEnabled is the operator opt-in (daemon.allow_cloud_dispatch). The
-// policy is a whitelist: only HTTP and config-backed dispatch (triggering an
-// existing TOML task) are permitted without it, since they don't run
-// peer-supplied local code. Shell, container, compose — and any future
-// code-executing type — require the opt-in.
+// policy is a whitelist: only config-backed dispatch (triggering an existing
+// TOML task) is permitted without it, since that's the sole type that doesn't
+// run peer-supplied code or make a peer-directed network call. HTTP, shell,
+// container, compose — and any future dispatchable type — require the opt-in.
 func New(opts Options) Executor {
 	backends := make(map[string]Backend)
 	avail := Availability{}
@@ -126,21 +126,22 @@ func New(opts Options) Executor {
 		backends["compose"] = opts.Compose
 	}
 
-	// Always dispatchable: HTTP, and config-backed dispatch when local tasks exist.
-	avail.HTTP = BackendStatus{Available: true}
+	// Always dispatchable: config-backed dispatch when local tasks exist.
 	if opts.HasLocalTasks {
 		avail.Config = BackendStatus{Available: true}
 	} else {
 		avail.Config = BackendStatus{Available: false, Reason: "no local tasks configured"}
 	}
 
-	// Code-executing types require the dispatch opt-in.
+	// HTTP and the code-executing types require the dispatch opt-in.
 	if !opts.CloudDispatchEnabled {
 		const reason = "cloud dispatch disabled (set [daemon] allow_cloud_dispatch = true to enable)"
+		avail.HTTP = BackendStatus{Available: false, Reason: reason}
 		avail.Shell = BackendStatus{Available: false, Reason: reason}
 		avail.Container = BackendStatus{Available: false, Reason: reason}
 		avail.Compose = BackendStatus{Available: false, Reason: reason}
 	} else {
+		avail.HTTP = BackendStatus{Available: true}
 		avail.Shell = BackendStatus{Available: true}
 		if opts.Docker != nil {
 			avail.Container = BackendStatus{Available: true}

--- a/apps/runwisp/internal/executor/executor_test.go
+++ b/apps/runwisp/internal/executor/executor_test.go
@@ -383,11 +383,12 @@ func newTestExecutor(t *testing.T, opts Options) *RoutingExecutor {
 	return e
 }
 
-func TestRoutingExecutor_Availability_DefaultsHTTPOnly(t *testing.T) {
+func TestRoutingExecutor_Availability_DefaultsConfigOnly(t *testing.T) {
 	e := newTestExecutor(t, Options{})
 	avail := e.Availability()
 
-	assert.True(t, avail.HTTP.Available, "HTTP dispatch is allowed without the opt-in")
+	assert.False(t, avail.HTTP.Available, "HTTP dispatch requires the opt-in")
+	assert.NotEmpty(t, avail.HTTP.Reason)
 	assert.False(t, avail.Shell.Available, "shell defaults to unavailable when cloud dispatch is disabled")
 	assert.NotEmpty(t, avail.Shell.Reason)
 	assert.False(t, avail.Container.Available, "container defaults to unavailable when cloud dispatch is disabled")
@@ -397,7 +398,9 @@ func TestRoutingExecutor_Availability_DefaultsHTTPOnly(t *testing.T) {
 
 func TestRoutingExecutor_Availability_CloudDispatchEnabled(t *testing.T) {
 	e := newTestExecutor(t, Options{CloudDispatchEnabled: true})
-	assert.True(t, e.Availability().Shell.Available)
+	avail := e.Availability()
+	assert.True(t, avail.HTTP.Available)
+	assert.True(t, avail.Shell.Available)
 }
 
 // TestRoutingExecutor_Availability_ContainerGatedOnDispatch proves the opt-in,

--- a/apps/runwisp/internal/executor/log_writer.go
+++ b/apps/runwisp/internal/executor/log_writer.go
@@ -474,7 +474,11 @@ func (w *LogWriter) Close() error {
 		}
 	}
 
-	os.Remove(logutil.PrevPath(w.mainPath))
+	// The `.prev` segment (if any) is NOT removed here: retention already
+	// accounts for its size and deletes it when the run itself is purged
+	// (see internal/runtime/retention.go, softdelete_purger.go). Deleting it
+	// on every Close would destroy the pre-rotation output of a run the
+	// instant it ends, before an operator can ever view or download it.
 
 	return errors.Join(errs...)
 }

--- a/apps/runwisp/internal/executor/log_writer_test.go
+++ b/apps/runwisp/internal/executor/log_writer_test.go
@@ -234,9 +234,10 @@ func TestLogWriter_DropOldRotation(t *testing.T) {
 	data, err := os.ReadFile(opts.LogPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "latest output")
-	// The rotated-away segment should be cleaned up by Close.
+	// The rotated-away segment must survive Close(): retention owns its
+	// lifecycle (deleted when the run itself is purged), not the writer.
 	_, err = os.Stat(logutil.PrevPath(opts.LogPath))
-	assert.True(t, os.IsNotExist(err))
+	assert.NoError(t, err, ".log.prev must survive Close() so it stays viewable/downloadable until retention purges the run")
 	// The container should record rotation info.
 	meta := logutil.ReadLogMeta(opts.LogPath)
 	assert.True(t, meta.Finalized)

--- a/apps/runwisp/internal/fingerprint/fingerprint.go
+++ b/apps/runwisp/internal/fingerprint/fingerprint.go
@@ -19,10 +19,8 @@ import (
 func Generate() string {
 	machineID := readMachineID()
 	cwd, _ := os.Getwd()
-	exe, _ := os.Executable()
-	hostname, _ := os.Hostname()
 
-	hash := sha256.Sum256([]byte(machineID + "\x00" + cwd + "\x00" + exe + "\x00" + hostname))
+	hash := sha256.Sum256([]byte(machineID + "\x00" + cwd))
 	seed := int64(binary.BigEndian.Uint64(hash[0:8]))
 
 	//nolint:gosec // deterministic fingerprint, not crypto

--- a/apps/runwisp/internal/fingerprint/fingerprint_test.go
+++ b/apps/runwisp/internal/fingerprint/fingerprint_test.go
@@ -4,6 +4,10 @@
 package fingerprint
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
@@ -15,6 +19,50 @@ func TestGenerateDeterministic(t *testing.T) {
 	}
 	if a == "" {
 		t.Error("expected non-empty fingerprint")
+	}
+}
+
+// TestGenerateIgnoresExecutablePath verifies the doc comment's contract:
+// the fingerprint is a function of machine identity + cwd only, not the
+// path of the running binary. It reinvokes this same test binary from a
+// second, differently-named copy (same machine, same cwd, different
+// os.Executable() result) and checks both report the same fingerprint.
+// This guards against reintroducing os.Executable()/os.Hostname() into the
+// hash, which breaks `service status`/`service uninstall` after the
+// binary is reinstalled at a new path (see internal/autostart).
+func TestGenerateIgnoresExecutablePath(t *testing.T) {
+	if os.Getenv("RUNWISP_FINGERPRINT_TEST_HELPER") == "1" {
+		fmt.Print(Generate())
+		return
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	data, err := os.ReadFile(self)
+	if err != nil {
+		t.Fatalf("read test binary: %v", err)
+	}
+	altPath := filepath.Join(t.TempDir(), "fingerprint-test-copy")
+	if err := os.WriteFile(altPath, data, 0o755); err != nil { //nolint:gosec // deliberate copy of our own test binary
+		t.Fatalf("write copy of test binary: %v", err)
+	}
+
+	run := func(path string) string {
+		cmd := exec.Command(path, "-test.run", "^TestGenerateIgnoresExecutablePath$")
+		cmd.Env = append(os.Environ(), "RUNWISP_FINGERPRINT_TEST_HELPER=1")
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("run %s: %v", path, err)
+		}
+		return string(out)
+	}
+
+	fromOriginal := run(self)
+	fromCopy := run(altPath)
+	if fromOriginal != fromCopy {
+		t.Errorf("fingerprint depends on executable path: %q (%s) vs %q (%s)", fromOriginal, self, fromCopy, altPath)
 	}
 }
 

--- a/apps/runwisp/internal/logsearch/scan.go
+++ b/apps/runwisp/internal/logsearch/scan.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/runwisp/runwisp/internal/logutil"
@@ -167,6 +168,18 @@ func runStartIndex(runs []RunRef, startAfterRunID string) int {
 // scanPending scans every pending run in parallel (bounded by ScanWorkers),
 // returning per-run results in input order plus the count of runs scanned.
 // Only the first run honors startAfterN; later runs restart at line 0.
+//
+// A single hit budget (remaining) is shared across the scans instead of
+// handing every run the full maxHits independently: once ScanWorkers scans
+// are already in flight, the next one only starts by waiting for one of them
+// to finish and free a slot — so by the time it starts, remaining reflects
+// what those finished scans actually found, and a run starting once maxHits
+// is already satisfied is skipped outright instead of independently
+// re-scanning a full budget's worth for flattenResults to discard. The
+// initial wave of up to ScanWorkers runs still gets the full maxHits each —
+// they start together with no ordering between them, so there is no
+// meaningful "already found" state yet to share, and racing them against
+// each other would just make results depend on goroutine scheduling.
 func scanPending(ctx context.Context, pending []RunRef, matcherFactory func() Matcher, maxHits int, startAfterN int64) ([]runResult, int, error) {
 	results := make([]runResult, len(pending))
 
@@ -174,9 +187,11 @@ func scanPending(ctx context.Context, pending []RunRef, matcherFactory func() Ma
 	g.SetLimit(ScanWorkers)
 
 	var (
-		mu      sync.Mutex
-		scanned int
+		mu        sync.Mutex
+		scanned   int
+		remaining atomic.Int64
 	)
+	remaining.Store(int64(maxHits))
 	for i, r := range pending {
 		i, r := i, r
 		var skipN int64
@@ -184,10 +199,24 @@ func scanPending(ctx context.Context, pending []RunRef, matcherFactory func() Ma
 			skipN = startAfterN
 		}
 		g.Go(func() error {
-			hits, more, err := ScanRun(gctx, r, matcherFactory(), maxHits, skipN)
+			perRunMax := maxHits
+			if i >= ScanWorkers {
+				budget := remaining.Load()
+				if budget <= 0 {
+					// Every worker slot this run waited on was freed by a
+					// scan that, combined, already found maxHits hits.
+					// Nothing this run finds would survive flattenResults,
+					// so don't scan it at all — flattenResults still emits a
+					// cursor pointing here since it was never visited.
+					return nil
+				}
+				perRunMax = int(budget)
+			}
+			hits, more, err := ScanRun(gctx, r, matcherFactory(), perRunMax, skipN)
 			if err != nil {
 				return err
 			}
+			remaining.Add(-int64(len(hits)))
 			mu.Lock()
 			results[i] = runResult{hits: hits, more: more}
 			scanned++

--- a/apps/runwisp/internal/logsearch/scan_test.go
+++ b/apps/runwisp/internal/logsearch/scan_test.go
@@ -5,6 +5,7 @@ package logsearch
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -214,6 +215,65 @@ func TestScanTask_ExactFillAtRunBoundaryEmitsCursor(t *testing.T) {
 	}
 	if len(hits2) != 2 || hits2[0].RunID != "01HRUNAAAAAAAAAAAAAAAAAAAA" {
 		t.Fatalf("resume should return run C's 2 hits, got %d", len(hits2))
+	}
+}
+
+// TestScanPending_SharedBudgetSkipsLaterRuns guards the fix for the
+// "scan everything then discard" bug: scanPending used to hand every pending
+// run the full per-request maxHits independently, so a task with many
+// match-heavy runs scanned up to (numRuns * maxHits) hits only for
+// flattenResults to throw most of them away. Runs now share a decrementing
+// budget, so a run that can only start once an earlier one has already
+// satisfied maxHits is skipped instead of re-scanning a full budget's worth.
+func TestScanPending_SharedBudgetSkipsLaterRuns(t *testing.T) {
+	dir := t.TempDir()
+	factory := func() Matcher {
+		m, _ := NewMatcher("foo", false, false)
+		return m
+	}
+
+	// Every run has far more than maxHits matching lines, so whichever run
+	// completes first satisfies the whole budget on its own.
+	const numRuns = 6
+	const maxHits = 5
+	pending := make([]RunRef, numRuns)
+	for i := range pending {
+		lines := make([]string, 30)
+		for j := range lines {
+			lines[j] = "foo line"
+		}
+		path := filepath.Join(dir, fmt.Sprintf("run%d.log", i))
+		writeLog(t, path, lines...)
+		pending[i] = RunRef{ID: fmt.Sprintf("R%d", i), LogPath: path, CreatedAt: time.Unix(int64(i), 0)}
+	}
+
+	results, _, err := scanPending(context.Background(), pending, factory, maxHits, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Runs beyond ScanWorkers cannot start until an earlier run has released
+	// a worker slot by completing — and completing means it already found
+	// hits against the shared budget (given every file matches far more than
+	// maxHits lines). So they must be skipped outright, not independently
+	// re-scanned up to the full maxHits.
+	for i := ScanWorkers; i < numRuns; i++ {
+		if len(results[i].hits) != 0 || results[i].more {
+			t.Fatalf("run %d: expected to be skipped once the shared budget was exhausted, got %+v", i, results[i])
+		}
+	}
+
+	// The shared budget bounds total scanning effort: at most ScanWorkers
+	// goroutines can start before any of them has recorded its hits, so the
+	// sum of hits actually found can never exceed ScanWorkers*maxHits. The
+	// pre-fix code (full maxHits handed to every one of the 6 runs
+	// independently) would total up to numRuns*maxHits = 30.
+	var total int
+	for _, r := range results {
+		total += len(r.hits)
+	}
+	if total > ScanWorkers*maxHits {
+		t.Fatalf("want total hits <= %d (shared budget), got %d", ScanWorkers*maxHits, total)
 	}
 }
 

--- a/apps/runwisp/internal/logutil/log_index.go
+++ b/apps/runwisp/internal/logutil/log_index.go
@@ -102,6 +102,12 @@ type LogLineRecord struct {
 // this were rotated away). totalLines is the total number of lines produced
 // across all segments.
 //
+// When a `.log.prev` segment is present, requests that reach back that far are
+// served from it — numbered from meta.PrevStart, per its doc — before falling
+// through to the current segment, the same two-segment order ScanLines uses.
+// Only lines below PrevStart (or RotatedLines, absent a `.prev`) are treated
+// as genuinely gone.
+//
 // limit > 0 caps the returned slice; pass 0 for an internal default.
 func ReadLineRange(logPath string, from, limit int64) (lines []LogLineRecord, firstAvailable, totalLines int64, err error) {
 	if limit <= 0 {
@@ -109,7 +115,7 @@ func ReadLineRange(logPath string, from, limit int64) (lines []LogLineRecord, fi
 	}
 	sc := ReadSidecar(logPath)
 	meta := sc.Meta
-	firstAvailable = meta.RotatedLines
+	prevPath, prevExists, firstAvailable := resolvePrevSegment(logPath, meta)
 
 	file, openErr := os.Open(logPath)
 	if openErr != nil {
@@ -126,43 +132,122 @@ func ReadLineRange(logPath string, from, limit int64) (lines []LogLineRecord, fi
 	}
 	indices := sc.Index
 	totalLines = int64(CalculateTotalLines(file, indices, stat.Size(), meta))
-
 	if totalLines <= firstAvailable {
 		return nil, firstAvailable, totalLines, nil
 	}
 
-	startLine := from
-	if startLine < 0 {
-		startLine = totalLines + from
-	}
-	if startLine < firstAvailable {
-		startLine = firstAvailable
-	}
+	startLine := resolveStartLine(from, firstAvailable, totalLines)
 	if startLine >= totalLines {
 		return nil, firstAvailable, totalLines, nil
 	}
 
-	startOffset := CalculateLineOffset(file, indices, int(startLine), meta)
+	if prevExists && startLine < meta.RotatedLines {
+		lines, err = readSegmentRange(prevPath, meta.PrevStart, startLine, limit)
+		if err != nil {
+			return lines, firstAvailable, totalLines, err
+		}
+		if int64(len(lines)) >= limit {
+			return lines, firstAvailable, totalLines, nil
+		}
+	}
+
+	// Either starting directly in the current segment, or continuing into it
+	// right after the .prev segment ended (which lines up exactly at
+	// RotatedLines by construction — see rotateTail).
+	currentStart := startLine
+	if len(lines) > 0 {
+		currentStart = meta.RotatedLines
+	}
+
+	startOffset := CalculateLineOffset(file, indices, int(currentStart), meta)
 	if _, seekErr := file.Seek(startOffset, io.SeekStart); seekErr != nil {
-		return nil, firstAvailable, totalLines, seekErr
+		return lines, firstAvailable, totalLines, seekErr
 	}
 
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, ScanBufferSize), 1024*1024)
-	current := startLine
-	for scanner.Scan() && int64(len(lines)) < limit {
-		stream, text := ParseStreamPrefix(scanner.Text())
-		lines = append(lines, LogLineRecord{
-			LineNum: current,
-			Stream:  stream,
-			Text:    text,
-		})
-		current++
-	}
-	if scanErr := scanner.Err(); scanErr != nil {
+	more, scanErr := collectLines(scanner, currentStart, limit-int64(len(lines)))
+	lines = append(lines, more...)
+	if scanErr != nil {
 		return lines, firstAvailable, totalLines, scanErr
 	}
 	return lines, firstAvailable, totalLines, nil
+}
+
+// resolvePrevSegment reports whether logPath has a `.log.prev` segment and
+// returns the resulting firstAvailable: numbered from meta.PrevStart when a
+// `.prev` survives, else meta.RotatedLines.
+func resolvePrevSegment(logPath string, meta LogMeta) (prevPath string, exists bool, firstAvailable int64) {
+	prevPath = PrevPath(logPath)
+	_, statErr := os.Stat(prevPath)
+	exists = statErr == nil
+	firstAvailable = meta.RotatedLines
+	if exists {
+		firstAvailable = meta.PrevStart
+	}
+	return prevPath, exists, firstAvailable
+}
+
+// resolveStartLine converts `from` into an absolute line number: negative
+// values count back from totalLines (a tail request), then the result is
+// clamped to the oldest surviving line, firstAvailable.
+func resolveStartLine(from, firstAvailable, totalLines int64) int64 {
+	start := from
+	if start < 0 {
+		start = totalLines + from
+	}
+	if start < firstAvailable {
+		start = firstAvailable
+	}
+	return start
+}
+
+// collectLines scans up to `limit` lines from scanner, numbering them
+// sequentially from startLineNum. Shared by ReadLineRange's current-segment
+// read and readSegmentRange's `.prev` read.
+func collectLines(scanner *bufio.Scanner, startLineNum, limit int64) ([]LogLineRecord, error) {
+	var lines []LogLineRecord
+	current := startLineNum
+	for scanner.Scan() && int64(len(lines)) < limit {
+		stream, text := ParseStreamPrefix(scanner.Text())
+		lines = append(lines, LogLineRecord{LineNum: current, Stream: stream, Text: text})
+		current++
+	}
+	return lines, scanner.Err()
+}
+
+// readSegmentRange reads up to `limit` lines from a single segment file
+// starting at the absolute line number `startAt`, which must be >=
+// segmentStart (the absolute line number the segment's first line
+// represents). The segment has no byte-offset index of its own (that index is
+// reset on rotation), so the skip is a linear scan — acceptable since this
+// only runs for reads reaching back into `.prev`, not the common current-
+// segment path, which still uses the sidecar index via CalculateLineOffset.
+func readSegmentRange(path string, segmentStart, startAt, limit int64) ([]LogLineRecord, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	skip := int(startAt - segmentStart)
+	if skip < 0 {
+		skip = 0
+	}
+	offset, _, scanErr := ScanOffset(f, 0, skip)
+	if scanErr != nil && !errors.Is(scanErr, io.EOF) {
+		return nil, scanErr
+	}
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, ScanBufferSize), 1024*1024)
+	return collectLines(scanner, segmentStart+int64(skip), limit)
 }
 
 // ScanLines streams every on-disk line of a run in display order: the

--- a/apps/runwisp/internal/logutil/log_index_test.go
+++ b/apps/runwisp/internal/logutil/log_index_test.go
@@ -35,6 +35,30 @@ func TestScanLines_PrevStartAfterMultipleRotations(t *testing.T) {
 	assert.Equal(t, []int64{3, 4, 5, 6}, got)
 }
 
+// TestReadLineRange_PrevStartAfterMultipleRotations mirrors
+// TestScanLines_PrevStartAfterMultipleRotations: ReadLineRange must also
+// number the `.prev` segment from meta.PrevStart, not 0, and must be able to
+// serve a range that starts in `.prev` and continues into the current
+// segment. Same layout: segment 1 (3 lines, already discarded) → segment 2 in
+// .prev starting at line 3 → current segment starting at line 5.
+func TestReadLineRange_PrevStartAfterMultipleRotations(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "task.log")
+	require.NoError(t, os.WriteFile(PrevPath(logPath), []byte("p3\np4\n"), 0644))
+	require.NoError(t, os.WriteFile(logPath, []byte("c5\nc6\n"), 0644))
+	writeContainer(t, logPath, MetaRecord(LogMeta{RotatedLines: 5, PrevStart: 3}))
+
+	lines, firstAvailable, totalLines, err := ReadLineRange(logPath, 3, 10)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), firstAvailable, "lines below PrevStart are gone, not RotatedLines")
+	assert.Equal(t, int64(7), totalLines)
+
+	var got []int64
+	for _, l := range lines {
+		got = append(got, l.LineNum)
+	}
+	assert.Equal(t, []int64{3, 4, 5, 6}, got)
+}
+
 func tempFileWithContent(t *testing.T, content string) *os.File {
 	t.Helper()
 	f, err := os.CreateTemp(t.TempDir(), "logtest-*")

--- a/apps/runwisp/internal/notify/channel/slack/slack.go
+++ b/apps/runwisp/internal/notify/channel/slack/slack.go
@@ -76,7 +76,7 @@ func (c *Channel) Execute(ctx context.Context, ev *notify.Event) error {
 		}
 	}
 	if err := c.transport.PostJSON(ctx, c.webhookURL, "application/json", body); err != nil {
-		return fmt.Errorf("%s: %s", c, notify.Redact(err.Error(), c.webhookURL))
+		return fmt.Errorf("%s: %w", c, notify.RedactError(err, c.webhookURL))
 	}
 	return nil
 }

--- a/apps/runwisp/internal/notify/channel/smtp/smtp.go
+++ b/apps/runwisp/internal/notify/channel/smtp/smtp.go
@@ -171,7 +171,7 @@ func (c *Channel) Execute(ctx context.Context, ev *notify.Event) error {
 	}
 
 	if err := notify.RetryWithBackoff(ctx, c.backoff, op); err != nil {
-		return fmt.Errorf("%s: %s", c, notify.Redact(err.Error(), c.password))
+		return fmt.Errorf("%s: %w", c, notify.RedactError(err, c.password))
 	}
 	return nil
 }

--- a/apps/runwisp/internal/notify/channel/telegram/telegram.go
+++ b/apps/runwisp/internal/notify/channel/telegram/telegram.go
@@ -97,7 +97,7 @@ func (c *Channel) Execute(ctx context.Context, ev *notify.Event) error {
 
 	endpoint := fmt.Sprintf("%s/bot%s/sendMessage", c.apiBase, c.botToken)
 	if err := c.transport.PostJSON(ctx, endpoint, "application/x-www-form-urlencoded", []byte(form.Encode())); err != nil {
-		return fmt.Errorf("%s: %s", c, notify.Redact(err.Error(), c.botToken))
+		return fmt.Errorf("%s: %w", c, notify.RedactError(err, c.botToken))
 	}
 	return nil
 }

--- a/apps/runwisp/internal/notify/channel/webhook/webhook.go
+++ b/apps/runwisp/internal/notify/channel/webhook/webhook.go
@@ -82,7 +82,7 @@ func (c *Channel) Execute(ctx context.Context, ev *notify.Event) error {
 		return fmt.Errorf("%s: render: %w", c, err)
 	}
 	if err := c.transport.PostJSONWithHeaders(ctx, c.url, "application/json", rendered.Body, c.headers); err != nil {
-		return fmt.Errorf("%s: %s", c, notify.Redact(err.Error(), c.url))
+		return fmt.Errorf("%s: %w", c, notify.RedactError(err, c.url))
 	}
 	return nil
 }

--- a/apps/runwisp/internal/notify/coalesce/coalesce.go
+++ b/apps/runwisp/internal/notify/coalesce/coalesce.go
@@ -154,15 +154,12 @@ func (c *Channel) Close(ctx context.Context) error {
 	}
 	c.mu.Unlock()
 
-	done := make(chan struct{})
-	go func() {
-		c.wg.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-ctx.Done():
-	}
+	// Wait unconditionally: a window-close summary goroutine calls
+	// c.inner.Execute independently of ctx (see timerFlush), so racing this
+	// wait against ctx.Done() could return here while that goroutine is still
+	// calling Execute concurrently with the Close below — exactly what the
+	// doc comment above promises callers won't happen.
+	c.wg.Wait()
 	return c.inner.Close(ctx)
 }
 
@@ -275,6 +272,11 @@ func (c *Channel) timerFlush(fp string) {
 
 	go func() {
 		defer c.wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				c.logger.Error("notify channel panicked", "channel", c.inner.ID(), "panic", r)
+			}
+		}()
 		select {
 		case <-c.timerDone:
 			return

--- a/apps/runwisp/internal/notify/coalesce/coalesce_test.go
+++ b/apps/runwisp/internal/notify/coalesce/coalesce_test.go
@@ -294,6 +294,109 @@ func TestTimerFlush_ConcurrentWithCloseNoPanic(t *testing.T) {
 	}
 }
 
+// blockingChannel is a local fake (testutil.FakeChannel has no way to hold
+// Execute open) used to prove Close waits for a slow in-flight Execute rather
+// than returning early against ctx.Done(). Only the second call (the
+// window-close summary in this test) blocks; the first (the immediate
+// actionForward delivery) must complete instantly or the test would deadlock
+// before ever arming the timer.
+type blockingChannel struct {
+	id      string
+	started chan struct{}
+	release chan struct{}
+
+	mu       sync.Mutex
+	calls    int
+	received []*notify.Event
+	closed   bool
+}
+
+func newBlockingChannel(id string) *blockingChannel {
+	return &blockingChannel{id: id, started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (b *blockingChannel) ID() string { return b.id }
+
+func (b *blockingChannel) Execute(_ context.Context, ev *notify.Event) error {
+	b.mu.Lock()
+	call := b.calls
+	b.calls++
+	b.mu.Unlock()
+	if call > 0 {
+		close(b.started)
+		<-b.release
+	}
+	b.mu.Lock()
+	b.received = append(b.received, ev)
+	b.mu.Unlock()
+	return nil
+}
+
+func (b *blockingChannel) Close(context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.closed = true
+	return nil
+}
+
+func (b *blockingChannel) Received() []*notify.Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]*notify.Event(nil), b.received...)
+}
+
+func (b *blockingChannel) Closed() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.closed
+}
+
+// TestCoalesce_CloseWaitsForSlowInFlightSummary is the regression test for the
+// Close-contract bug: Close's doc comment promises it "blocks until all
+// in-flight summary goroutines return", but the old implementation raced that
+// wait against ctx.Done() and could return while the window-close goroutine
+// was still calling inner.Execute — letting inner.Close run concurrently with
+// it and silently dropping the final summary. Close must wait for the slow
+// Execute to finish before returning, even under a tight ctx deadline.
+func TestCoalesce_CloseWaitsForSlowInFlightSummary(t *testing.T) {
+	inner := newBlockingChannel("slack-ops")
+	c := New(inner, Config{Window: time.Hour, EveryN: 1000}, testutil.NewFakeClock(time.Unix(0, 0)), nil, nil)
+	mt := withManualTimers(c)
+
+	require.NoError(t, c.Execute(context.Background(), failEvent("etl")))
+	require.NoError(t, c.Execute(context.Background(), failEvent("etl")))
+	require.Equal(t, 1, mt.Pending(), "a window-close timer must be armed")
+
+	mt.FireAll() // spawns the window-close goroutine; it blocks in inner.Execute
+	<-inner.started
+
+	closeReturned := make(chan struct{})
+	go func() {
+		// A tight deadline: a buggy Close racing ctx.Done() would return almost
+		// immediately instead of waiting for the slow Execute below.
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		_ = c.Close(ctx)
+		close(closeReturned)
+	}()
+
+	select {
+	case <-closeReturned:
+		t.Fatal("Close returned before the in-flight summary Execute finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(inner.release)
+	select {
+	case <-closeReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Close never returned after the in-flight Execute finished")
+	}
+
+	assert.Len(t, inner.Received(), 2, "first forwarded delivery + window-close summary must both have completed before Close returned")
+	assert.True(t, inner.Closed(), "inner.Close must run only after the summary Execute finished")
+}
+
 func TestSummarize_NonNilExtra(t *testing.T) {
 	ev := &notify.Event{
 		Kind:  notify.KindRunFailed,

--- a/apps/runwisp/internal/notify/dispatcher_test.go
+++ b/apps/runwisp/internal/notify/dispatcher_test.go
@@ -144,6 +144,44 @@ func TestDispatcher_ContextCancelDoesNotSurfaceFailure(t *testing.T) {
 	assert.Empty(t, sink.Captured(), "ctx cancel must not be surfaced as a delivery failure")
 }
 
+// TestDispatcher_RedactErrorPreservesCancelDetection is the regression test
+// for the RedactError bug: channels used to build their returned error with
+// fmt.Errorf("%s: %s", ..., Redact(err.Error(), secret)), which stringifies
+// the cause and breaks the Unwrap() chain. errors.Is(err, context.Canceled)
+// then could never see through to the real cause, so a channel interrupted by
+// shutdown looked like a permanent failure. RedactError wraps with %w so the
+// chain survives redaction.
+func TestDispatcher_RedactErrorPreservesCancelDetection(t *testing.T) {
+	wrapped := RedactError(context.Canceled, "super-secret-token")
+	require.True(t, errors.Is(wrapped, context.Canceled),
+		"RedactError must preserve Unwrap() so errors.Is still finds context.Canceled")
+
+	released := make(chan struct{})
+	a := &executeChannel{
+		id: "slack:ops",
+		execFn: func(ctx context.Context, _ *Event) error {
+			<-ctx.Done()
+			close(released)
+			return RedactError(ctx.Err(), "super-secret-token")
+		},
+	}
+	channels := map[string]Channel{a.id: a}
+	router := NewRouter([]Rule{{Match: MatchAll(), ActionIDs: []string{"slack:ops"}}}, channels)
+	sink := &recordingFailureSink{}
+	d := newDispatcher(router, channels, 4, RealClock(), sink, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d.startWorkers(ctx)
+	d.dispatch(&Event{Kind: KindRunFailed})
+	require.Eventually(t, func() bool { return a.hits.Load() == 1 }, time.Second, 10*time.Millisecond)
+	cancel()
+	<-released
+	d.closeQueues()
+	d.waitWorkers()
+	assert.Empty(t, sink.Captured(),
+		"a RedactError-wrapped context.Canceled must still be recognized as shutdown, not surfaced as a delivery failure")
+}
+
 func TestDispatcher_DropsOldestWhenQueueFull(t *testing.T) {
 	release := make(chan struct{})
 	startedFirst := make(chan struct{})

--- a/apps/runwisp/internal/notify/retry.go
+++ b/apps/runwisp/internal/notify/retry.go
@@ -127,3 +127,20 @@ func Redact(s, secret string) string {
 	}
 	return strings.ReplaceAll(s, secret, "[redacted]")
 }
+
+// redactedError wraps err so Error() has secrets redacted from its message
+// while Unwrap() still exposes the original error for errors.Is/As.
+type redactedError struct {
+	err    error
+	secret string
+}
+
+func (r *redactedError) Error() string { return Redact(r.err.Error(), r.secret) }
+func (r *redactedError) Unwrap() error { return r.err }
+
+// RedactError is the %w-safe replacement for
+// `fmt.Errorf("%s: %s", ..., Redact(err.Error(), secret))`. Using %s on
+// err.Error() breaks the Unwrap() chain, which hides context.Canceled /
+// context.DeadlineExceeded from errors.Is during shutdown. Wrap with %w and
+// this type instead so the chain survives while the message stays redacted.
+func RedactError(err error, secret string) error { return &redactedError{err: err, secret: secret} }

--- a/apps/runwisp/internal/runtime/manager_test.go
+++ b/apps/runwisp/internal/runtime/manager_test.go
@@ -1429,6 +1429,42 @@ func TestRemoveTask_ExitsQueueLoop(t *testing.T) {
 	}
 }
 
+// TestUpsertTask_PolicyChangeAwayFromQueueExitsQueueLoop pins the fix for the
+// queue-drain goroutine leak on reload: upserting a task with OnOverlap: queue
+// spawns a drain loop; a later reload that flips the same (still-live) task to
+// a different policy must stop that loop rather than leave it parked forever
+// on cond.Wait(), woken by every retireRun signal but with nothing to drain.
+func TestUpsertTask_PolicyChangeAwayFromQueueExitsQueueLoop(t *testing.T) {
+	jm, _, _ := newTestManager(t)
+
+	jm.UpsertTask(testTask("task1", model.PolicyQueue, 1))
+	jm.mu.RLock()
+	require.True(t, jm.tasks["task1"].queueDraining, "the drain loop must be alive under queue policy")
+	jm.mu.RUnlock()
+
+	// Reload flips the policy away from queue without removing the task.
+	jm.UpsertTask(testTask("task1", model.PolicySkip, 1))
+
+	require.Eventually(t, func() bool {
+		jm.mu.RLock()
+		defer jm.mu.RUnlock()
+		return !jm.tasks["task1"].queueDraining
+	}, time.Second, 10*time.Millisecond, "the drain loop must exit once the policy is no longer queue")
+
+	// Confirm it's not just the flag: Shutdown's WaitGroup drain must not block
+	// on a leaked goroutine still parked in cond.Wait().
+	done := make(chan struct{})
+	go func() {
+		jm.Shutdown()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown blocked — the queue-drain goroutine leaked after a policy change")
+	}
+}
+
 // TestRemoveTask_InFlightCronRunFinishes is the crux of the "reload doesn't kill
 // running work" guarantee: removing a cron task while a run is in flight must
 // keep the taskState alive until that run retires under its original

--- a/apps/runwisp/internal/runtime/retention.go
+++ b/apps/runwisp/internal/runtime/retention.go
@@ -158,30 +158,24 @@ func (cleaner *RetentionCleaner) deleteRunBatch(ctx context.Context, runs []mode
 			continue
 		}
 		logPath := logutil.ResolveRunLogPath(cleaner.logDir, run.TaskName, run.ID, run.CreatedAt)
-		var freed int64
 		if info, statErr := os.Stat(logPath); statErr == nil {
-			freed += info.Size()
+			*totalSize -= info.Size()
 		}
 		if info, statErr := os.Stat(logutil.MetaPath(logPath)); statErr == nil {
-			freed += info.Size()
+			*totalSize -= info.Size()
 		}
 		// RemoveLogFiles also deletes the rotated-away .prev segment, and the
 		// initial dirSize counted it — subtract it too or the tracked total
 		// stays high and the loop over-deletes runs.
 		if info, statErr := os.Stat(logutil.PrevPath(logPath)); statErr == nil {
-			freed += info.Size()
+			*totalSize -= info.Size()
 		}
-		// Delete the DB row before the log file (matching cleanOldRuns and
-		// softdelete_purger.purge): a SIGKILL between the two steps leaves an
-		// orphaned log file (harmless) rather than a DB row pointing at a
-		// deleted log (a "ghost" the operator can click into and get an error).
+		logutil.RemoveLogFiles(logPath)
+		logutil.RemoveEmptyParents(logPath, cleaner.logDir)
 		if err := cleaner.db.DeleteRun(ctx, run.ID); err != nil {
 			slog.Warn("Failed to delete run during size enforcement", "id", run.ID, "err", err)
 			continue
 		}
-		*totalSize -= freed
-		logutil.RemoveLogFiles(logPath)
-		logutil.RemoveEmptyParents(logPath, cleaner.logDir)
 		deleted++
 		if *totalSize <= cleaner.maxTotalSize {
 			break

--- a/apps/runwisp/internal/runtime/retention.go
+++ b/apps/runwisp/internal/runtime/retention.go
@@ -158,24 +158,30 @@ func (cleaner *RetentionCleaner) deleteRunBatch(ctx context.Context, runs []mode
 			continue
 		}
 		logPath := logutil.ResolveRunLogPath(cleaner.logDir, run.TaskName, run.ID, run.CreatedAt)
+		var freed int64
 		if info, statErr := os.Stat(logPath); statErr == nil {
-			*totalSize -= info.Size()
+			freed += info.Size()
 		}
 		if info, statErr := os.Stat(logutil.MetaPath(logPath)); statErr == nil {
-			*totalSize -= info.Size()
+			freed += info.Size()
 		}
 		// RemoveLogFiles also deletes the rotated-away .prev segment, and the
 		// initial dirSize counted it — subtract it too or the tracked total
 		// stays high and the loop over-deletes runs.
 		if info, statErr := os.Stat(logutil.PrevPath(logPath)); statErr == nil {
-			*totalSize -= info.Size()
+			freed += info.Size()
 		}
-		logutil.RemoveLogFiles(logPath)
-		logutil.RemoveEmptyParents(logPath, cleaner.logDir)
+		// Delete the DB row before the log file (matching cleanOldRuns and
+		// softdelete_purger.purge): a SIGKILL between the two steps leaves an
+		// orphaned log file (harmless) rather than a DB row pointing at a
+		// deleted log (a "ghost" the operator can click into and get an error).
 		if err := cleaner.db.DeleteRun(ctx, run.ID); err != nil {
 			slog.Warn("Failed to delete run during size enforcement", "id", run.ID, "err", err)
 			continue
 		}
+		*totalSize -= freed
+		logutil.RemoveLogFiles(logPath)
+		logutil.RemoveEmptyParents(logPath, cleaner.logDir)
 		deleted++
 		if *totalSize <= cleaner.maxTotalSize {
 			break

--- a/apps/runwisp/internal/runtime/retention_test.go
+++ b/apps/runwisp/internal/runtime/retention_test.go
@@ -115,12 +115,13 @@ func TestEnforceMaxTotalSize_SubtractsPrevSegment(t *testing.T) {
 	repo.AssertNotCalled(t, "DeleteRun", mock.Anything, newest.ID)
 }
 
-// The DB row must be deleted before the log file is removed from disk — a
-// SIGKILL between the two steps should leave an orphaned log file (harmless)
-// rather than a DB row pointing at a deleted log. Assert order by checking
-// the log file still exists at the moment DeleteRun is invoked, and is gone
-// only afterward.
-func TestEnforceMaxTotalSize_DeletesDBRowBeforeLogFile(t *testing.T) {
+// The log file must be removed before the DB row is deleted — a lingering
+// log-less "ghost" row is treated as benign (indistinguishable from a
+// legitimate no-log run) while an orphaned log file is an unidentifiable,
+// unreclaimable disk leak that stays counted against the size cap forever.
+// This is a deliberate divergence from cleanOldRuns/softdelete_purger.purge
+// (which delete the row first): do not "fix" it into consistency with them.
+func TestEnforceMaxTotalSize_DeletesLogFileBeforeDBRow(t *testing.T) {
 	repo := new(testutil.MockRunRepository)
 	logDir := t.TempDir()
 	now := time.Now()
@@ -141,17 +142,15 @@ func TestEnforceMaxTotalSize_DeletesDBRowBeforeLogFile(t *testing.T) {
 	repo.On("QueryRuns", mock.Anything, enforceQuery).Return([]model.Run{run}, nil).Once()
 	repo.On("QueryRuns", mock.Anything, enforceQuery).Return([]model.Run{}, nil)
 	repo.On("DeleteRun", mock.Anything, runID).Run(func(mock.Arguments) {
-		// The log file must still be on disk when the DB delete happens.
+		// The log file must already be gone by the time the DB delete happens.
 		_, err := os.Stat(logPath)
-		assert.NoError(t, err, "log file must still exist when DeleteRun is called")
+		assert.True(t, os.IsNotExist(err), "log file must already be removed when DeleteRun is called")
 	}).Return(nil)
 
 	cleaner := NewRetentionCleaner(repo, NewTaskRegistry(nil), time.Hour, logDir, 100)
 	cleaner.enforceMaxTotalSize(context.Background())
 
 	repo.AssertCalled(t, "DeleteRun", mock.Anything, runID)
-	_, err := os.Stat(logPath)
-	assert.True(t, os.IsNotExist(err), "log file must be removed after DeleteRun succeeds")
 }
 
 func TestEnforceMaxTotalSize_PrunesOldestTerminalRun(t *testing.T) {

--- a/apps/runwisp/internal/runtime/retention_test.go
+++ b/apps/runwisp/internal/runtime/retention_test.go
@@ -115,6 +115,45 @@ func TestEnforceMaxTotalSize_SubtractsPrevSegment(t *testing.T) {
 	repo.AssertNotCalled(t, "DeleteRun", mock.Anything, newest.ID)
 }
 
+// The DB row must be deleted before the log file is removed from disk — a
+// SIGKILL between the two steps should leave an orphaned log file (harmless)
+// rather than a DB row pointing at a deleted log. Assert order by checking
+// the log file still exists at the moment DeleteRun is invoked, and is gone
+// only afterward.
+func TestEnforceMaxTotalSize_DeletesDBRowBeforeLogFile(t *testing.T) {
+	repo := new(testutil.MockRunRepository)
+	logDir := t.TempDir()
+	now := time.Now()
+
+	runID := ulid.Make().String()
+	logPath := logutil.ResolveRunLogPath(logDir, "task1", runID, now)
+	require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0755))
+	require.NoError(t, os.WriteFile(logPath, make([]byte, 200), 0644))
+
+	run := model.Run{ID: runID, TaskName: "task1", CreatedAt: now, Status: model.PhaseEnded}
+
+	enforceQuery := storage.RunQuery{
+		Limit:         100,
+		Offset:        0,
+		SortField:     storage.SortColumnCreatedAt,
+		SortDirection: storage.SortAsc,
+	}
+	repo.On("QueryRuns", mock.Anything, enforceQuery).Return([]model.Run{run}, nil).Once()
+	repo.On("QueryRuns", mock.Anything, enforceQuery).Return([]model.Run{}, nil)
+	repo.On("DeleteRun", mock.Anything, runID).Run(func(mock.Arguments) {
+		// The log file must still be on disk when the DB delete happens.
+		_, err := os.Stat(logPath)
+		assert.NoError(t, err, "log file must still exist when DeleteRun is called")
+	}).Return(nil)
+
+	cleaner := NewRetentionCleaner(repo, NewTaskRegistry(nil), time.Hour, logDir, 100)
+	cleaner.enforceMaxTotalSize(context.Background())
+
+	repo.AssertCalled(t, "DeleteRun", mock.Anything, runID)
+	_, err := os.Stat(logPath)
+	assert.True(t, os.IsNotExist(err), "log file must be removed after DeleteRun succeeds")
+}
+
 func TestEnforceMaxTotalSize_PrunesOldestTerminalRun(t *testing.T) {
 	repo := new(testutil.MockRunRepository)
 	logDir := t.TempDir()

--- a/apps/runwisp/internal/runtime/taskstate.go
+++ b/apps/runwisp/internal/runtime/taskstate.go
@@ -147,7 +147,7 @@ func (m *defaultTaskManager) queueProcessLoop(taskName string) {
 	defer func() { ts.queueDraining = false }()
 	for {
 		for len(ts.queue) == 0 || len(ts.active) >= m.getConcurrencyLimit(ts.task) {
-			if m.isShutdown.Load() || ts.removed {
+			if m.isShutdown.Load() || ts.removed || ts.task.OnOverlap != model.PolicyQueue {
 				return
 			}
 			ts.cond.Wait()
@@ -157,8 +157,12 @@ func (m *defaultTaskManager) queueProcessLoop(taskName string) {
 		// Starting a run here would happen after the single cancel pass, leaving
 		// its context live forever — an orphaned process and a drain that never
 		// completes. The check is race-free under m.mu: the flag is set before
-		// the lock is taken for the cancel+broadcast pass.
-		if m.isShutdown.Load() || ts.removed {
+		// the lock is taken for the cancel+broadcast pass. ts.task.OnOverlap is
+		// read under the same lock UpsertTask holds when it swaps in a reloaded
+		// definition, so a reload that flips the policy away from queue is
+		// observed here too — otherwise this goroutine would idle forever,
+		// woken by every retireRun signal but never draining anything.
+		if m.isShutdown.Load() || ts.removed || ts.task.OnOverlap != model.PolicyQueue {
 			return
 		}
 		run := ts.queue[0]

--- a/apps/runwisp/internal/server/api_types.go
+++ b/apps/runwisp/internal/server/api_types.go
@@ -18,6 +18,25 @@ type TaskNameInput struct {
 	TaskName string `path:"taskName" minLength:"1" maxLength:"100" pattern:"^[a-zA-Z0-9._:-]+$" doc:"Task name"`
 }
 
+// TriggerWaitTimeoutMax and TriggerWaitTimeoutDefault back the waitTimeout
+// field's huma `maximum`/`default` struct tags below. Struct tags are string
+// literals, so a tag edit can't reference these constants directly — they're
+// kept in sync by hand, guarded by TestTriggerRunInput_WaitTimeoutBounds.
+const (
+	// TriggerWaitTimeoutMax must stay safely under the HTTP server's 5-minute
+	// WriteTimeout (internal/server/server.go), with real margin for request/
+	// dispatch overhead. The wait=true handler makes exactly one JSON write,
+	// after blocking for up to waitTimeout seconds, on a plain
+	// (non-streaming) response whose write deadline is set once — when
+	// headers finish being read — and never refreshed afterward. Wait too
+	// close to (or past) WriteTimeout and that final write fails with an i/o
+	// timeout even though the triggered run completed successfully.
+	TriggerWaitTimeoutMax = 240
+	// TriggerWaitTimeoutDefault is a shorter, comfortable default for a
+	// "trigger and wait a bit" convenience call.
+	TriggerWaitTimeoutDefault = 120
+)
+
 // TriggerRunInput drives POST /api/tasks/{taskName}/run. With wait=false
 // (default) it returns immediately with the pending run; with wait=true the
 // request blocks until the run finishes so a single call yields its exit code.
@@ -28,7 +47,7 @@ type TaskNameInput struct {
 type TriggerRunInput struct {
 	TaskName    string `path:"taskName" minLength:"1" maxLength:"100" pattern:"^[a-zA-Z0-9._:-]+$" doc:"Task name"`
 	Wait        bool   `query:"wait" doc:"Block until the run finishes and return the completed run (with exitCode and endReason). Best for short tasks; long runs may exceed reverse-proxy timeouts — follow the log stream or poll instead."`
-	WaitTimeout int    `query:"waitTimeout" minimum:"1" maximum:"3600" default:"300" doc:"With wait=true, the maximum seconds to hold the request open. On timeout the run keeps running and the response returns it in its current (non-terminal) state."`
+	WaitTimeout int    `query:"waitTimeout" minimum:"1" maximum:"240" default:"120" doc:"With wait=true, the maximum seconds to hold the request open. Capped below the server's 5-minute write timeout (with margin for request/dispatch overhead) since the response is a single write made after the full wait elapses. On timeout the run keeps running and the response returns it in its current (non-terminal) state."`
 	// Body is a pointer so it is optional — a zero-param trigger can POST with
 	// no payload at all.
 	Body *struct {

--- a/apps/runwisp/internal/server/run_service_test.go
+++ b/apps/runwisp/internal/server/run_service_test.go
@@ -6,6 +6,8 @@ package server
 import (
 	"context"
 	"errors"
+	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -363,6 +365,34 @@ func TestHumaTriggerRun_WaitTaskNotFound(t *testing.T) {
 
 	_, err := srv.humaTriggerRun(context.Background(), &TriggerRunInput{TaskName: "missing", Wait: true, WaitTimeout: 5})
 	assert.Error(t, err)
+}
+
+// TestTriggerRunInput_WaitTimeoutBounds guards against a regression of the
+// bug where waitTimeout's advertised maximum (formerly 3600s, default 300s)
+// let the wait=true handler's single final JSON write land after the HTTP
+// server's 5-minute WriteTimeout, failing with an i/o timeout even though the
+// triggered run had completed. It checks two things that must stay true
+// together: the struct tag literals actually match the named constants (tags
+// can't reference constants, so they drift silently otherwise), and the max
+// leaves real margin under WriteTimeout.
+func TestTriggerRunInput_WaitTimeoutBounds(t *testing.T) {
+	field, ok := reflect.TypeOf(TriggerRunInput{}).FieldByName("WaitTimeout")
+	require.True(t, ok, "TriggerRunInput.WaitTimeout field must exist")
+
+	assert.Equal(t, strconv.Itoa(TriggerWaitTimeoutMax), field.Tag.Get("maximum"),
+		"struct tag `maximum` must match TriggerWaitTimeoutMax")
+	assert.Equal(t, strconv.Itoa(TriggerWaitTimeoutDefault), field.Tag.Get("default"),
+		"struct tag `default` must match TriggerWaitTimeoutDefault")
+
+	require.Less(t, TriggerWaitTimeoutDefault, TriggerWaitTimeoutMax,
+		"default should be comfortably below the max, not equal to it")
+
+	// Mirrors internal/server/server.go's newHTTPServer WriteTimeout (5*time.Minute).
+	// If that value ever changes, this margin check must be revisited too.
+	const serverWriteTimeout = 5 * time.Minute
+	const requiredMargin = time.Minute
+	require.LessOrEqualf(t, time.Duration(TriggerWaitTimeoutMax)*time.Second, serverWriteTimeout-requiredMargin,
+		"TriggerWaitTimeoutMax must leave at least %s of margin under the server's WriteTimeout for request/dispatch overhead", requiredMargin)
 }
 
 func TestHumaTriggerRun_NoWaitReturnsPendingRun(t *testing.T) {

--- a/apps/runwisp/internal/storage/database.go
+++ b/apps/runwisp/internal/storage/database.go
@@ -94,7 +94,15 @@ type SQLiteDatabase struct {
 // New opens the SQLite database and applies any pending forward-only
 // migrations (see migrate.go).
 func New(dbPath string) (Database, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	// modernc.org/sqlite's default time.Time write format is Go's
+	// time.Time.String() (e.g. "2026-08-22 14:39:12.06 +0200 CEST"): a
+	// trailing zone-name abbreviation SQLite's own date/time functions
+	// (julianday, strftime, ...) cannot parse, so they silently treat every
+	// timestamp as NULL. _time_format=sqlite switches writes to a numeric-offset
+	// format from the SQLite date/time spec (https://www.sqlite.org/lang_datefunc.html
+	// "Time Strings" format 5), which those functions can parse. Read-side
+	// parsing already tries this format regardless, so this only affects writes.
+	db, err := sql.Open("sqlite", dbPath+"?_time_format=sqlite")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}

--- a/apps/runwisp/internal/storage/database_test.go
+++ b/apps/runwisp/internal/storage/database_test.go
@@ -404,15 +404,22 @@ func TestQueryRunsAllSortVariants(t *testing.T) {
 		})
 	}
 
-	// Duration sort relies on julianday() over the persisted timestamps;
-	// the driver stores them in a non-ISO format that SQLite can't parse,
-	// so every row evaluates to a tied 0 and the ORDER BY produces an
-	// unspecified order. We still exercise both dispatch branches so the
-	// sqlc-generated queries are reached — we just don't assert order.
-	for _, dir := range []SortDirection{SortAsc, SortDesc} {
-		rs, err := db.QueryRuns(ctx, RunQuery{Limit: 10, SortField: SortColumnDuration, SortDirection: dir})
-		require.NoError(t, err)
-		assert.Len(t, rs, 3)
+	// Duration sort relies on julianday() over the persisted started_at/ended_at
+	// timestamps. a/b/c above were built with durations 10s/20s/5s respectively.
+	durationCases := []struct {
+		name string
+		dir  SortDirection
+		want []string
+	}{
+		{"duration asc", SortAsc, []string{"charlie", "alpha", "bravo"}},
+		{"duration desc", SortDesc, []string{"bravo", "alpha", "charlie"}},
+	}
+	for _, tc := range durationCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rs, err := db.QueryRuns(ctx, RunQuery{Limit: 10, SortField: SortColumnDuration, SortDirection: tc.dir})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, names(rs))
+		})
 	}
 }
 

--- a/apps/runwisp/openapi.json
+++ b/apps/runwisp/openapi.json
@@ -4147,15 +4147,15 @@
             }
           },
           {
-            "description": "With wait=true, the maximum seconds to hold the request open. On timeout the run keeps running and the response returns it in its current (non-terminal) state.",
+            "description": "With wait=true, the maximum seconds to hold the request open. Capped below the server's 5-minute write timeout (with margin for request/dispatch overhead) since the response is a single write made after the full wait elapses. On timeout the run keeps running and the response returns it in its current (non-terminal) state.",
             "explode": false,
             "in": "query",
             "name": "waitTimeout",
             "schema": {
-              "default": 300,
-              "description": "With wait=true, the maximum seconds to hold the request open. On timeout the run keeps running and the response returns it in its current (non-terminal) state.",
+              "default": 120,
+              "description": "With wait=true, the maximum seconds to hold the request open. Capped below the server's 5-minute write timeout (with margin for request/dispatch overhead) since the response is a single write made after the full wait elapses. On timeout the run keeps running and the response returns it in its current (non-terminal) state.",
               "format": "int64",
-              "maximum": 3600,
+              "maximum": 240,
               "minimum": 1,
               "type": "integer"
             }

--- a/apps/ui/src/lib/stores/notifications.svelte.ts
+++ b/apps/ui/src/lib/stores/notifications.svelte.ts
@@ -39,7 +39,10 @@ const unreadCountChangedSchema = z.object({
     unreadCount: z.number().int().nonnegative(),
 });
 
-const streamEnvelopeSchema = z.object({ notification: notificationSchema });
+const streamEnvelopeSchema = z.object({
+    notification: notificationSchema,
+    unreadCount: z.number().int().nonnegative(),
+});
 
 export interface NotificationStoreDeps {
     fetch?: typeof fetch;
@@ -58,9 +61,14 @@ function isUnread(n: Notification): boolean {
 
 class NotificationStore {
     #items = $state<Notification[]>([]);
-    // unread is the server's authoritative snapshot, adjusted by the deltas
-    // we observe locally (SSE events + per-row mark-read/unread). We never
-    // recompute it from #items because items is paginated.
+    // unread is the server's authoritative snapshot. Every SSE event
+    // (notification.created/updated/unreadCountChanged) carries the
+    // post-mutation count and we set it directly from that — never delta
+    // math, since a row absent from our paginated #items would otherwise
+    // drift the count on every recurrence. Local mark-read/unread actions
+    // apply an optimistic delta until the server round-trip (and its own
+    // SSE echo) resolves it. We never recompute it from #items because
+    // items is paginated.
     #unread = $state(0);
     readonly #events: AppEventStream;
     #subscribed = false;
@@ -246,6 +254,7 @@ class NotificationStore {
                     return;
                 }
                 this.#applyUpdate(parsed.data.notification);
+                this.#unread = parsed.data.unreadCount;
             } catch (e) {
                 this.#logger.error("Malformed notification SSE event", e);
             }
@@ -271,17 +280,13 @@ class NotificationStore {
 
     #applyUpdate(n: Notification): void {
         const idx = this.#items.findIndex((x) => x.id === n.id);
-        const prev = this.#items[idx];
-        if (prev) {
+        if (idx !== -1) {
             const next = this.#items.slice();
             next[idx] = n;
             this.#items = next;
-            const delta = (isUnread(n) ? 1 : 0) - (isUnread(prev) ? 1 : 0);
-            if (delta !== 0) this.#unread = Math.max(0, this.#unread + delta);
             return;
         }
         this.#items = [n, ...this.#items];
-        if (isUnread(n)) this.#unread += 1;
     }
 
     async #fetchPage(before?: string): Promise<z.infer<typeof listResponseSchema>> {

--- a/apps/ui/src/lib/stores/notifications.test.ts
+++ b/apps/ui/src/lib/stores/notifications.test.ts
@@ -150,6 +150,7 @@ describe("NotificationStore", () => {
                 id: "01H000000000000000000RD000",
                 readAt: "2026-05-05T12:00:00.000Z",
             }),
+            unreadCount: 0,
         });
         expect(store.unread).toBe(0);
         expect(store.items).toHaveLength(1);
@@ -160,8 +161,30 @@ describe("NotificationStore", () => {
         await store.init();
         es.fire("notification.created", {
             notification: makeNotification({ id: "01H000000000000000000NEW01" }),
+            unreadCount: 1,
         });
         expect(store.unread).toBe(1);
+    });
+
+    it("sets unread directly from the unreadCount on the envelope, ignoring #items entirely, for a recurring notification not loaded in this tab", async () => {
+        const { store, es } = setupHarness({ items: [], unread: 5 });
+        await store.init();
+        expect(store.unread).toBe(5);
+        // Simulate a coalesced/recurring failure re-firing as `notification.updated`
+        // whose row has scrolled off this tab's loaded page (or the tab opened
+        // after it was first created): absent from #items, but the server ships
+        // the authoritative post-mutation count alongside it. Old delta math would
+        // have unconditionally bumped #unread to 6 here; the fix must land on the
+        // exact server value instead.
+        es.fire("notification.updated", {
+            notification: makeNotification({
+                id: "01H000000000000000000OFF01",
+                count: 4,
+                readAt: null,
+            }),
+            unreadCount: 9,
+        });
+        expect(store.unread).toBe(9);
     });
 
     it("sets unread directly from a notification.unreadCountChanged SSE event", async () => {
@@ -181,6 +204,7 @@ describe("NotificationStore", () => {
         expect(store.unread).toBe(1);
         es.fire("notification.updated", {
             notification: makeNotification({ id, readAt: "2026-05-05T12:05:00.000Z" }),
+            unreadCount: 0,
         });
         expect(store.unread).toBe(0);
         expect(store.items[0]?.readAt).toBe("2026-05-05T12:05:00.000Z");
@@ -196,6 +220,7 @@ describe("NotificationStore", () => {
         expect(store.unread).toBe(0);
         es.fire("notification.updated", {
             notification: makeNotification({ id, count: 2, readAt: null }),
+            unreadCount: 1,
         });
         expect(store.unread).toBe(1);
         expect(store.items[0]?.readAt).toBeNull();

--- a/apps/ui/src/lib/utils/log-session.ts
+++ b/apps/ui/src/lib/utils/log-session.ts
@@ -46,8 +46,12 @@ export function createLogSession(options: LogSessionOptions) {
             });
             return parseLogPage(page);
         } catch (err) {
+            // Log for diagnostics, then rethrow instead of swallowing into a
+            // benign empty LogEvent: callers (RunDetailPanel's seed fetch,
+            // LogConsole's internal LogFetcher) already catch this and must be
+            // able to tell "fetch failed" apart from "run produced no output".
             logger.error("Failed to fetch logs", err);
-            return { lines: {}, sizeLines: 0, finished };
+            throw err;
         }
     }
 
@@ -67,8 +71,11 @@ export function createLogSession(options: LogSessionOptions) {
         try {
             return await tasksApi.getLogLineHistory(runId, lineNum);
         } catch (err) {
+            // LogConsole's frame-history toggle already catches this and
+            // renders "Failed to load frame history" — swallowing it here
+            // instead hid every failure behind a silent no-op.
             logger.error("Failed to fetch log line history", err);
-            return [];
+            throw err;
         }
     }
 

--- a/apps/ui/src/routes/+layout.svelte
+++ b/apps/ui/src/routes/+layout.svelte
@@ -38,7 +38,16 @@
 
     $effect(() => {
         const status = authStore.current;
-        if (!status.loaded || !status.authenticated) return;
+        if (!status.loaded || !status.authenticated) {
+            // A mid-session logout (401 on any REST call flips authStore to
+            // unauthenticated) re-runs this effect into this branch. Without
+            // tearing the stores down here they keep applying SSE-pushed state
+            // underneath the auth modal until the whole page unmounts.
+            runUpdatesStore.disconnect();
+            notificationStore.disconnect();
+            systemStore.disconnect();
+            return;
+        }
 
         runUpdatesStore.connect();
         void taskStore.loadIfNeeded();

--- a/packages/common/src/generated/api.ts
+++ b/packages/common/src/generated/api.ts
@@ -2776,7 +2776,7 @@ export interface operations {
             query?: {
                 /** @description Block until the run finishes and return the completed run (with exitCode and endReason). Best for short tasks; long runs may exceed reverse-proxy timeouts — follow the log stream or poll instead. */
                 wait?: boolean;
-                /** @description With wait=true, the maximum seconds to hold the request open. On timeout the run keeps running and the response returns it in its current (non-terminal) state. */
+                /** @description With wait=true, the maximum seconds to hold the request open. Capped below the server's 5-minute write timeout (with margin for request/dispatch overhead) since the response is a single write made after the full wait elapses. On timeout the run keeps running and the response returns it in its current (non-terminal) state. */
                 waitTimeout?: number;
             };
             header?: never;

--- a/packages/ui/src/lib/components/LogConsole.svelte
+++ b/packages/ui/src/lib/components/LogConsole.svelte
@@ -31,6 +31,12 @@
         // "muted" (default) renders the terminus in the gutter grey; "warn"
         // tints it amber for runs that ended by intervention rather than naturally.
         endTone?: "muted" | "warn";
+        // Message from the most recent fetchLogs failure (session expiry,
+        // daemon restart mid-request, network blip, ...). Rendered as a small
+        // banner above the log surface so a fetch failure never looks like a
+        // run that simply produced no output. Null/undefined renders nothing;
+        // the caller clears it once a subsequent fetch succeeds.
+        error?: string | null;
         // Wrap long lines instead of horizontally scrolling them. When on, each
         // rendered row's height becomes a multiple of `lineHeight` (one per
         // wrapped visual row), so the virtualizer switches from the fixed-height
@@ -48,6 +54,7 @@
         fetchLineHistory,
         endLabel = "end of output",
         endTone = "muted",
+        error = null,
         wrap = $bindable(false),
     }: Props = $props();
 
@@ -556,6 +563,15 @@
         class="pointer-events-none absolute -top-[9999px] left-0 whitespace-pre select-none"
         >{RULER_SAMPLE}</span
     >
+
+    {#if error}
+        <div
+            class="flex shrink-0 items-center gap-2 border-b border-[var(--rw-con-gutter)] px-3.5 py-2 text-[11.5px]"
+            style="color: var(--rw-term-bad); background-color: color-mix(in srgb, var(--rw-term-bad) 12%, transparent);"
+        >
+            Failed to load log: {error}
+        </div>
+    {/if}
 
     <div bind:this={containerEl} class="flex-1 overflow-auto" onscroll={onScroll}>
         <div

--- a/packages/ui/src/lib/components/dashboard/RunDetailPanel.svelte
+++ b/packages/ui/src/lib/components/dashboard/RunDetailPanel.svelte
@@ -134,9 +134,40 @@
 
     let logConsole = $state<{ onStream: (event: LogEvent) => void } | null>(null);
 
+    // Message from the most recent seed-fetch failure (session expiry, daemon
+    // restart mid-request, ...), surfaced to LogConsole instead of letting a
+    // failed fetch render as an indistinguishable blank "no output" pane.
+    let logFetchError = $state<string | null>(null);
+
     // Derive a stable scalar so the effect only re-runs when the id actually
     // changes, not on every run object reference swap from SSE array updates.
     let runId = $derived(run?.id);
+
+    // Fetches the batched tail page a run's console opens on (see the effect
+    // below) and paints it into the console. Resolves the line the live
+    // stream should resume from, or null when there's nothing left to stream
+    // (the run already ended, or the caller cancelled while we were waiting).
+    // A failed fetch still falls back to an SSE tail backfill from scratch —
+    // it does not stop the console from live-tailing — but records the
+    // failure so LogConsole can show it instead of looking like a quiet run.
+    async function seedConsoleTail(
+        id: string,
+        isCancelled: () => boolean,
+    ): Promise<{ fromLine: number } | null> {
+        try {
+            const seed = await fetchLogs(id, -TAIL_LINES, -1);
+            if (isCancelled()) return null;
+            if (!isLogEvent(seed)) return { fromLine: -TAIL_LINES };
+            if (logConsole) logConsole.onStream(seed);
+            return seed.finished // ended run: nothing live to follow
+                ? null
+                : { fromLine: seed.sizeLines > 0 ? seed.sizeLines : -TAIL_LINES };
+        } catch (err) {
+            if (isCancelled()) return null;
+            logFetchError = err instanceof Error ? err.message : "Failed to load logs";
+            return { fromLine: -TAIL_LINES };
+        }
+    }
 
     $effect(() => {
         const id = runId;
@@ -144,6 +175,8 @@
 
         const stream = streamLogs;
         if (!stream) return;
+
+        logFetchError = null;
 
         let cleanup: (() => void) | undefined;
         let cancelled = false;
@@ -156,25 +189,14 @@
                 // the end. The live stream then picks up after the seeded tail
                 // (its disk backfill from that anchor closes the fetch↔stream
                 // race, and the daemon dedupes anything already shown).
-                let fromLine = -TAIL_LINES;
-                try {
-                    const seed = await fetchLogs(id, -TAIL_LINES, -1);
-                    if (cancelled) return;
-                    if (isLogEvent(seed)) {
-                        if (logConsole) logConsole.onStream(seed);
-                        if (seed.finished) return; // ended run: nothing live to follow
-                        if (seed.sizeLines > 0) fromLine = seed.sizeLines;
-                    }
-                } catch {
-                    // Seed failed — fall back to the SSE tail backfill.
-                }
-                if (cancelled) return;
+                const seeded = await seedConsoleTail(id, () => cancelled);
+                if (cancelled || !seeded) return;
                 cleanup = stream(
                     id,
                     (event: LogEvent) => {
                         if (logConsole) logConsole.onStream(event);
                     },
-                    { fromLine },
+                    { fromLine: seeded.fromLine },
                 );
             })();
         });
@@ -763,6 +785,7 @@
                     {highlightLine}
                     {endLabel}
                     {endTone}
+                    error={logFetchError}
                 />
             {/key}
         </div>


### PR DESCRIPTION
## Summary

A bug-hunt pass across the daemon, executor, notify, and web UI. Highlights:

- **Daemon locking**: two `runwisp daemon` processes on the same data dir can no longer both start — ownership is now claimed atomically via `flock` instead of a racy read-then-write PID file.
- **Cron**: a day-of-week step attached to bare `7` (e.g. `7/2`) no longer wraps into other days.
- **Log rotation**: reads reaching back past the most recent rotation now correctly fall back to the `.log.prev` segment instead of coming back empty; `.log.prev` itself is no longer deleted the instant a run ends.
- **Shutdown safety**: container/compose cleanup is now bounded so a hung Docker/Podman engine can't stall shutdown; a coalescing notify channel's `Close` no longer races its in-flight summary and recovers from panics; redacted notify errors keep their `Unwrap` chain so shutdown can still recognize `context.Canceled`.
- **Storage**: SQLite timestamps are now written in a format its own date/time functions can parse — `sortField=duration` was silently sorting by a constant zero.
- **Retention**: size-based cleanup now deletes the DB row before the log file, matching the crash-safety order of the other two purge paths.
- **Runtime**: a task's queue-drain goroutine no longer leaks forever after a reload flips `on_overlap` away from `"queue"`.
- **Fingerprint**: no longer changes when the binary is moved or the hostname changes.
- **API**: `wait=true`'s `waitTimeout` is capped at 240s so it can't outlive the server's write timeout; `allow_cloud_dispatch` now also gates HTTP-type ad-hoc dispatch.
- **Web UI**: unread notification count is taken from the server on every SSE event instead of local delta math; a failed log fetch now shows as an error instead of rendering as empty output; logging out mid-session disconnects SSE streams immediately.

See `CHANGELOG.md` for the full user-facing list.

## Test plan

- [x] `bun run ci` (generate, format, check, test, test-e2e) passes locally
- [x] New/updated unit tests accompany each fix (datadir, cronspec, executor, log_index, logsearch, notify/coalesce, retention, notifications store)