### PR TITLE
Fix catch-up, reload staleness, log rotation, import quoting, and runs-list races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Missed-run catch-up no longer misses gaps on tasks with `run_on_start`.** The daemon now anchors catch-up detection to the last run recorded before boot, rather than a run created during startup.
 - **`reload` and `SIGHUP` now apply a task's `treat_missed_as_failure` change immediately**, instead of requiring a full daemon restart.
 - **Fixed line numbering on `.log.prev` after 2+ log rotations**, once the run had finished.
+- **`import cron`/`import supervisord` no longer drop or corrupt data on plausible input.** A supervisord `environment=` value containing an apostrophe or stray quote (an English contraction, `O'Brien`) no longer swallows every subsequent `KEY=value` pair; a system crontab's user column now accepts uppercase account names (`Deploy`, not just `deploy`).
+- **The optional cloud integration's task list now reflects `reload`/`SIGHUP` on the next reconnect**, instead of staying frozen at whatever the daemon's task set looked like at startup.
+- **A jittered task with `on_overlap = "queue"` no longer leaks a stale in-flight slot when its queued run is orphaned by a `reload`** that removes or reconfigures the task.
+- **Fixed the runs list occasionally showing a duplicate or skipping a row** when a run started, finished, or was deleted live while the list was loading its next page.
 
 ## [0.16.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Missed-run catch-up no longer misses gaps on tasks with `run_on_start`.** The daemon now anchors catch-up detection to the last run recorded before boot, rather than a run created during startup.
+- **`reload` and `SIGHUP` now apply a task's `treat_missed_as_failure` change immediately**, instead of requiring a full daemon restart.
+- **Fixed line numbering on `.log.prev` after 2+ log rotations**, once the run had finished.
+
 ## [0.16.0] - 2026-08-23
 
 ### Added

--- a/apps/runwisp/cmd/runwisp/cmd_daemon_run.go
+++ b/apps/runwisp/cmd/runwisp/cmd_daemon_run.go
@@ -224,7 +224,7 @@ func runDaemon(mode daemonMode, f Flags, headless bool) (err error) {
 		svc:         svc,
 		srv:         srv,
 		fatalCh:     fatalCh,
-		reconciler:  reconciler,
+		reload:      reloadFn,
 		debugWriter: debugWriter,
 		logBuffer:   logBuffer,
 		cancelCloud: cancelCloud,
@@ -268,7 +268,18 @@ func newReconciler(mode daemonMode, cfg *daemonConfig, svc *daemonServices, f Fl
 		Snapshot:   snap,
 		Now:        time.Now,
 	})
-	return r, r.Reconcile
+	reload := func() (model.ReloadResult, error) {
+		result, err := r.Reconcile()
+		if err == nil {
+			// treat_missed_as_failure lives on model.Task, not [notify], so
+			// Reconcile() can change it live — refresh notify's mute set here
+			// rather than leaving it fixed at boot, or the change silently
+			// never takes effect short of a full restart.
+			syncMutedMissed(svc)
+		}
+		return result, err
+	}
+	return r, reload
 }
 
 // startCronHoldWatcher starts the loop that keeps the cron holds honest, so an

--- a/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
+++ b/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
@@ -18,8 +18,8 @@ import (
 	"github.com/runwisp/runwisp/internal/autostart"
 	"github.com/runwisp/runwisp/internal/clilog"
 	"github.com/runwisp/runwisp/internal/cloud"
+	"github.com/runwisp/runwisp/internal/model"
 	"github.com/runwisp/runwisp/internal/runlog"
-	"github.com/runwisp/runwisp/internal/runtime"
 	"github.com/runwisp/runwisp/internal/server"
 	"github.com/runwisp/runwisp/internal/tui"
 	"github.com/runwisp/runwisp/internal/tui/uikit"
@@ -276,7 +276,7 @@ type daemonRuntime struct {
 	svc         *daemonServices
 	srv         *server.Server
 	fatalCh     chan error
-	reconciler  *runtime.Reconciler
+	reload      func() (model.ReloadResult, error)
 	debugWriter *tui.DebugLogWriter
 	logBuffer   *server.DaemonLogBuffer
 	cancelCloud context.CancelFunc
@@ -332,12 +332,12 @@ func readFatal(ch <-chan error) error {
 // logged and the daemon keeps running on its current set — SIGHUP never tears
 // the process down. nil reconciler (cloud mode) makes this a logged no-op.
 func handleReloadSignal(rt *daemonRuntime) {
-	if rt.reconciler == nil {
+	if rt.reload == nil {
 		slog.Warn("received SIGHUP but reload is not available in this mode")
 		return
 	}
 	slog.Info("received SIGHUP, reloading configuration")
-	result, err := rt.reconciler.Reconcile()
+	result, err := rt.reload()
 	if err != nil {
 		slog.Error("reload rejected", "err", err)
 		return

--- a/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
+++ b/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
@@ -45,7 +45,7 @@ func startCloudClient(
 		RunRepo:           svc.DB,
 		PendingUploadRepo: svc.DB,
 		EventBus:          svc.EventBus,
-		LocalTasks:        svc.Tasks.Snapshot(),
+		LocalTasks:        svc.Tasks,
 		LogDir:            flags.LogDir(),
 		Availability:      svc.Executor.Availability(),
 		Now:               time.Now,

--- a/apps/runwisp/cmd/runwisp/daemon_notify.go
+++ b/apps/runwisp/cmd/runwisp/daemon_notify.go
@@ -50,6 +50,7 @@ func initNotify(
 	cfg *daemonConfig,
 	db storage.Database,
 	bus *events.Bus,
+	tasksMap map[string]*model.Task,
 	logger *slog.Logger,
 ) (notifyBundle, error) {
 	notifyCfg := cfg.Config.Notify
@@ -134,20 +135,33 @@ func initNotify(
 		Logger:           logger,
 		RetentionEvery:   5 * time.Minute,
 		RetentionFn:      retentionFn,
-		MutedMissedTasks: mutedMissedTasks(cfg.Config.Tasks),
+		MutedMissedTasks: mutedMissedTasks(tasksMap),
 	})
 
 	return notifyBundle{Service: svc, Hub: hub}, nil
 }
 
+// syncMutedMissed refreshes the notify service's per-task missed-run mute set
+// from the live task registry. Called after every successful reload (SIGHUP
+// and POST /api/daemon/reload both route through this) so a task's
+// treat_missed_as_failure change takes effect immediately instead of only
+// after a full daemon restart.
+func syncMutedMissed(svc *daemonServices) {
+	if svc.Notify.Service == nil {
+		return
+	}
+	svc.Notify.Service.SetMutedMissed(mutedMissedTasks(svc.Tasks.Snapshot()))
+}
+
 // mutedMissedTasks collects the names of tasks with treat_missed_as_failure = false.
 // The notify Service drops run.missed events for these at ingress, leaving the
 // browsable missed run row untouched. Returns nil when none are muted so the
-// common case allocates nothing.
-func mutedMissedTasks(tasks []model.Task) map[string]struct{} {
+// common case allocates nothing. Takes a name-keyed map so both the boot path
+// (built from cfg.Config.Tasks) and the reload path (the live TaskRegistry
+// snapshot) can share it.
+func mutedMissedTasks(tasks map[string]*model.Task) map[string]struct{} {
 	var muted map[string]struct{}
-	for i := range tasks {
-		t := &tasks[i]
+	for _, t := range tasks {
 		if t.NotifiesOnMissed() {
 			continue
 		}

--- a/apps/runwisp/cmd/runwisp/daemon_notify_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_notify_test.go
@@ -7,15 +7,18 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/runwisp/runwisp/internal/config"
 	"github.com/runwisp/runwisp/internal/events"
 	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/notify"
 	"github.com/runwisp/runwisp/internal/notify/channel"
 	"github.com/runwisp/runwisp/internal/notify/channel/inapp"
 	"github.com/runwisp/runwisp/internal/notify/coalesce"
+	"github.com/runwisp/runwisp/internal/runtime"
 	"github.com/runwisp/runwisp/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -202,7 +205,7 @@ func TestInitNotify_NoNotifiersNoRoutesReturnsZero(t *testing.T) {
 		},
 	}
 
-	bundle, err := initNotify(cfg, db, events.NewEventBus(), slog.Default())
+	bundle, err := initNotify(cfg, db, events.NewEventBus(), nil, slog.Default())
 	require.NoError(t, err)
 	assert.Nil(t, bundle.Service, "expected zero bundle when nothing is configured")
 	assert.Nil(t, bundle.Hub)
@@ -229,10 +232,21 @@ func TestInitNotify_InappRouteWiresHubAndService(t *testing.T) {
 		},
 	}
 
-	bundle, err := initNotify(cfg, db, events.NewEventBus(), slog.Default())
+	bundle, err := initNotify(cfg, db, events.NewEventBus(), nil, slog.Default())
 	require.NoError(t, err)
 	require.NotNil(t, bundle.Service, "expected Service when inapp route is wired")
 	require.NotNil(t, bundle.Hub, "expected Hub when inapp route is wired")
+}
+
+// taskMap builds the name-keyed map mutedMissedTasks expects, from a
+// varargs list — mirrors both the boot path (built from cfg.Config.Tasks)
+// and the reload path (a TaskRegistry snapshot).
+func taskMap(tasks ...model.Task) map[string]*model.Task {
+	m := make(map[string]*model.Task, len(tasks))
+	for i := range tasks {
+		m[tasks[i].Name] = &tasks[i]
+	}
+	return m
 }
 
 func TestMutedMissedTasks(t *testing.T) {
@@ -240,20 +254,20 @@ func TestMutedMissedTasks(t *testing.T) {
 	muteTrue := true
 
 	t.Run("nil when nothing is muted", func(t *testing.T) {
-		tasks := []model.Task{
-			{Name: "a"}, // omitted → notifies
-			{Name: "b", TreatMissedAsFailure: &muteTrue}, // explicit true → notifies
-		}
+		tasks := taskMap(
+			model.Task{Name: "a"}, // omitted → notifies
+			model.Task{Name: "b", TreatMissedAsFailure: &muteTrue}, // explicit true → notifies
+		)
 		assert.Nil(t, mutedMissedTasks(tasks),
 			"the common case must allocate nothing")
 	})
 
 	t.Run("collects only the explicit-false tasks", func(t *testing.T) {
-		tasks := []model.Task{
-			{Name: "loud"},
-			{Name: "quiet", TreatMissedAsFailure: &muteFalse},
-			{Name: "also-quiet", TreatMissedAsFailure: &muteFalse},
-		}
+		tasks := taskMap(
+			model.Task{Name: "loud"},
+			model.Task{Name: "quiet", TreatMissedAsFailure: &muteFalse},
+			model.Task{Name: "also-quiet", TreatMissedAsFailure: &muteFalse},
+		)
 		muted := mutedMissedTasks(tasks)
 		require.Len(t, muted, 2)
 		_, hasQuiet := muted["quiet"]
@@ -281,4 +295,73 @@ func TestRoutesReferenceInapp(t *testing.T) {
 			assert.Equal(t, tt.want, routesReferenceInapp(tt.routes))
 		})
 	}
+}
+
+// recordingChannel is a minimal notify.Channel that counts deliveries, for
+// asserting whether an event reached routing.
+type recordingChannel struct {
+	delivered atomic.Int64
+}
+
+func (c *recordingChannel) ID() string { return "test" }
+func (c *recordingChannel) Execute(context.Context, *notify.Event) error {
+	c.delivered.Add(1)
+	return nil
+}
+func (c *recordingChannel) Close(context.Context) error { return nil }
+
+func publishMissedRun(bus *events.Bus, taskName string) {
+	reason := model.ReasonMissed
+	bus.Publish(events.EventRunFailed, events.RunEvent{
+		Run: &model.Run{
+			TaskName:  taskName,
+			Status:    model.PhaseEnded,
+			EndReason: &reason,
+			ExitCode:  -1,
+		},
+	})
+}
+
+// TestSyncMutedMissed_ReloadTakesEffectWithoutRestart is the end-to-end
+// regression test for the reload-staleness bug: notify.Service used to fix
+// its missed-run mute set at construction time under the assumption that
+// treat_missed_as_failure could only change via a full restart. It's an
+// ordinary per-task field, so `runwisp reload`/SIGHUP can change it live —
+// syncMutedMissed (wired into every successful reload) must re-derive the
+// mute set from the live task registry and apply it immediately, with no
+// service restart.
+func TestSyncMutedMissed_ReloadTakesEffectWithoutRestart(t *testing.T) {
+	bus := events.NewEventBus()
+	recorder := &recordingChannel{}
+	svc := notify.New(notify.Config{
+		Bus:      bus,
+		Channels: []notify.Channel{recorder},
+		Rules: []notify.Rule{{
+			Match:     func(ev *notify.Event) bool { return ev.Kind == notify.KindRunMissed },
+			ActionIDs: []string{recorder.ID()},
+		}},
+	})
+	require.NoError(t, svc.Start(context.Background()))
+	t.Cleanup(func() { _ = svc.Stop(context.Background()) })
+
+	tasks := runtime.NewTaskRegistry(map[string]*model.Task{
+		"nightly": {Name: "nightly"}, // notifies by default
+	})
+	daemonSvc := &daemonServices{Tasks: tasks, Notify: notifyBundle{Service: svc}}
+	syncMutedMissed(daemonSvc)
+
+	publishMissedRun(bus, "nightly")
+	require.Eventually(t, func() bool { return recorder.delivered.Load() == 1 }, time.Second, time.Millisecond,
+		"nightly must alert on miss before the reload")
+
+	// Simulate a reload that flips treat_missed_as_failure to false, the way
+	// Reconciler.applyChanged swaps the changed task into the live registry.
+	muteFalse := false
+	tasks.Set(&model.Task{Name: "nightly", TreatMissedAsFailure: &muteFalse})
+	syncMutedMissed(daemonSvc)
+
+	publishMissedRun(bus, "nightly")
+	time.Sleep(50 * time.Millisecond) // let the async dispatch settle
+	assert.Equal(t, int64(1), recorder.delivered.Load(),
+		"reload must mute run.missed immediately, without restarting the daemon")
 }

--- a/apps/runwisp/cmd/runwisp/daemon_services.go
+++ b/apps/runwisp/cmd/runwisp/daemon_services.go
@@ -108,13 +108,14 @@ func initDaemonServices(ctx context.Context, cfg *daemonConfig, db storage.Datab
 
 	debugSrv := startDebugServer()
 
-	notifyB := startNotify(ctx, cfg, db, eventBus, addWarning)
+	notifyB := startNotify(ctx, cfg, db, eventBus, tasksMap, addWarning)
 
 	if mode == modeStandalone {
 		// Run catch-up now that notify is subscribed, so a missed-run gap
 		// detected from persisted history raises a run.missed alert instead of
-		// emitting into a bus nobody is listening on yet.
-		boot.catchUpResult = runMissedTickCatchUp(ctx, db, tasksMap, taskManager, boot.schedLoc)
+		// emitting into a bus nobody is listening on yet. Uses the anchor
+		// snapshot captured before the scheduler/run_on_start could taint it.
+		boot.catchUpResult = runMissedTickCatchUp(tasksMap, taskManager, boot.catchUpNow, boot.schedLoc, boot.catchUpAnchors, boot.catchUpSnapshotErrors)
 	}
 
 	return &daemonServices{
@@ -150,6 +151,13 @@ type standaloneBoot struct {
 	pendingSummary   uikit.PendingRunsSummary
 	runOnStartResult runtime.RunOnStartResult
 	catchUpResult    runtime.CatchUpResult
+	// catchUpNow and catchUpAnchors/catchUpSnapshotErrors are captured by
+	// SnapshotCatchupAnchors before the scheduler starts or run_on_start
+	// fires — see the comment in startStandaloneScheduling. The deferred
+	// runMissedTickCatchUp call (after notify subscribes) consumes them.
+	catchUpNow            time.Time
+	catchUpAnchors        map[string]time.Time
+	catchUpSnapshotErrors int
 }
 
 // startStandaloneScheduling brings up the scheduler, resumes pending runs, and
@@ -169,6 +177,17 @@ func startStandaloneScheduling(ctx context.Context, cfg *daemonConfig, db storag
 		return boot, locErr
 	}
 	boot.schedLoc = schedLoc
+
+	// Snapshot catch-up anchors now, before anything below can create a run
+	// for this boot: scheduler.Start() can fire a live tick and
+	// RunStartupTasks always creates a run for run_on_start tasks. Reading
+	// "the last run" any later would pick up that boot-time run instead of
+	// the real last run before the daemon went down, silently hiding the
+	// downtime gap catch-up exists to detect. runMissedTickCatchUp consumes
+	// this snapshot later, once notify has subscribed.
+	boot.catchUpNow = time.Now()
+	boot.catchUpAnchors, boot.catchUpSnapshotErrors = runtime.SnapshotCatchupAnchors(ctx, db, tasksMap, boot.catchUpNow)
+
 	scheduler := runtime.NewScheduler(taskManager, tasksMap, schedLoc, nil)
 	boot.scheduler = scheduler
 	schedResult, err := scheduler.Start()
@@ -197,8 +216,8 @@ func startStandaloneScheduling(ctx context.Context, cfg *daemonConfig, db storag
 // startNotify initializes the notify subsystem and starts its service, routing
 // both the init failure and the start failure to warnings (non-fatal: the
 // daemon must boot even when notify is misconfigured or unavailable).
-func startNotify(ctx context.Context, cfg *daemonConfig, db storage.Database, eventBus *events.Bus, addWarning func(string, ...any)) notifyBundle {
-	notifyB, err := initNotify(cfg, db, eventBus, slog.Default())
+func startNotify(ctx context.Context, cfg *daemonConfig, db storage.Database, eventBus *events.Bus, tasksMap map[string]*model.Task, addWarning func(string, ...any)) notifyBundle {
+	notifyB, err := initNotify(cfg, db, eventBus, tasksMap, slog.Default())
 	if err != nil {
 		addWarning("Failed to initialize notify subsystem: %v", err)
 	}
@@ -212,9 +231,11 @@ func startNotify(ctx context.Context, cfg *daemonConfig, db storage.Database, ev
 
 // runMissedTickCatchUp runs missed-tick catch-up and narrates the outcome via
 // slog only when something went wrong; the banner already shows the triggered
-// total, so default-verbosity INFO output stays uncluttered.
-func runMissedTickCatchUp(ctx context.Context, db storage.Database, tasksMap map[string]*model.Task, taskManager runtime.TaskManager, schedLoc *time.Location) runtime.CatchUpResult {
-	catchUpResult := runtime.RunMissedTickCatchUp(ctx, db, tasksMap, taskManager, time.Now(), schedLoc)
+// total, so default-verbosity INFO output stays uncluttered. now and anchors
+// come from startStandaloneScheduling's SnapshotCatchupAnchors call, captured
+// before the scheduler or run_on_start could create a run for this boot.
+func runMissedTickCatchUp(tasksMap map[string]*model.Task, taskManager runtime.TaskManager, now time.Time, schedLoc *time.Location, anchors map[string]time.Time, snapshotErrors int) runtime.CatchUpResult {
+	catchUpResult := runtime.RunMissedTickCatchUp(tasksMap, taskManager, now, schedLoc, anchors, snapshotErrors)
 	if catchUpResult.Errors > 0 {
 		slog.Warn("Missed-tick catch-up completed with errors",
 			"triggered", catchUpResult.Triggered, "errors", catchUpResult.Errors)

--- a/apps/runwisp/internal/cloud/client.go
+++ b/apps/runwisp/internal/cloud/client.go
@@ -40,7 +40,7 @@ type Dependencies struct {
 	RunRepo           ExternalRunGetter
 	PendingUploadRepo PendingLogUploadRepository
 	EventBus          EventSubscriber
-	LocalTasks        map[string]*model.Task
+	LocalTasks        LocalTaskSource
 	LogDir            string
 	Availability      executor.Availability
 	OnConnected       func()
@@ -65,7 +65,7 @@ type Client struct {
 
 	syncClient   *TaskSyncClient
 	taskManager  TaskRunner
-	localTasks   map[string]*model.Task
+	localTasks   LocalTaskSource
 	availability executor.Availability
 	onConnected  func()
 	handler      *InboundHandler
@@ -105,15 +105,6 @@ func NewClient(cfg Config, deps Dependencies) (*Client, error) {
 		return nil, fmt.Errorf("cloud client requires event bus")
 	}
 
-	localTasks := make(map[string]*model.Task, len(deps.LocalTasks))
-	for name, task := range deps.LocalTasks {
-		if task == nil {
-			continue
-		}
-		copyTask := *task
-		localTasks[name] = &copyTask
-	}
-
 	tracker := NewExecutionTracker()
 	connMgr := newConnectionManager(tracker)
 
@@ -125,7 +116,7 @@ func NewClient(cfg Config, deps Dependencies) (*Client, error) {
 		logDir:       deps.LogDir,
 		syncClient:   NewTaskSyncClient(cfg.TaskSyncURL(), requestTimeout),
 		taskManager:  deps.TaskManager,
-		localTasks:   localTasks,
+		localTasks:   deps.LocalTasks,
 		availability: deps.Availability,
 		onConnected:  deps.OnConnected,
 		tracker:      tracker,
@@ -320,15 +311,24 @@ func (client *Client) syncTasks(ctx context.Context, connection *websocket.Conn)
 // snapshotForSync builds the task set reported in tasks.sync: the TOML-loaded
 // local tasks plus every daemon-supervised service the task manager currently
 // holds that the TOML doesn't already cover. The extras are cloud-declared
-// services (registered at runtime via service:apply, named "cloud-<id>"); folding
-// them in tells the cloud they are live on this runner, which gates their
-// deletion. A cold-start's first sync runs before any service:apply has landed,
-// so a freshly declared service is confirmed on the next sync (reconnect or
-// TOML reload), not this one — the task manager retains it across reconnects.
+// services (registered at runtime via service:apply, named "cloud-<id>");
+// folding them in tells the cloud they are live on this runner, which gates
+// their deletion. Run-to-completion tasks the manager also holds (e.g. an
+// ad-hoc inline cloud dispatch) are deliberately excluded by the
+// ListServiceTasks filter — those are one-shot executions, never a live task
+// on this runner, and reporting them would misrepresent them as persistent.
+// A cold-start's first sync runs before any service:apply has landed, so a
+// freshly declared service is confirmed on the next sync (reconnect or TOML
+// reload), not this one — the task manager retains it across reconnects.
 func (client *Client) snapshotForSync() map[string]*model.Task {
-	snapshot := make(map[string]*model.Task, len(client.localTasks))
-	for name, task := range client.localTasks {
-		snapshot[name] = task
+	snapshot := map[string]*model.Task{}
+	if client.localTasks != nil {
+		for name, task := range client.localTasks.Snapshot() {
+			if task == nil {
+				continue
+			}
+			snapshot[name] = task
+		}
 	}
 	if client.taskManager != nil {
 		for _, svc := range client.taskManager.ListServiceTasks() {

--- a/apps/runwisp/internal/cloud/client_test.go
+++ b/apps/runwisp/internal/cloud/client_test.go
@@ -747,7 +747,7 @@ func TestNewClient_MissingEventBus(t *testing.T) {
 	assert.Contains(t, err.Error(), "event bus")
 }
 
-func TestNewClient_CopiesLocalTasksAndSkipsNil(t *testing.T) {
+func TestNewClient_SkipsNilLocalTask(t *testing.T) {
 	baseURL, _ := url.Parse("http://localhost:0")
 	bus := events.NewEventBus()
 	mockExec := &testutil.MockExecutor{}
@@ -755,6 +755,7 @@ func TestNewClient_CopiesLocalTasksAndSkipsNil(t *testing.T) {
 	defer jm.Shutdown()
 
 	original := &model.Task{Name: "alpha"}
+	registry := runtime.NewTaskRegistry(map[string]*model.Task{"alpha": original, "beta": nil})
 	client, err := NewClient(Config{
 		Enabled: true,
 		BaseURL: baseURL,
@@ -762,18 +763,56 @@ func TestNewClient_CopiesLocalTasksAndSkipsNil(t *testing.T) {
 		TaskManager: &testTaskRunnerAdapter{inner: jm},
 		RunRepo:     &testutil.MockRunRepository{},
 		EventBus:    bus,
-		LocalTasks:  map[string]*model.Task{"alpha": original, "beta": nil},
+		LocalTasks:  registry,
 		LogDir:      t.TempDir(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	// localTasks copy must contain "alpha" but skip the nil "beta" entry.
-	require.Contains(t, client.localTasks, "alpha")
-	assert.NotContains(t, client.localTasks, "beta")
-	// And the copy is a distinct pointer from the caller-supplied value.
-	assert.NotSame(t, original, client.localTasks["alpha"])
-	assert.Equal(t, "alpha", client.localTasks["alpha"].Name)
+	snapshot := client.snapshotForSync()
+	require.Contains(t, snapshot, "alpha")
+	assert.NotContains(t, snapshot, "beta")
+	assert.Equal(t, "alpha", snapshot["alpha"].Name)
+}
+
+// TestSnapshotForSync_ReflectsLiveReload is the bug: a `runwisp reload` that
+// adds/renames/removes tasks mutates the daemon's live TaskRegistry without a
+// process restart, but the cloud client used to snapshot that registry once
+// at startCloudClient time. tasks.sync kept reporting the boot-time task set
+// forever, even across reconnects, until the whole daemon process restarted.
+func TestSnapshotForSync_ReflectsLiveReload(t *testing.T) {
+	baseURL, _ := url.Parse("http://localhost:0")
+	bus := events.NewEventBus()
+	mockExec := &testutil.MockExecutor{}
+	jm := runtime.NewTaskManager(mockExec, bus, time.Now)
+	defer jm.Shutdown()
+
+	registry := runtime.NewTaskRegistry(map[string]*model.Task{"backup": {Name: "backup"}})
+	client, err := NewClient(Config{
+		Enabled: true,
+		BaseURL: baseURL,
+	}, Dependencies{
+		TaskManager: &testTaskRunnerAdapter{inner: jm},
+		RunRepo:     &testutil.MockRunRepository{},
+		EventBus:    bus,
+		LocalTasks:  registry,
+		LogDir:      t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	before := client.snapshotForSync()
+	require.Contains(t, before, "backup")
+	require.NotContains(t, before, "cleanup")
+
+	// Simulate `runwisp reload`: rename backup -> nightly-backup, add cleanup.
+	registry.Delete("backup")
+	registry.Set(&model.Task{Name: "nightly-backup"})
+	registry.Set(&model.Task{Name: "cleanup"})
+
+	after := client.snapshotForSync()
+	assert.NotContains(t, after, "backup", "reload removed this task; sync must stop reporting it")
+	assert.Contains(t, after, "nightly-backup")
+	assert.Contains(t, after, "cleanup")
 }
 
 // Nil-receiver Run is a safe no-op so callers can wire the cloud client

--- a/apps/runwisp/internal/cloud/dependencies.go
+++ b/apps/runwisp/internal/cloud/dependencies.go
@@ -54,6 +54,15 @@ type TaskRunner interface {
 	ServiceSnapshot(taskName string) (model.ServiceSnapshot, bool)
 }
 
+// LocalTaskSource returns the daemon's current TOML-defined task set. The
+// cloud client re-reads it on every sync rather than caching it once, so a
+// `runwisp reload` (which mutates the registry live, without a process
+// restart) is reflected on the next reconnect. *runtime.TaskRegistry
+// satisfies this directly via its existing Snapshot method.
+type LocalTaskSource interface {
+	Snapshot() map[string]*model.Task
+}
+
 // ExternalRunGetter is the subset of run persistence the cloud package needs.
 // Mirrors a slice of storage.RunRepository so the cloud doesn't depend on
 // the SQLite-backed concrete.

--- a/apps/runwisp/internal/configedit/txn.go
+++ b/apps/runwisp/internal/configedit/txn.go
@@ -65,7 +65,7 @@ func New() *Txn { return &Txn{} }
 // Apply is still the file's original content. Nothing touches the disk until
 // Apply.
 func (t *Txn) Write(path string, data []byte, perm fs.FileMode) {
-	t.queued = append(t.queued, queuedWrite{path: path, data: data, perm: perm})
+	t.enqueue(queuedWrite{path: path, data: data, perm: perm})
 }
 
 // Remove queues the deletion of a file. Its pre-image is captured at Apply like
@@ -77,7 +77,7 @@ func (t *Txn) Write(path string, data []byte, perm fs.FileMode) {
 // into the operator's own config: an empty runwisp.d/imported.toml would only
 // look like it still had something to say.
 func (t *Txn) Remove(path string) {
-	t.queued = append(t.queued, queuedWrite{path: path, remove: true})
+	t.enqueue(queuedWrite{path: path, remove: true})
 }
 
 // WritePreservingOwner queues a full rewrite of a file that must land under the
@@ -88,7 +88,22 @@ func (t *Txn) Remove(path string) {
 // writeFileAtomicPreservingOwner) rather than silently landing owned by
 // whoever the daemon runs as.
 func (t *Txn) WritePreservingOwner(path string, data []byte) {
-	t.queued = append(t.queued, queuedWrite{path: path, data: data, preserveOwner: true})
+	t.enqueue(queuedWrite{path: path, data: data, preserveOwner: true})
+}
+
+// enqueue queues w, replacing any earlier queued operation on the same path so
+// "last write wins" holds at queue time rather than at Apply: at most one
+// queued operation ever exists per path, so Apply never performs a write that
+// a later one in the same Txn immediately discards, and its backup step never
+// needs to distinguish a path's first appearance from a repeat.
+func (t *Txn) enqueue(w queuedWrite) {
+	for i := range t.queued {
+		if t.queued[i].path == w.path {
+			t.queued[i] = w
+			return
+		}
+	}
+	t.queued = append(t.queued, w)
 }
 
 // Apply writes every queued file through temp+rename (or removes it, for a
@@ -108,6 +123,9 @@ func (t *Txn) Apply(gate func() error) error {
 		}
 	}
 
+	// enqueue collapses repeat writes to the same path down to one queued
+	// operation, so each path appears here at most once — its backup is
+	// always the true pre-transaction original.
 	for _, w := range t.queued {
 		backups = append(backups, backupFile(w.path))
 		if err := w.perform(); err != nil {

--- a/apps/runwisp/internal/configedit/txn_test.go
+++ b/apps/runwisp/internal/configedit/txn_test.go
@@ -49,6 +49,44 @@ func TestTxn_GateFailureRestoresEveryPreImage(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "a file that didn't exist must not survive a rollback")
 }
 
+// TestTxn_GateFailureRestoresOriginalWhenPathWrittenTwice is the same
+// guarantee as TestTxn_GateFailureRestoresEveryPreImage, but for a path
+// queued more than once in the same Txn (Write's own doc: "the pre-image
+// captured at Apply is still the file's original content"). A rollback must
+// land back on the true original, not on the intermediate write.
+func TestTxn_GateFailureRestoresOriginalWhenPathWrittenTwice(t *testing.T) {
+	dir := writeFileTree(t, map[string]string{"existing.toml": "original\n"})
+	existing := filepath.Join(dir, "existing.toml")
+
+	txn := New()
+	txn.Write(existing, []byte("intermediate\n"), DefaultPerm)
+	txn.Write(existing, []byte("final\n"), DefaultPerm)
+
+	sentinel := errors.New("gate says no")
+	err := txn.Apply(func() error { return sentinel })
+	require.ErrorIs(t, err, sentinel)
+
+	assert.Equal(t, "original\n", readFile(t, existing), "must roll back to the true original, not the intermediate write")
+}
+
+// TestTxn_RepeatedWriteCollapsesAtQueueTime pins down where "last write wins"
+// is enforced: at Write time, not at Apply. A repeat write to an already-queued
+// path replaces the earlier entry in place rather than piling up a second one,
+// so Apply never performs (and then discards) an intermediate write.
+func TestTxn_RepeatedWriteCollapsesAtQueueTime(t *testing.T) {
+	txn := New()
+	txn.Write("/a", []byte("first"), DefaultPerm)
+	txn.Write("/b", []byte("other"), DefaultPerm)
+	txn.Write("/a", []byte("second"), DefaultPerm)
+
+	require.Len(t, txn.queued, 2)
+	for _, w := range txn.queued {
+		if w.path == "/a" {
+			assert.Equal(t, []byte("second"), w.data)
+		}
+	}
+}
+
 // TestTxn_RemoveDeletesTheFile covers `promote` retiring the staging file once
 // its last entry has moved into the operator's own config.
 func TestTxn_RemoveDeletesTheFile(t *testing.T) {

--- a/apps/runwisp/internal/executor/log_writer.go
+++ b/apps/runwisp/internal/executor/log_writer.go
@@ -479,9 +479,14 @@ func (w *LogWriter) Close() error {
 
 	// Persist finalized metadata so readers never need to scan the file. This
 	// also creates the container for short runs that produced no index/frames.
+	// PrevStart must be carried forward from the last rotation (see
+	// rewriteContainerForRotation) — sidecar records are last-write-wins, so
+	// omitting it here would zero out the .prev segment's real start line the
+	// moment the run ends.
 	w.appendRecord(logutil.MetaRecord(logutil.LogMeta{
 		RotatedLines: w.rotatedLines,
 		RotatedBytes: w.rotatedBytes,
+		PrevStart:    w.prevSegmentStart,
 		FinalLines:   w.lineCount,
 		Finalized:    true,
 	}))

--- a/apps/runwisp/internal/executor/log_writer_test.go
+++ b/apps/runwisp/internal/executor/log_writer_test.go
@@ -284,6 +284,7 @@ func TestLogWriter_MultipleRotationsMeta(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		w.WriteLineEvent(line, logutil.StreamStdout)
 	}
+	wantPrevStart := w.prevSegmentStart
 	require.NoError(t, w.Close())
 
 	assert.True(t, w.truncated)
@@ -293,6 +294,13 @@ func TestLogWriter_MultipleRotationsMeta(t *testing.T) {
 	assert.Greater(t, meta.RotatedLines, int64(0), "should have rotated away some lines")
 	assert.Greater(t, meta.RotatedBytes, int64(0), "should have rotated away some bytes")
 	assert.Greater(t, meta.FinalLines, int64(0), "current file should have lines")
+
+	// Regression: Close()'s finalized meta record must carry PrevStart forward
+	// from the last rotation. Sidecar records are last-write-wins, so omitting
+	// it there zeroes out the .prev segment's real start line the instant the
+	// run ends, corrupting every reader's line numbering for that segment.
+	require.Greater(t, wantPrevStart, int64(0), "test must exercise 2+ rotations for PrevStart to be meaningful")
+	assert.Equal(t, wantPrevStart, meta.PrevStart, "Close() must preserve PrevStart from the last rotation")
 
 	// Total lines should account for all written lines
 	totalLines := meta.RotatedLines + meta.FinalLines

--- a/apps/runwisp/internal/importer/cron.go
+++ b/apps/runwisp/internal/importer/cron.go
@@ -827,7 +827,7 @@ func isLikelyUsername(s string) bool {
 	}
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if !(c == '_' || c == '-' || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+		if !(c == '_' || c == '-' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
 			return false
 		}
 	}

--- a/apps/runwisp/internal/importer/cron_test.go
+++ b/apps/runwisp/internal/importer/cron_test.go
@@ -654,6 +654,19 @@ func TestCronSystemLineWithARealUserColumnStillImports(t *testing.T) {
 	}
 }
 
+// TestCronSystemUserColumnAcceptsUppercase: POSIX login names may contain
+// uppercase letters (RHEL/cronie/openSUSE useradd all permit them), so a real
+// account like "Deploy" must not be declined as an unlikely username.
+func TestCronSystemUserColumnAcceptsUppercase(t *testing.T) {
+	res := parseCron(t, "0 3 * * * Deploy /usr/bin/backup.sh --now\n", CronOptions{System: true})
+	out := res.TOML()
+	mustContain(t, out, `user = "Deploy"`)
+	mustContain(t, out, `run = "/usr/bin/backup.sh --now"`)
+	if got := res.Items()[0].Status(); got != StatusClean {
+		t.Errorf("status = %v, want clean", got)
+	}
+}
+
 // TestCronSystemUserColumnMustNameARealAccount closes the half of the missing
 // user column the shape sniff cannot see: `echo` is a flawless login name by
 // shape, so `* * * * * echo "hi"` in /etc/cron.d imported as user `echo` running

--- a/apps/runwisp/internal/importer/supervisord.go
+++ b/apps/runwisp/internal/importer/supervisord.go
@@ -562,7 +562,7 @@ func parseSupervisordEnv(value string) map[string]string {
 			} else {
 				val.WriteByte(c)
 			}
-		case (c == '"' || c == '\'') && !inKey:
+		case (c == '"' || c == '\'') && !inKey && val.Len() == 0:
 			inQuote = c
 		case c == '=' && inKey:
 			inKey = false

--- a/apps/runwisp/internal/importer/supervisord_test.go
+++ b/apps/runwisp/internal/importer/supervisord_test.go
@@ -261,3 +261,35 @@ func TestSupervisordSkipEmitsNoOtherNotes(t *testing.T) {
 		t.Fatalf("a skipped program must not explain a mapping that never happened: %+v", allNotes(res))
 	}
 }
+
+// TestParseSupervisordEnvApostropheMidValue guards against a quote character
+// appearing mid-value (an English contraction, an apostrophe-name) being
+// mistaken for the start of a quoted value — which previously swallowed
+// every subsequent KEY=value pair into the current one.
+func TestParseSupervisordEnvApostropheMidValue(t *testing.T) {
+	got := parseSupervisordEnv(`MSG=it's fine,DEBUG=1`)
+	want := map[string]string{"MSG": "it's fine", "DEBUG": "1"}
+	if len(got) != len(want) {
+		t.Fatalf("parseSupervisordEnv(...) = %#v, want %#v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("parseSupervisordEnv(...) = %#v, want %#v", got, want)
+		}
+	}
+}
+
+// TestParseSupervisordEnvQuotedValueStillHonored makes sure a genuinely
+// quoted value (the documented syntax) still has its commas protected.
+func TestParseSupervisordEnvQuotedValueStillHonored(t *testing.T) {
+	got := parseSupervisordEnv(`GREETING="a,b",OTHER=x`)
+	want := map[string]string{"GREETING": "a,b", "OTHER": "x"}
+	if len(got) != len(want) {
+		t.Fatalf("parseSupervisordEnv(...) = %#v, want %#v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("parseSupervisordEnv(...) = %#v, want %#v", got, want)
+		}
+	}
+}

--- a/apps/runwisp/internal/notify/notify.go
+++ b/apps/runwisp/internal/notify/notify.go
@@ -36,9 +36,13 @@ type Service struct {
 	// mutedMissed is the set of task names whose run.missed events are
 	// suppressed (treat_missed_as_failure = false). The browsable missed run row is
 	// still persisted by the runtime; only the active notification is dropped,
-	// at ingress, before routing. Restart-static — config reload is
-	// restart-only — so a plain set is correct.
-	mutedMissed map[string]struct{}
+	// at ingress, before routing. treat_missed_as_failure is an ordinary
+	// per-task field (not part of [notify]), so a `runwisp reload`/SIGHUP can
+	// change it live — SetMutedMissed lets the reload path push the refreshed
+	// set in. An atomic.Pointer lets onBusEvent (called from the bus
+	// publisher goroutine) read it without locking against a concurrent
+	// reload.
+	mutedMissed atomic.Pointer[map[string]struct{}]
 
 	clock  Clocker
 	logger *slog.Logger
@@ -101,7 +105,7 @@ func New(cfg Config) *Service {
 	router := NewRouter(cfg.Rules, channelByID)
 	disp := newDispatcher(router, channelByID, DefaultActionQueueSize, clock, cfg.FailureSink, logger)
 
-	return &Service{
+	s := &Service{
 		bus:            cfg.Bus,
 		ingressCh:      make(chan *Event, DefaultActionQueueSize),
 		router:         router,
@@ -112,8 +116,17 @@ func New(cfg Config) *Service {
 		logger:         logger,
 		retentionEvery: retentionEvery,
 		retentionFn:    cfg.RetentionFn,
-		mutedMissed:    cfg.MutedMissedTasks,
 	}
+	s.mutedMissed.Store(&cfg.MutedMissedTasks)
+	return s
+}
+
+// SetMutedMissed replaces the set of task names whose run.missed events are
+// suppressed. Safe to call concurrently with onBusEvent — used by the reload
+// path so a live `treat_missed_as_failure` change takes effect immediately
+// instead of only after a full daemon restart.
+func (s *Service) SetMutedMissed(muted map[string]struct{}) {
+	s.mutedMissed.Store(&muted)
 }
 
 // Start subscribes to the event bus, launches the dispatch goroutine and the
@@ -237,8 +250,10 @@ func (s *Service) onBusEvent(e events.Event) {
 	// after mapping, because the additive route model can't express a per-task
 	// deny against the global catch-all that delivers run.missed by default.
 	if ev.Kind == KindRunMissed {
-		if _, muted := s.mutedMissed[ev.TaskName]; muted {
-			return
+		if muted := s.mutedMissed.Load(); muted != nil {
+			if _, ok := (*muted)[ev.TaskName]; ok {
+				return
+			}
 		}
 	}
 	// RLock lets concurrent publishes send in parallel (channel sends are

--- a/apps/runwisp/internal/notify/notify_test.go
+++ b/apps/runwisp/internal/notify/notify_test.go
@@ -77,6 +77,32 @@ func TestOnBusEvent_UnmutedMissedTaskRoutes(t *testing.T) {
 	}
 }
 
+// TestSetMutedMissed_TakesEffectImmediately is the regression test for the
+// reload-staleness bug: mutedMissed used to be fixed at construction time
+// under the (false) assumption that treat_missed_as_failure could only change
+// via a full restart. It is an ordinary per-task field, so a live
+// `runwisp reload`/SIGHUP can change it — SetMutedMissed must be observed by
+// onBusEvent right away, in both directions, without reconstructing the
+// Service.
+func TestSetMutedMissed_TakesEffectImmediately(t *testing.T) {
+	svc := New(Config{MutedMissedTasks: map[string]struct{}{"quiet-task": {}}})
+
+	svc.SetMutedMissed(nil)
+	svc.onBusEvent(missedRunEvent("quiet-task"))
+	select {
+	case ev := <-svc.ingressCh:
+		assert.Equal(t, "quiet-task", ev.TaskName, "unmuting must take effect without a restart")
+	default:
+		t.Fatal("expected quiet-task's run.missed to route once unmuted")
+	}
+
+	svc.SetMutedMissed(map[string]struct{}{"loud-task": {}})
+	before := svc.droppedIngress.Load()
+	svc.onBusEvent(missedRunEvent("loud-task"))
+	assert.Empty(t, svc.ingressCh, "muting must take effect without a restart")
+	assert.Equal(t, before, svc.droppedIngress.Load(), "an intentional mute is not a backpressure drop")
+}
+
 // TestOnBusEvent_MissedRoutesByDefault confirms misses alert with no mute set —
 // the default-on behaviour (decision: misses reach failure subscribers).
 func TestOnBusEvent_MissedRoutesByDefault(t *testing.T) {

--- a/apps/runwisp/internal/runtime/catchup.go
+++ b/apps/runwisp/internal/runtime/catchup.go
@@ -24,14 +24,21 @@ type CatchUpResult struct {
 	Errors    int
 }
 
-// RunMissedTickCatchUp inspects each scheduled task and triggers catch-up runs
-// for cron ticks that were missed while the daemon was down. defaultLoc is the
-// scheduler's resolved timezone ([scheduler] timezone); a task's own timezone
-// overrides it, exactly as the live scheduler resolves it.
-func RunMissedTickCatchUp(ctx context.Context, db storage.RunRepository, tasks map[string]*model.Task, runner TaskRunner, now time.Time, defaultLoc *time.Location) CatchUpResult {
-	var result CatchUpResult
-	parser := cronspec.NewScheduleParser()
-
+// SnapshotCatchupAnchors resolves every schedulable task's catch-up anchor
+// (registering its first-seen timestamp along the way) and returns a snapshot
+// keyed by task name; a task absent from the result has no usable anchor
+// (never seen before and its registration couldn't be read back) and must be
+// skipped by RunMissedTickCatchUp. errs counts registration/lookup failures.
+//
+// Call this before the scheduler starts and before RunStartupTasks fires —
+// both can create a run for this boot, and if that happens before the anchor
+// is read, the boot's own run masquerades as "the last run", hiding the real
+// downtime gap it exists to detect. RunMissedTickCatchUp itself must still run
+// later, once notify has subscribed (see its own doc comment) — this split is
+// what lets detection happen at the right time while alerting still happens
+// after the right time.
+func SnapshotCatchupAnchors(ctx context.Context, db storage.RunRepository, tasks map[string]*model.Task, now time.Time) (anchors map[string]time.Time, errs int) {
+	anchors = make(map[string]time.Time, len(tasks))
 	for _, task := range tasks {
 		// The re-run policy is not consulted: detection is independent of it, so
 		// even catch_up = "skip" records and alerts on the gap. What is consulted
@@ -47,7 +54,43 @@ func RunMissedTickCatchUp(ctx context.Context, db storage.RunRepository, tasks m
 		if !task.Schedulable() {
 			continue
 		}
-		triggered, errors := catchupOneTask(ctx, db, parser, task, runner, now, defaultLoc)
+		// Persist first-seen timestamp; INSERT OR IGNORE is a no-op on every
+		// restart after the first. On first startup firstSeenAt == now, so
+		// countMissedTicks returns 0 — no spurious initial run.
+		if err := db.EnsureTaskRegistered(ctx, task.Name, now); err != nil {
+			slog.Warn("Failed to register task for catch-up", "task", task.Name, "err", err)
+			errs++
+			continue
+		}
+		at, ok, errCount := resolveCatchupAnchor(ctx, db, task)
+		errs += errCount
+		if ok {
+			anchors[task.Name] = at
+		}
+	}
+	return anchors, errs
+}
+
+// RunMissedTickCatchUp triggers catch-up runs for cron ticks that were missed
+// while the daemon was down, for every task with an entry in anchors (from a
+// prior SnapshotCatchupAnchors call — a task with no entry is skipped).
+// defaultLoc is the scheduler's resolved timezone ([scheduler] timezone); a
+// task's own timezone overrides it, exactly as the live scheduler resolves it.
+// snapshotErrors seeds the result so registration/lookup failures from the
+// snapshot phase are still reflected in the total.
+func RunMissedTickCatchUp(tasks map[string]*model.Task, runner TaskRunner, now time.Time, defaultLoc *time.Location, anchors map[string]time.Time, snapshotErrors int) CatchUpResult {
+	result := CatchUpResult{Errors: snapshotErrors}
+	parser := cronspec.NewScheduleParser()
+
+	for _, task := range tasks {
+		if !task.Schedulable() {
+			continue
+		}
+		anchor, ok := anchors[task.Name]
+		if !ok {
+			continue
+		}
+		triggered, errors := catchupOneTask(parser, task, runner, now, defaultLoc, anchor)
 		result.Triggered += triggered
 		result.Errors += errors
 	}
@@ -69,16 +112,9 @@ func catchupSchedule(parser cron.ScheduleParser, task *model.Task, defaultLoc *t
 }
 
 // catchupOneTask processes a single task's catch-up logic and returns the
-// number of runs triggered and errors encountered.
-func catchupOneTask(ctx context.Context, db storage.RunRepository, parser cron.ScheduleParser, task *model.Task, runner TaskRunner, now time.Time, defaultLoc *time.Location) (triggered, errors int) {
-	// Persist first-seen timestamp; INSERT OR IGNORE is a no-op on every
-	// restart after the first. On first startup firstSeenAt == now, so
-	// countMissedTicks returns 0 — no spurious initial run.
-	if err := db.EnsureTaskRegistered(ctx, task.Name, now); err != nil {
-		slog.Warn("Failed to register task for catch-up", "task", task.Name, "err", err)
-		return 0, 1
-	}
-
+// number of runs triggered and errors encountered. anchor is the task's
+// catch-up anchor, resolved earlier by SnapshotCatchupAnchors.
+func catchupOneTask(parser cron.ScheduleParser, task *model.Task, runner TaskRunner, now time.Time, defaultLoc *time.Location, anchor time.Time) (triggered, errors int) {
 	schedule, loc, err := catchupSchedule(parser, task, defaultLoc)
 	if err != nil {
 		slog.Warn("Failed to parse schedule for catch-up", "task", task.Name, "err", err)
@@ -88,11 +124,6 @@ func catchupOneTask(ctx context.Context, db storage.RunRepository, parser cron.S
 	// case the schedule preserves the input location, so converting the anchor
 	// and now here is what pins evaluation to defaultLoc.
 	now = now.In(loc)
-
-	anchor, ok, errCount := resolveCatchupAnchor(ctx, db, task)
-	if !ok {
-		return 0, errCount
-	}
 	anchor = anchor.In(loc)
 
 	// Bound counting at max(cap, floor)+1: the +1 lets computeCatchupTriggers

--- a/apps/runwisp/internal/runtime/catchup_anchor_test.go
+++ b/apps/runwisp/internal/runtime/catchup_anchor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/runwisp/runwisp/internal/storage"
 	"github.com/runwisp/runwisp/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,7 +66,7 @@ func TestRunMissedTickCatchUp_RecordedRowAnchorsNextRestart(t *testing.T) {
 	}))
 
 	now1 := time.Date(2026, 4, 7, 10, 20, 0, 0, time.UTC)
-	res1 := RunMissedTickCatchUp(context.Background(), db, tasks, jm, now1, time.UTC)
+	res1 := runCatchUp(context.Background(), db, tasks, jm, now1, time.UTC)
 	assert.Equal(t, 0, res1.Errors)
 	assert.Equal(t, 0, res1.Triggered, "skip re-fires nothing")
 
@@ -86,7 +87,7 @@ func TestRunMissedTickCatchUp_RecordedRowAnchorsNextRestart(t *testing.T) {
 	// Second restart two minutes later — still inside the same */5 window, so
 	// there is nothing new to miss.
 	now2 := time.Date(2026, 4, 7, 10, 22, 0, 0, time.UTC)
-	res2 := RunMissedTickCatchUp(context.Background(), db, tasks, jm, now2, time.UTC)
+	res2 := runCatchUp(context.Background(), db, tasks, jm, now2, time.UTC)
 	assert.Equal(t, 0, res2.Errors)
 	assert.Equal(t, 0, res2.Triggered)
 
@@ -97,4 +98,70 @@ func TestRunMissedTickCatchUp_RecordedRowAnchorsNextRestart(t *testing.T) {
 		return sErr == nil && s.Missed != 1
 	}, 100*time.Millisecond, 10*time.Millisecond,
 		"a restart inside the same tick window must not record a second missed row")
+}
+
+// TestSnapshotCatchupAnchors_FreezesBeforeContaminatingWrites is the
+// regression test for the boot-order bug: production calls
+// SnapshotCatchupAnchors before the scheduler starts or run_on_start fires,
+// specifically because either can write a fresh run for this boot before
+// catch-up ever runs (catch-up itself is deferred until notify subscribes).
+// Before the fix, the equivalent of this anchor read happened live, at
+// catch-up time — so a run_on_start task's own boot-time run (or a tick the
+// live scheduler already fired) became "the last run", and a real downtime
+// gap was silently reported as zero missed ticks.
+func TestSnapshotCatchupAnchors_FreezesBeforeContaminatingWrites(t *testing.T) {
+	db, err := storage.New(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	task := catchupTask(model.MissedRunAll) // */5 * * * *, MaxCatchUpRuns: 100
+	task.RunOnStart = true
+	tasks := map[string]*model.Task{task.Name: task}
+
+	// The real last run before the daemon went down: six hours ago.
+	staleAnchor := time.Date(2026, 4, 7, 4, 0, 0, 0, time.UTC)
+	require.NoError(t, db.CreateRun(ctx, &model.Run{
+		ID:        ulid.Make().String(),
+		TaskName:  task.Name,
+		Status:    model.PhaseEnded,
+		EndReason: model.EndReasonPtr(model.ReasonSuccess),
+		CreatedAt: staleAnchor,
+	}))
+
+	now := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+
+	// Snapshot the anchor at true boot time, before anything else can write a
+	// run for this boot.
+	anchors, errs := SnapshotCatchupAnchors(ctx, db, tasks, now)
+	require.Equal(t, 0, errs)
+
+	// Simulate what RunStartupTasks (or a live scheduler tick) does next in
+	// the real boot sequence: create a fresh run for this boot, stamped "now".
+	require.NoError(t, db.CreateRun(ctx, &model.Run{
+		ID:          ulid.Make().String(),
+		TaskName:    task.Name,
+		Status:      model.PhaseEnded,
+		EndReason:   model.EndReasonPtr(model.ReasonSuccess),
+		TriggeredBy: model.TriggeredByStartup,
+		CreatedAt:   now,
+	}))
+
+	// Prove the contamination is real: a live query for "the last run" now
+	// returns the boot-time run, not the stale one — this is exactly what the
+	// pre-fix code queried at catch-up time.
+	lastRun, err := db.GetLastRunByTask(ctx, task.Name)
+	require.NoError(t, err)
+	require.True(t, lastRun.CreatedAt.Equal(now), "sanity: the boot-time run is now the DB's most recent row")
+
+	runner := new(mockTaskRunner)
+	runner.On("RecordMissedRun", task.Name, mock.Anything, mock.Anything).Return(nil)
+	runner.On("TriggerRun", task.Name, model.TriggeredByCron).Return(&model.Run{}, nil)
+
+	result := RunMissedTickCatchUp(tasks, runner, now, time.UTC, anchors, errs)
+
+	// Six hours at */5 = 72 missed ticks, detected despite the DB's "last run"
+	// now being the contaminating boot-time write.
+	assert.Equal(t, 72, result.Triggered,
+		"catch-up must use the frozen pre-boot anchor, not the live (contaminated) last run")
 }

--- a/apps/runwisp/internal/runtime/catchup_test.go
+++ b/apps/runwisp/internal/runtime/catchup_test.go
@@ -17,10 +17,22 @@ import (
 
 	"github.com/runwisp/runwisp/internal/cronspec"
 	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/storage"
 	"github.com/runwisp/runwisp/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+// runCatchUp recreates the pre-refactor single-call shape (resolve anchors,
+// then run catch-up) so the scenario tests below — written against that
+// shape — don't need rewriting just to exercise the now-two-phase production
+// API (SnapshotCatchupAnchors + RunMissedTickCatchUp). See
+// TestSnapshotCatchupAnchors_FreezesBeforeContaminatingWrites for a test of
+// the split itself.
+func runCatchUp(ctx context.Context, db storage.RunRepository, tasks map[string]*model.Task, runner TaskRunner, now time.Time, loc *time.Location) CatchUpResult {
+	anchors, errs := SnapshotCatchupAnchors(ctx, db, tasks, now)
+	return RunMissedTickCatchUp(tasks, runner, now, loc, anchors, errs)
+}
 
 func catchupTask(policy model.MissedRunPolicy) *model.Task {
 	return &model.Task{
@@ -233,7 +245,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 1, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 1)
@@ -260,7 +272,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 4, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 4)
@@ -295,7 +307,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 2, result.Triggered,
 			"the New York midnights in the window must be counted in America/New_York, not UTC")
@@ -322,7 +334,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return(lastRun, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 0, result.Triggered, "skip never re-fires a missed tick")
 		assert.Equal(t, 0, result.Errors)
@@ -347,7 +359,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return(nil, nil)
 		db.On("GetTaskRegistration", mock.Anything, "my-task").Return(reg, nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 0, result.Triggered)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -372,7 +384,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 1, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 1)
@@ -396,7 +408,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 4, result.Triggered)
 		runner.AssertNumberOfCalls(t, "TriggerRun", 4)
@@ -422,7 +434,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 5, result.Triggered, "cap of 5 must clamp the 12-tick backlog")
 		runner.AssertNumberOfCalls(t, "TriggerRun", 5)
@@ -455,7 +467,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 			return strings.Contains(reason, "at least") && strings.Contains(reason, "+")
 		})).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 5, result.Triggered, "cap of 5 must clamp the per-second backlog")
 		runner.AssertNumberOfCalls(t, "TriggerRun", 5)
@@ -487,7 +499,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 			return anchor.Equal(now)
 		}), mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 0, result.Triggered, "skip policy re-runs nothing")
 		runner.AssertNumberOfCalls(t, "RecordMissedRun", 1)
@@ -514,7 +526,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return(&model.Run{}, nil)
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 12, result.Triggered, "backlog under the cap must be backfilled in full")
 		runner.AssertNumberOfCalls(t, "TriggerRun", 12)
@@ -531,7 +543,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 
 		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(assert.AnError)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors,
 			"failure to register the task surfaces as a catch-up error, not a silent skip")
@@ -550,8 +562,12 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		tasks := map[string]*model.Task{"my-task": task}
 
 		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(nil)
+		// A valid anchor, so SnapshotCatchupAnchors doesn't skip the task before
+		// RunMissedTickCatchUp ever reaches the cron parse this test targets.
+		db.On("GetLastRunByTask", mock.Anything, "my-task").
+			Return(&model.Run{CreatedAt: now.Add(-time.Hour)}, nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -569,7 +585,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(nil)
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return((*model.Run)(nil), assert.AnError)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -588,7 +604,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return((*model.Run)(nil), nil)
 		db.On("GetTaskRegistration", mock.Anything, "my-task").Return((*model.TaskRegistration)(nil), assert.AnError)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -607,7 +623,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return((*model.Run)(nil), nil)
 		db.On("GetTaskRegistration", mock.Anything, "my-task").Return((*model.TaskRegistration)(nil), nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 0, result.Errors,
 			"missing registration with no prior run isn't an error — the task simply has no anchor yet")
@@ -634,7 +650,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).Return(nil)
 		runner.On("TriggerRun", "my-task", model.TriggeredByCron).Return((*model.Run)(nil), assert.AnError)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 		assert.Equal(t, 0, result.Triggered)
 		assert.Equal(t, 1, result.Errors)
 	})
@@ -658,7 +674,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		db.On("EnsureTaskRegistered", mock.Anything, "my-task", now).Return(nil)
 		db.On("GetLastRunByTask", mock.Anything, "my-task").Return(lastRun, nil)
 
-		result := RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		result := runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Equal(t, 0, result.Triggered)
 		runner.AssertNotCalled(t, "TriggerRun")
@@ -689,7 +705,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 				gotReason = args.Get(2).(string)
 			}).Return(nil)
 
-		RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		runner.AssertNumberOfCalls(t, "RecordMissedRun", 1)
 		wantTick := time.Date(2026, 4, 7, 10, 20, 0, 0, time.UTC)
@@ -721,7 +737,7 @@ func TestRunMissedTickCatchUp(t *testing.T) {
 		runner.On("RecordMissedRun", "my-task", mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) { gotReason = args.Get(2).(string) }).Return(nil)
 
-		RunMissedTickCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
+		runCatchUp(context.Background(), db, tasks, runner, now, time.UTC)
 
 		assert.Contains(t, gotReason, "12 scheduled runs missed",
 			"alert reports the detected total even though only 5 were re-run")

--- a/apps/runwisp/internal/runtime/hold_test.go
+++ b/apps/runwisp/internal/runtime/hold_test.go
@@ -263,7 +263,7 @@ func TestCatchUpSkipsHeldTaskAndLeavesNoAnchor(t *testing.T) {
 	held := heldCronTask("held", "0 * * * *")
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 
-	result := RunMissedTickCatchUp(context.Background(), db,
+	result := runCatchUp(context.Background(), db,
 		map[string]*model.Task{"held": held}, runner, now, time.UTC)
 
 	assert.Equal(t, 0, result.Triggered)
@@ -285,13 +285,13 @@ func TestCatchUpAfterHoldLiftsCountsNoMissedTicks(t *testing.T) {
 
 	// A week of the daemon running with the job held by cron.
 	start := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
-	RunMissedTickCatchUp(context.Background(), db, held, runner, start, time.UTC)
+	runCatchUp(context.Background(), db, held, runner, start, time.UTC)
 
 	// cron is retired, the config reloads, the hold is gone.
 	unheld := *task
 	unheld.HeldBy = model.HeldByNothing
 	later := start.Add(7 * 24 * time.Hour)
-	result := RunMissedTickCatchUp(context.Background(), db,
+	result := runCatchUp(context.Background(), db,
 		map[string]*model.Task{"job": &unheld}, runner, later, time.UTC)
 
 	assert.Equal(t, 0, result.Triggered,

--- a/apps/runwisp/internal/runtime/jitter_gate_test.go
+++ b/apps/runwisp/internal/runtime/jitter_gate_test.go
@@ -361,3 +361,54 @@ func TestJitterGate_ShutdownAbandonsPending(t *testing.T) {
 	assert.Equal(t, 0, jm.GetActiveRunCount("b"), "no run is created for the abandoned fire")
 	exec.noMoreStarts(t)
 }
+
+// gateInflightIDs snapshots the gate's in-flight run IDs under its lock.
+func gateInflightIDs(g *jitterGate) map[string]bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make(map[string]bool, len(g.inflight))
+	for id := range g.inflight {
+		out[id] = true
+	}
+	return out
+}
+
+// TestJitterGate_RemoveTaskRetiresOrphanedQueuedRunFromGate is the bug: a
+// jittered fire that breaches into the manager's own per-task queue (because
+// OnOverlap=Queue and the concurrency slot is already taken by an earlier
+// gate-fired run) is recorded as in-flight in the gate — by design, since it
+// still has to run eventually. But if the task is removed (a `runwisp
+// reload`) while that run is still sitting in the queue, RemoveTask finalizes
+// it via endOrphanedPending without ever telling the gate, so it never runs
+// and never completes — leaving a permanent stale entry in the gate's
+// in-flight set that (for one jitter window) makes freeFor() wrongly report
+// the gate as busy for unrelated tasks, and leaks forever after that.
+func TestJitterGate_RemoveTaskRetiresOrphanedQueuedRunFromGate(t *testing.T) {
+	clk := testutil.NewClock(time.Date(2026, 6, 10, 3, 0, 0, 0, time.UTC))
+	jm, exec, mt, _ := newJitterTestManager(t, clk.Now)
+	jm.UpsertTask(testTask("t", model.PolicyQueue, 1))
+
+	tick := clk.Now()
+	jm.ScheduleJitteredRun("t", tick, tick, 30*time.Minute) // gate free: pulled forward at once
+	idA := exec.waitStarted(t)                              // occupies t's only concurrency slot
+
+	// A second tick for the same task: the daemon-wide gate is busy (a is
+	// in flight), so this one is held — then forced through by its breach
+	// timer despite the gate being congested, straight into t's own queue
+	// (OnOverlap=Queue, MaxConcurrent=1, a still holds the slot).
+	jm.ScheduleJitteredRun("t", tick.Add(time.Minute), tick.Add(time.Minute), 30*time.Minute)
+	require.Equal(t, 1, mt.pending(), "b is held behind a")
+	mt.fireAll()
+	exec.noMoreStarts(t) // b is sitting in t's queue, not executing
+
+	inflight := gateInflightIDs(jm.gate)
+	require.Len(t, inflight, 2, "both the running a and the queued b are tracked in-flight")
+	require.True(t, inflight[idA])
+
+	// A reload removes the task while b is still queued.
+	jm.RemoveTask("t")
+
+	after := gateInflightIDs(jm.gate)
+	assert.Len(t, after, 1, "the orphaned queued run must be retired from the gate's in-flight set")
+	assert.True(t, after[idA], "only the still-running a may remain in-flight")
+}

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -163,6 +163,17 @@ func (m *defaultTaskManager) registerForceKill(runID string, forceKill func()) {
 
 // UpsertTask adds a task if missing or replaces the existing definition.
 func (m *defaultTaskManager) UpsertTask(task *model.Task) {
+	// A run orphaned out of the queue below may have been recorded as
+	// in-flight by the jitter gate (a breached fire that queued behind the
+	// concurrency limit). Retiring it from the gate must happen after m.mu is
+	// released (gateMu -> mu lock order; see jitterGate's doc), so the flush
+	// is deferred ahead of the lock — LIFO defer order runs it after Unlock.
+	var orphanedRunIDs []string
+	defer func() {
+		for _, id := range orphanedRunIDs {
+			m.gate.onComplete(id)
+		}
+	}()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -215,12 +226,27 @@ func (m *defaultTaskManager) UpsertTask(task *model.Task) {
 		// 'pending' with no goroutine left to start or finalize them. Finalize
 		// whatever is queued the same way RemoveTask does, then broadcast
 		// unconditionally so a loop parked on an already-empty queue wakes too.
-		for _, r := range ts.queue {
-			m.endOrphanedPending(r)
-		}
-		ts.queue = nil
+		orphanedRunIDs = m.finalizeOrphanedQueue(ts)
 		ts.cond.Broadcast()
 	}
+}
+
+// finalizeOrphanedQueue ends every run still sitting in ts.queue (a policy
+// change or task removal left them with no drain loop to ever start them)
+// and reports their IDs, so the caller can retire them from the jitter gate
+// once m.mu is released — a queued run can be one it marked in-flight (see
+// jitterGate.fire). Caller holds m.mu.
+func (m *defaultTaskManager) finalizeOrphanedQueue(ts *taskState) []string {
+	if len(ts.queue) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(ts.queue))
+	for _, r := range ts.queue {
+		m.endOrphanedPending(r)
+		ids = append(ids, r.ID)
+	}
+	ts.queue = nil
+	return ids
 }
 
 // RemoveTask drops a task from the manager when a reload removes it.
@@ -232,6 +258,14 @@ func (m *defaultTaskManager) UpsertTask(task *model.Task) {
 // taskState is deleted now when nothing is in flight; otherwise the last run's
 // recordRunOutcome deletes it on retirement (single-writer-per-task preserved).
 func (m *defaultTaskManager) RemoveTask(taskName string) {
+	// See UpsertTask: a queued run orphaned below may be tracked in-flight by
+	// the jitter gate, and retiring it must happen after m.mu is released.
+	var orphanedRunIDs []string
+	defer func() {
+		for _, id := range orphanedRunIDs {
+			m.gate.onComplete(id)
+		}
+	}()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -245,10 +279,7 @@ func (m *defaultTaskManager) RemoveTask(taskName string) {
 	// Queued runs were already persisted as 'pending'; finalize them here so a
 	// reload that removes the task never leaves a permanent non-terminal row.
 	if ts.cond != nil {
-		for _, r := range ts.queue {
-			m.endOrphanedPending(r)
-		}
-		ts.queue = nil
+		orphanedRunIDs = m.finalizeOrphanedQueue(ts)
 		ts.cond.Broadcast()
 	}
 

--- a/apps/ui/src/lib/utils/runs-source.svelte.ts
+++ b/apps/ui/src/lib/utils/runs-source.svelte.ts
@@ -142,9 +142,34 @@ export function createRunsSource(): RunsSource {
 
     const done = $derived(currentFilters !== null && items.length >= total);
 
+    // A live upsert() or remove() can mutate `items` while a page request is in
+    // flight, shifting every later run's true server-side rank — forward on an
+    // insert, back on a removal. Either way the page fetched at `offset` no
+    // longer lines up with what's already loaded: applying it directly would
+    // re-deliver an already-loaded run (rank shifted forward) or silently skip
+    // one (rank shifted back). `expectedLength` is the pre-fetch length; a
+    // mismatch means drift occurred, so retry from the corrected offset
+    // instead of guessing.
+    function resolvePage(
+        res: { runs: Run[]; total: number },
+        replace: boolean,
+        expectedLength: number,
+    ): void {
+        if (replace) {
+            items = res.runs;
+        } else if (items.length !== expectedLength) {
+            void fetchPage(items.length, false);
+            return;
+        } else {
+            items = [...items, ...res.runs];
+        }
+        total = res.total;
+    }
+
     async function fetchPage(offset: number, replace: boolean): Promise<void> {
         if (!currentFilters) return;
         const f = currentFilters;
+        const expectedLength = replace ? 0 : items.length;
         const token = ++fetchToken;
         loading = true;
         try {
@@ -153,8 +178,7 @@ export function createRunsSource(): RunsSource {
                 ? await tasksApi.getRuns(f.taskName, query)
                 : await runsApi.getAll(query);
             if (token !== fetchToken) return;
-            items = replace ? res.runs : [...items, ...res.runs];
-            total = res.total;
+            resolvePage(res, replace, expectedLength);
             error = null;
         } catch (err) {
             if (token !== fetchToken) return;

--- a/apps/ui/src/lib/utils/runs-source.test.ts
+++ b/apps/ui/src/lib/utils/runs-source.test.ts
@@ -107,6 +107,107 @@ describe("createRunsSource", () => {
         src.refresh();
         expect(runsApi.getAll).not.toHaveBeenCalled();
     });
+
+    // A loadMore() page fetch captures its offset from items.length at call
+    // time. If a live SSE upsert() splices a new row to the front while that
+    // fetch is still in flight, every already-loaded run's true server-side
+    // rank shifts forward by one — so the in-flight page (computed at the old
+    // offset) would re-deliver an already-loaded row if merged blindly.
+    // fetchPage detects the drift (items.length no longer matches what it was
+    // when the request started) and retries from the corrected offset instead.
+    it("retries loadMore's page instead of duplicating a run when a live SSE insert shifts ranks forward", async () => {
+        const src = createRunsSource();
+        const r5 = makeRun("r5", { createdAt: "2026-06-22T12:05:00.000Z" });
+        const r4 = makeRun("r4", { createdAt: "2026-06-22T12:04:00.000Z" });
+        const r3 = makeRun("r3", { createdAt: "2026-06-22T12:03:00.000Z" });
+        vi.mocked(runsApi.getAll).mockResolvedValueOnce({ runs: [r5, r4, r3], total: 10 });
+        src.setFilters(baseFilters());
+        await vi.waitFor(() => {
+            expect(src.loaded).toBe(true);
+        });
+        expect(src.items.map((r) => r.id)).toEqual(["r5", "r4", "r3"]);
+
+        // Kick off loadMore() (offset=3) but hold the response back.
+        let resolveStale: (v: { runs: Run[]; total: number }) => void = () => {};
+        const stale = new Promise<{ runs: Run[]; total: number }>((resolve) => {
+            resolveStale = resolve;
+        });
+        vi.mocked(runsApi.getAll).mockReturnValueOnce(stale);
+        src.loadMore();
+        expect(runsApi.getAll).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 3 }));
+
+        // A run finishes and its SSE update arrives before the page above
+        // resolves — inserted at the front, shifting r5/r4/r3's true rank.
+        const fresh = makeRun("fresh", { createdAt: "2026-06-22T12:06:00.000Z" });
+        src.upsert(fresh);
+        expect(src.items.map((r) => r.id)).toEqual(["fresh", "r5", "r4", "r3"]);
+
+        // The stale page (whatever it contains) must be discarded, never
+        // merged — its content is irrelevant to the assertions below.
+        const ghost = makeRun("ghost", { createdAt: "2026-06-22T12:03:30.000Z" });
+        resolveStale({ runs: [ghost], total: 11 });
+
+        // A retry fires at the corrected offset (4, matching items.length
+        // after the insert), and its response is what actually gets merged.
+        const r2 = makeRun("r2", { createdAt: "2026-06-22T12:02:00.000Z" });
+        vi.mocked(runsApi.getAll).mockResolvedValueOnce({ runs: [r2], total: 11 });
+        await vi.waitFor(() => {
+            expect(runsApi.getAll).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 4 }));
+        });
+        await vi.waitFor(() => {
+            expect(src.items.map((r) => r.id)).toContain("r2");
+        });
+
+        expect(src.items.map((r) => r.id)).toEqual(["fresh", "r5", "r4", "r3", "r2"]);
+    });
+
+    // The opposite direction of the same race: a live remove() (the optimistic
+    // delete, or its SSE echo) shifts every later run's true server-side rank
+    // *back* by one while loadMore()'s page is in flight. Blindly appending
+    // that page would silently skip a run entirely — there's no duplicate id
+    // to filter out, the row is just gone. The same drift detection that
+    // fixes the insert case must also catch this and retry.
+    it("retries loadMore's page instead of skipping a run when a live remove shifts ranks back", async () => {
+        const src = createRunsSource();
+        const r5 = makeRun("r5", { createdAt: "2026-06-22T12:05:00.000Z" });
+        const r4 = makeRun("r4", { createdAt: "2026-06-22T12:04:00.000Z" });
+        const r3 = makeRun("r3", { createdAt: "2026-06-22T12:03:00.000Z" });
+        vi.mocked(runsApi.getAll).mockResolvedValueOnce({ runs: [r5, r4, r3], total: 10 });
+        src.setFilters(baseFilters());
+        await vi.waitFor(() => {
+            expect(src.loaded).toBe(true);
+        });
+
+        let resolveStale: (v: { runs: Run[]; total: number }) => void = () => {};
+        const stale = new Promise<{ runs: Run[]; total: number }>((resolve) => {
+            resolveStale = resolve;
+        });
+        vi.mocked(runsApi.getAll).mockReturnValueOnce(stale);
+        src.loadMore();
+        expect(runsApi.getAll).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 3 }));
+
+        // r4 is deleted (the SSE echo of a real deletion) while that page is
+        // still in flight.
+        src.remove("r4");
+        expect(src.items.map((r) => r.id)).toEqual(["r5", "r3"]);
+
+        const ghost = makeRun("ghost", { createdAt: "2026-06-22T12:03:30.000Z" });
+        resolveStale({ runs: [ghost], total: 10 });
+
+        // Without drift detection this page (fetched at the pre-removal
+        // offset 3) would land at what is now rank 2, and the run that
+        // belongs there — r2 — would never be fetched at all.
+        const r2 = makeRun("r2", { createdAt: "2026-06-22T12:02:00.000Z" });
+        vi.mocked(runsApi.getAll).mockResolvedValueOnce({ runs: [r2], total: 9 });
+        await vi.waitFor(() => {
+            expect(runsApi.getAll).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 2 }));
+        });
+        await vi.waitFor(() => {
+            expect(src.items.map((r) => r.id)).toContain("r2");
+        });
+
+        expect(src.items.map((r) => r.id)).toEqual(["r5", "r3", "r2"]);
+    });
 });
 
 // A live SSE row is merged through `upsert`, which re-evaluates the active


### PR DESCRIPTION
## Summary

Six bug fixes, all post-0.16.0:

- Missed-run catch-up no longer misses gaps on tasks with `run_on_start`. The daemon now anchors catch-up detection to the last run recorded before boot, rather than a run created during startup.
- `reload` and `SIGHUP` now apply a task's `treat_missed_as_failure` change immediately, instead of requiring a full daemon restart.
- Fixed line numbering on `.log.prev` after 2+ log rotations, once the run had finished.
- `import cron`/`import supervisord` no longer drop or corrupt data on plausible input: a supervisord `environment=` value containing an apostrophe or stray quote no longer swallows every subsequent `KEY=value` pair, and a system crontab's user column now accepts uppercase account names.
- The optional cloud integration's task list now reflects `reload`/`SIGHUP` on the next reconnect, instead of staying frozen at the daemon's startup-time task set.
- Fixed the runs list occasionally showing a duplicate or skipping a row when a run started, finished, or was deleted live while the list was loading its next page.

## Test plan

- [x] `bun run ci` (generate, format, check, test, test-e2e) passes locally
- [ ] CI green on this PR