### PR TITLE
Fix reload kind-flip run cancel, wedged-engine hangs, coalesce count, and supervisord include merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A notifier's `retry_budget` now applies to SMTP and sendmail notifiers too**, not just Slack, Discord, Telegram, and webhook.
 - **The unread-notification badge no longer overcounts after a failed "mark read" action**, even if a newer update for that notification had arrived while the request was in flight.
 - **Local CLI/TUI streaming connections (log tail, event stream) are no longer subject to the same per-IP cap as remote clients** — only the overall connection limit still applies to them.
+- **`reload` no longer silently restarts a service the operator had stopped (or that had exhausted its retry budget) when only its config changed.** A changed service now recycles its running instances in place, leaving a stopped or fatally-failed service exactly as it was.
+- **Killing a task's Docker/Podman container during shutdown or a `graceful_stop` no longer hangs indefinitely if the container engine itself stops responding.**
+- **Fetching a run's log or searching logs now returns a proper error instead of a misleading "not found" when the underlying storage lookup itself fails.**
+- **A rejected config write (failed validation on `reload`) now rolls back through the same crash-safe atomic write every config write uses**, instead of a plain in-place write that could leave the file corrupted if interrupted mid-rollback.
+- **A notifier's `retry_budget` is now honoured even when a single delivery attempt hangs**, by capping the HTTP client's own timeout to the configured budget.
 
 ## [0.16.1] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fetching a run's log or searching logs now returns a proper error instead of a misleading "not found" when the underlying storage lookup itself fails.**
 - **A rejected config write (failed validation on `reload`) now rolls back through the same crash-safe atomic write every config write uses**, instead of a plain in-place write that could leave the file corrupted if interrupted mid-rollback.
 - **A notifier's `retry_budget` is now honoured even when a single delivery attempt hangs**, by capping the HTTP client's own timeout to the configured budget.
+- **Redefining a plain task as a service on `reload` now starts the new service like any newly-added one and lets the in-flight run finish under its old definition**, instead of cancelling that still-draining run.
+- **A coalesced notification now states how many repeats it stands in for** (`×N`), so a folded burst of failures no longer reads as a single occurrence.
+- **A hung (not merely down) Docker/Podman engine no longer blocks container-task startup indefinitely** — the first-connect probe is now time-bounded, so one wedged engine can't stall every other container task's start.
+- **`import supervisord` now merges a `[program]` that appears in more than one included file** (last value wins, as supervisord itself assembles it), instead of importing it twice as `web` and `web-2`.
 
 ## [0.16.1] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A task removed by `reload` and then re-added by a later `reload` now resumes as a normal running service**, instead of coming back with all instances stopped.
+- **Log rotation no longer deletes the previous rotated segment (`.log.prev`) when the rename that replaces it fails**, and a failed write to the active log file no longer advances its line/byte counters as though it had succeeded.
+- **A notifier's `retry_budget` now applies to SMTP and sendmail notifiers too**, not just Slack, Discord, Telegram, and webhook.
+- **The unread-notification badge no longer overcounts after a failed "mark read" action**, even if a newer update for that notification had arrived while the request was in flight.
+- **Local CLI/TUI streaming connections (log tail, event stream) are no longer subject to the same per-IP cap as remote clients** — only the overall connection limit still applies to them.
+
 ## [0.16.1] - 2026-08-28
 
 ### Fixed

--- a/apps/runwisp/cmd/runwisp/daemon_notify.go
+++ b/apps/runwisp/cmd/runwisp/daemon_notify.go
@@ -78,7 +78,12 @@ func initNotify(
 
 	if override := backoffOverride(notifyCfg.RetryBudget, logger); override != nil {
 		for i := range resolved.Notifiers {
-			resolved.Notifiers[i].Transport = override()
+			t := override()
+			resolved.Notifiers[i].Transport = t
+			// SMTP/sendmail don't go through Transport at all, so the override
+			// must also be threaded through as a plain BackoffConfig or
+			// retry_budget silently has no effect on those channels.
+			resolved.Notifiers[i].Backoff = t.Backoff
 		}
 	}
 

--- a/apps/runwisp/cmd/runwisp/daemon_notify.go
+++ b/apps/runwisp/cmd/runwisp/daemon_notify.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/runwisp/runwisp/internal/config"
@@ -197,6 +198,13 @@ func backoffOverride(d time.Duration, logger *slog.Logger) func() *notify.HTTPPr
 			bo.MaxInterval = d
 		}
 		t.Backoff = bo
+		// The client's own per-request timeout must not outlive the budget: cenkalti's
+		// backoff only checks MaxElapsedTime between attempts, so an unbounded (or
+		// merely larger) per-request timeout lets one hanging request alone block
+		// past a budget the operator asked for.
+		if client, ok := t.Client.(*http.Client); ok && client.Timeout > d {
+			client.Timeout = d
+		}
 		return t
 	}
 }

--- a/apps/runwisp/cmd/runwisp/daemon_notify_test.go
+++ b/apps/runwisp/cmd/runwisp/daemon_notify_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -67,6 +68,31 @@ func TestBackoffOverride(t *testing.T) {
 		assert.LessOrEqual(t, provider.Backoff.MaxElapsedTime, cap)
 		assert.LessOrEqual(t, provider.Backoff.InitialInterval, cap)
 		assert.LessOrEqual(t, provider.Backoff.MaxInterval, cap)
+	})
+	// Regression: retry_budget used to only rewrite the backoff schedule, never
+	// the HTTP client's own fixed 15s request timeout. A single hanging request
+	// could then block far longer than the operator's configured budget before
+	// MaxElapsedTime (checked only between attempts) ever got a chance to fire.
+	t.Run("shrinks the client timeout when smaller than the default", func(t *testing.T) {
+		cap := 2 * time.Second
+		fn := backoffOverride(cap, slog.Default())
+		require.NotNil(t, fn)
+		provider := fn()
+		require.NotNil(t, provider)
+		client, ok := provider.Client.(*http.Client)
+		require.True(t, ok)
+		assert.LessOrEqual(t, client.Timeout, cap,
+			"a single request must not be able to outlive retry_budget")
+	})
+	t.Run("leaves the client timeout alone when the budget is larger", func(t *testing.T) {
+		cap := time.Minute
+		fn := backoffOverride(cap, slog.Default())
+		require.NotNil(t, fn)
+		provider := fn()
+		require.NotNil(t, provider)
+		client, ok := provider.Client.(*http.Client)
+		require.True(t, ok)
+		assert.Equal(t, 15*time.Second, client.Timeout)
 	})
 }
 

--- a/apps/runwisp/internal/configedit/txn.go
+++ b/apps/runwisp/internal/configedit/txn.go
@@ -173,6 +173,12 @@ type fileBackup struct {
 	path    string
 	existed bool
 	perm    fs.FileMode
+	// owner is the file's uid/gid at backup time, captured so restore's
+	// rename-based replace (which otherwise takes on the temp file's own
+	// ownership) can put a preserve-owner write's file back under its original
+	// owner. Nil when the platform can't report it (restore then falls back to
+	// whatever owns the process doing the restore).
+	owner   *ownerID
 	content []byte
 }
 
@@ -186,20 +192,21 @@ func backupFile(path string) fileBackup {
 	b.content = data
 	if info, err := os.Stat(path); err == nil {
 		b.perm = info.Mode().Perm()
+		if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+			b.owner = &ownerID{uid: int(stat.Uid), gid: int(stat.Gid)}
+		}
 	}
 	return b
 }
 
-// restore returns the file to its snapshotted state: rewriting the prior content
-// and mode, or removing the file if it didn't exist before. Best-effort — a
+// restore returns the file to its snapshotted state: rewriting the prior
+// content, mode, and owner through the same temp+rename path every forward
+// write uses, or removing the file if it didn't exist before. Best-effort — a
 // rollback runs on an already-failing path, and reporting a second error there
 // would only bury the first.
 func (b fileBackup) restore() {
 	if b.existed {
-		// WriteFile only applies the mode when it creates the file, and the file
-		// exists at this point, so the mode is restored explicitly.
-		_ = os.WriteFile(b.path, b.content, b.perm)
-		_ = os.Chmod(b.path, b.perm)
+		_ = atomicReplace(b.path, b.content, b.perm, b.owner)
 		return
 	}
 	_ = os.Remove(b.path)

--- a/apps/runwisp/internal/configedit/txn_test.go
+++ b/apps/runwisp/internal/configedit/txn_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -203,6 +204,38 @@ func TestTxn_WriteFailureRollsBackEarlierFiles(t *testing.T) {
 	assert.Equal(t, "original\n", readFile(t, first))
 }
 
+// TestFileBackup_RestoreUsesAtomicReplace guards the crash-safety fix for
+// restore(): it used to rewrite an existing file in place via os.WriteFile,
+// which is not crash-safe — a kill mid-write can leave a torn file, exactly
+// what this package's "every file goes through temp+rename" contract exists to
+// prevent. restore must now replace the file the same way every forward write
+// does. Exercised directly against backupFile/restore (bypassing Txn.Apply,
+// whose own forward write already rotates the inode once) so the assertion
+// isolates restore's own behavior: an in-place rewrite leaves the inode from
+// the intervening write untouched, a rename-based replace does not.
+func TestFileBackup_RestoreUsesAtomicReplace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.toml")
+	require.NoError(t, os.WriteFile(path, []byte("original\n"), 0o644))
+	b := backupFile(path)
+
+	// The write this backup exists to undo — an in-place rewrite, so it does
+	// not itself touch the inode.
+	require.NoError(t, os.WriteFile(path, []byte("changed\n"), 0o644))
+	changed, err := os.Stat(path)
+	require.NoError(t, err)
+	changedIno := changed.Sys().(*syscall.Stat_t).Ino
+
+	b.restore()
+
+	assert.Equal(t, "original\n", readFile(t, path))
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	afterIno := after.Sys().(*syscall.Stat_t).Ino
+	assert.NotEqual(t, changedIno, afterIno,
+		"restore must replace the file via rename (a new inode), not rewrite it in place")
+}
+
 // TestTxn_LeavesNoTempFiles guards against the temp+rename mechanism littering
 // the operator's config dir when a write is rolled back.
 func TestTxn_LeavesNoTempFiles(t *testing.T) {
@@ -254,10 +287,16 @@ func TestTxn_WritePreservingOwnerRefusesAMissingFile(t *testing.T) {
 
 // TestTxn_WritePreservingOwnerRollsBackOnFailure covers a WritePreservingOwner
 // queued alongside a write that later fails: the crontab rewrite must unwind
-// exactly like an ordinary Write does.
+// exactly like an ordinary Write does. It must also land back under the file's
+// original owner: restore replaces the file via rename, which — unlike an
+// in-place rewrite — takes on the temp file's own ownership unless the backup
+// explicitly chowns it back.
 func TestTxn_WritePreservingOwnerRollsBackOnFailure(t *testing.T) {
 	dir := writeFileTree(t, map[string]string{"crontab": "original\n"})
 	crontab := filepath.Join(dir, "crontab")
+	before, err := os.Stat(crontab)
+	require.NoError(t, err)
+	beforeOwner := before.Sys().(*syscall.Stat_t)
 
 	txn := New()
 	txn.WritePreservingOwner(crontab, []byte("rewritten\n"))
@@ -265,4 +304,10 @@ func TestTxn_WritePreservingOwnerRollsBackOnFailure(t *testing.T) {
 	sentinel := errors.New("gate says no")
 	require.ErrorIs(t, txn.Apply(func() error { return sentinel }), sentinel)
 	assert.Equal(t, "original\n", readFile(t, crontab))
+
+	after, err := os.Stat(crontab)
+	require.NoError(t, err)
+	afterOwner := after.Sys().(*syscall.Stat_t)
+	assert.Equal(t, beforeOwner.Uid, afterOwner.Uid, "restore must preserve the original owner")
+	assert.Equal(t, beforeOwner.Gid, afterOwner.Gid, "restore must preserve the original group")
 }

--- a/apps/runwisp/internal/executor/container.go
+++ b/apps/runwisp/internal/executor/container.go
@@ -30,12 +30,14 @@ var allowedVolumePrefixes = []string{
 	"/tmp",
 }
 
-// containerCleanupTimeout bounds the ContainerRemove/ImageRemove calls made
-// from Process.Cleanup. Cleanup runs in the same goroutine the daemon shutdown
-// coordinator waits on after ForceKill has already unblocked it; without a
-// deadline a hung (not merely unreachable — that fails fast) Docker/Podman
-// engine would stall shutdown indefinitely even though the process itself is
-// already dead. A var (not const) so tests can shrink it instead of waiting
+// containerCleanupTimeout bounds every Docker SDK call issued outside a run's
+// own context: ContainerRemove/ImageRemove from Process.Cleanup, ContainerKill
+// from ForceKill, and ContainerStop from the graceful-stop watcher. ForceKill
+// in particular runs synchronously under the task manager's lock (see
+// forceKillSurvivors) while the daemon shutdown coordinator waits on it; a
+// hung (not merely unreachable — that fails fast) Docker/Podman engine would
+// otherwise freeze that lock, and with it every other task operation, not
+// just shutdown. A var (not const) so tests can shrink it instead of waiting
 // out the real 10s to prove the deadline fires.
 var containerCleanupTimeout = 10 * time.Second
 
@@ -213,9 +215,14 @@ func (b *ContainerBackend) Start(ctx context.Context, task *model.Task, run *mod
 			return code, waitErr
 		},
 		// ForceKill skips the graceful window (daemon shutdown fast path):
-		// SIGKILL the container now rather than sending stop_signal first.
+		// SIGKILL the container now rather than sending stop_signal first. It
+		// runs under the task manager's lock (forceKillSurvivors), so the call
+		// is bounded the same way Cleanup is — an unbounded call here would
+		// freeze that lock, not just this one run's shutdown.
 		ForceKill: func() {
-			if _, err := b.docker.ContainerKill(context.Background(), containerID, client.ContainerKillOptions{Signal: "SIGKILL"}); err != nil {
+			killCtx, cancel := context.WithTimeout(context.Background(), containerCleanupTimeout)
+			defer cancel()
+			if _, err := b.docker.ContainerKill(killCtx, containerID, client.ContainerKillOptions{Signal: "SIGKILL"}); err != nil {
 				slog.Warn("Failed to kill container", "id", containerID, "err", err)
 			}
 		},
@@ -242,7 +249,15 @@ func (b *ContainerBackend) gracefulStopContainer(containerID string, task *model
 	}
 	secs := gracefulStopSeconds(task.GracefulStop)
 	opts.Timeout = &secs
-	if _, err := b.docker.ContainerStop(context.Background(), containerID, opts); err != nil {
+	// Docker's own wait (opts.Timeout) is the graceful window the operator
+	// configured via graceful_stop; the call is expected to block that long
+	// before Docker's native ladder falls back to SIGKILL. containerCleanupTimeout
+	// is added on top purely as a safety margin against an engine that never
+	// honours its own timeout — it must never cut the configured grace window
+	// short.
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Duration(secs)*time.Second+containerCleanupTimeout)
+	defer cancel()
+	if _, err := b.docker.ContainerStop(stopCtx, containerID, opts); err != nil {
 		slog.Warn("Failed to stop container gracefully", "id", containerID, "err", err)
 	}
 }

--- a/apps/runwisp/internal/executor/container.go
+++ b/apps/runwisp/internal/executor/container.go
@@ -185,25 +185,71 @@ func (b *ContainerBackend) Start(ctx context.Context, task *model.Task, run *mod
 
 	stdoutPR, stderrPR := demuxAttachStream(attachResp)
 
-	// The container's lifetime is decoupled from the run ctx so a stop/timeout
-	// runs the signal ladder instead of an instant force-remove: ContainerWait
-	// blocks on a cancel-decoupled context derived from ctx via
-	// context.WithoutCancel (it keeps ctx's values but is never cancelled, so the
-	// wait returns only when the container truly exits), while a watcher
-	// translates run-ctx cancellation into a graceful ContainerStop (stop_signal,
-	// then SIGKILL after graceful_stop). Mirrors the shell/compose cmd.Cancel
-	// ladder, using Docker's native stop semantics.
-	waitFn := b.waitFunc(context.WithoutCancel(ctx), containerID)
+	// Capture the cleanup budget once, synchronously, at construction: the
+	// watcher and forceKill closures below outlive Start and must not re-read the
+	// package var later (tests mutate it, and a leaked watcher reading it then
+	// would race the next test's write). Threaded through every bounded call so
+	// one Process uses one consistent timeout.
+	cleanupTimeout := containerCleanupTimeout
+
+	// closeAttach severs our end of the hijacked attach connection, which makes
+	// the StdCopy pump in demuxAttachStream return and close the stdout/stderr
+	// pipes the executor's stream capture is blocked on. A wedged engine never
+	// EOFs that stream on its own — the container never actually dies — so
+	// without an explicit close here the run goroutine would hang in the
+	// stream-copy wait (which runs *before* Process.Wait) forever. Guarded so the
+	// give-up path and Cleanup can both call it.
+	var attachOnce sync.Once
+	closeAttach := func() { attachOnce.Do(func() { attachResp.Close() }) }
+
+	// waitCtx decouples ContainerWait from the run ctx so a stop/timeout runs the
+	// signal ladder below instead of an instant force-remove; the wait returns
+	// only when the container truly exits. cancelWait is the escape hatch: an
+	// engine that hangs — accepts the socket but never reports the exit, the
+	// class the cleanup bounds target — would otherwise pin ContainerWait, and
+	// with it Process.Wait, per-task stop, and daemon shutdown, forever. The
+	// give-up path cancels it so the run finalizes with a terminal status.
+	waitCtx, cancelWait := context.WithCancel(context.WithoutCancel(ctx))
+	waitFn := b.waitFunc(waitCtx, containerID)
+
 	done := make(chan struct{})
 	var doneOnce sync.Once
 	closeDone := func() { doneOnce.Do(func() { close(done) }) }
 
+	// forceKill SIGKILLs the container (bounded), then tears down the local
+	// stream + wait so the run finalizes even if the engine never confirms the
+	// kill. It is both the shutdown fast path (skips the graceful window) and the
+	// watcher's final escalation step; both may call it, so every step is
+	// idempotent. It runs under the task manager's lock via forceKillSurvivors,
+	// so it never blocks beyond the bounded ContainerKill — the stream/wait
+	// teardown is non-blocking.
+	forceKill := func() {
+		killCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+		defer cancel()
+		if _, err := b.docker.ContainerKill(killCtx, containerID, client.ContainerKillOptions{Signal: "SIGKILL"}); err != nil {
+			slog.Warn("Failed to kill container", "id", containerID, "err", err)
+		}
+		closeAttach()
+		cancelWait()
+	}
+
 	go func() {
 		select {
 		case <-ctx.Done():
-			b.gracefulStopContainer(containerID, task)
 		case <-done:
+			return
 		}
+		// A stop/timeout/shutdown asked the run to end. Run Docker's native
+		// graceful ladder first (stop_signal, then SIGKILL after graceful_stop);
+		// if the container still hasn't exited afterwards — a wedged engine that
+		// ignored it — escalate to a direct kill plus local teardown so the run
+		// can't hang. A healthy engine exits inside ContainerStop, closing done
+		// before the check, so the escalation never fires for it.
+		b.gracefulStopContainer(containerID, task, cleanupTimeout)
+		if waitClosed(done, cleanupTimeout) {
+			return
+		}
+		forceKill()
 	}()
 
 	return &Process{
@@ -214,22 +260,12 @@ func (b *ContainerBackend) Start(ctx context.Context, task *model.Task, run *mod
 			closeDone()
 			return code, waitErr
 		},
-		// ForceKill skips the graceful window (daemon shutdown fast path):
-		// SIGKILL the container now rather than sending stop_signal first. It
-		// runs under the task manager's lock (forceKillSurvivors), so the call
-		// is bounded the same way Cleanup is — an unbounded call here would
-		// freeze that lock, not just this one run's shutdown.
-		ForceKill: func() {
-			killCtx, cancel := context.WithTimeout(context.Background(), containerCleanupTimeout)
-			defer cancel()
-			if _, err := b.docker.ContainerKill(killCtx, containerID, client.ContainerKillOptions{Signal: "SIGKILL"}); err != nil {
-				slog.Warn("Failed to kill container", "id", containerID, "err", err)
-			}
-		},
+		ForceKill: forceKill,
 		Cleanup: func() {
 			closeDone()
-			attachResp.Close()
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), containerCleanupTimeout)
+			cancelWait()
+			closeAttach()
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 			defer cancel()
 			b.removeContainer(cleanupCtx, containerID)
 			b.builder.Remove(cleanupCtx, imageTag)
@@ -237,12 +273,26 @@ func (b *ContainerBackend) Start(ctx context.Context, task *model.Task, run *mod
 	}, nil
 }
 
+// waitClosed reports whether done is closed within d. Used by the container
+// stop watcher to decide whether Docker's graceful ladder actually stopped the
+// container before escalating to a force kill.
+func waitClosed(done <-chan struct{}, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
 // gracefulStopContainer sends the task's stop_signal to the container and lets
 // Docker force-kill it after the graceful_stop window (its native ladder:
 // signal, wait Timeout seconds, then SIGKILL). A non-positive graceful_stop maps
 // to Timeout=0 — no grace, immediate kill — matching the shell ladder's
 // "grace <= 0 goes straight to SIGKILL".
-func (b *ContainerBackend) gracefulStopContainer(containerID string, task *model.Task) {
+func (b *ContainerBackend) gracefulStopContainer(containerID string, task *model.Task, cleanupTimeout time.Duration) {
 	opts := client.ContainerStopOptions{}
 	if sig, ok := model.NormalizeSignalName(task.StopSignal); ok {
 		opts.Signal = sig
@@ -251,11 +301,11 @@ func (b *ContainerBackend) gracefulStopContainer(containerID string, task *model
 	opts.Timeout = &secs
 	// Docker's own wait (opts.Timeout) is the graceful window the operator
 	// configured via graceful_stop; the call is expected to block that long
-	// before Docker's native ladder falls back to SIGKILL. containerCleanupTimeout
+	// before Docker's native ladder falls back to SIGKILL. cleanupTimeout
 	// is added on top purely as a safety margin against an engine that never
 	// honours its own timeout — it must never cut the configured grace window
 	// short.
-	stopCtx, cancel := context.WithTimeout(context.Background(), time.Duration(secs)*time.Second+containerCleanupTimeout)
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Duration(secs)*time.Second+cleanupTimeout)
 	defer cancel()
 	if _, err := b.docker.ContainerStop(stopCtx, containerID, opts); err != nil {
 		slog.Warn("Failed to stop container gracefully", "id", containerID, "err", err)

--- a/apps/runwisp/internal/executor/container_test.go
+++ b/apps/runwisp/internal/executor/container_test.go
@@ -949,7 +949,7 @@ func TestGracefulStopContainerHonoursGracePeriod(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		b.gracefulStopContainer("ctr", &model.Task{GracefulStop: graceful})
+		b.gracefulStopContainer("ctr", &model.Task{GracefulStop: graceful}, containerCleanupTimeout)
 		close(done)
 	}()
 
@@ -961,6 +961,95 @@ func TestGracefulStopContainerHonoursGracePeriod(t *testing.T) {
 
 	require.True(t, <-stillWaitingAtGrace,
 		"the bounding context must not fire before the configured graceful_stop window elapses")
+}
+
+// blockingConn is a net.Conn whose Read blocks until Close is called — it models
+// an attach stream from a wedged engine that never EOFs on its own.
+type blockingConn struct {
+	r *io.PipeReader
+}
+
+func (c *blockingConn) Read(b []byte) (int, error)       { return c.r.Read(b) }
+func (c *blockingConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (c *blockingConn) Close() error                     { return c.r.Close() }
+func (c *blockingConn) LocalAddr() net.Addr              { return nil }
+func (c *blockingConn) RemoteAddr() net.Addr             { return nil }
+func (c *blockingConn) SetDeadline(time.Time) error      { return nil }
+func (c *blockingConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *blockingConn) SetWriteDeadline(time.Time) error { return nil }
+
+func newBlockingHijackedResponse() client.ContainerAttachResult {
+	pr, _ := io.Pipe() // write end never used: the read side blocks until Close
+	return client.ContainerAttachResult{HijackedResponse: client.NewHijackedResponse(&blockingConn{r: pr}, "")}
+}
+
+// TestStartWedgedEngineDoesNotHangRun pins the remaining half of the hung-engine
+// fix: bounding ForceKill/Cleanup/ContainerStop is not enough on its own,
+// because a wedged engine — one that accepts the socket but never reports the
+// container's exit and never EOFs the attach stream — pins the run goroutine in
+// two places the earlier bounds don't reach: the stream copy (which runs before
+// Process.Wait) and ContainerWait itself, whose context was deliberately
+// un-cancelable. A stop/timeout must still drive the run to a terminal state
+// within a bounded window: the stop watcher escalates to a SIGKILL and, when
+// even that goes unanswered, severs the local attach + wait so the run can
+// finalize instead of hanging — and, with it, freezing daemon shutdown.
+func TestStartWedgedEngineDoesNotHangRun(t *testing.T) {
+	original := containerCleanupTimeout
+	containerCleanupTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { containerCleanupTimeout = original })
+
+	mock := &mockDockerClient{
+		imageBuildFunc: func(ctx context.Context, _ io.Reader, _ client.ImageBuildOptions) (client.ImageBuildResult, error) {
+			return client.ImageBuildResult{Body: io.NopCloser(strings.NewReader(`{"stream":"ok"}`))}, nil
+		},
+		containerAttachFunc: func(ctx context.Context, _ string, _ client.ContainerAttachOptions) (client.ContainerAttachResult, error) {
+			return newBlockingHijackedResponse(), nil
+		},
+		// The exit is never reported until the wait's own context is cancelled —
+		// the give-up escape hatch the fix adds.
+		containerWaitFunc: func(ctx context.Context, _ string, _ client.ContainerWaitOptions) client.ContainerWaitResult {
+			errCh := make(chan error, 1)
+			go func() {
+				<-ctx.Done()
+				errCh <- ctx.Err()
+			}()
+			return client.ContainerWaitResult{Result: make(chan container.WaitResponse), Error: errCh}
+		},
+		// Stop and kill both hang until their own bounded context gives up: the
+		// engine never actually acts on them.
+		containerStopFunc: func(ctx context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
+			<-ctx.Done()
+			return client.ContainerStopResult{}, ctx.Err()
+		},
+		containerKillFunc: func(ctx context.Context, _ string, _ client.ContainerKillOptions) (client.ContainerKillResult, error) {
+			<-ctx.Done()
+			return client.ContainerKillResult{}, ctx.Err()
+		},
+	}
+	b := NewContainerBackendFromClient(mock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	proc, err := b.Start(ctx, &model.Task{}, nil, &model.ContainerExecution{Script: "sleep 100", BaseImage: "alpine"})
+	require.NoError(t, err)
+
+	// Mirror the executor's real ordering: drain both streams to EOF (where the
+	// run goroutine blocks first), then Wait, then Cleanup.
+	finished := make(chan struct{})
+	go func() {
+		io.Copy(io.Discard, proc.Stdout)
+		io.Copy(io.Discard, proc.Stderr)
+		proc.Wait()
+		proc.Cleanup()
+		close(finished)
+	}()
+
+	cancel() // a stop/timeout cancels the run ctx
+
+	select {
+	case <-finished:
+	case <-time.After(3 * time.Second):
+		t.Fatal("a wedged engine froze the run: stream+wait never finalized after the run ctx was cancelled")
+	}
 }
 
 func TestRemoveContainerLogsError(t *testing.T) {

--- a/apps/runwisp/internal/executor/container_test.go
+++ b/apps/runwisp/internal/executor/container_test.go
@@ -865,6 +865,104 @@ func TestCleanupBoundedWhenDockerHangs(t *testing.T) {
 	}
 }
 
+// TestForceKillBoundedWhenDockerHangs pins the fix for the shutdown-freeze
+// bug: ForceKill's ContainerKill call used context.Background(), and
+// forceKillSurvivors (internal/runtime/manager.go) calls ForceKill
+// synchronously while holding the task manager's lock. A Docker/Podman engine
+// that merely hangs (not fails fast like "unreachable") would therefore block
+// that lock forever — freezing every other task operation, not just this
+// run's shutdown. ForceKill must bound the call with containerCleanupTimeout
+// the same way Cleanup already does.
+func TestForceKillBoundedWhenDockerHangs(t *testing.T) {
+	original := containerCleanupTimeout
+	containerCleanupTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { containerCleanupTimeout = original })
+
+	killSawCancellation := make(chan struct{}, 1)
+	mock := &mockDockerClient{
+		imageBuildFunc: func(ctx context.Context, _ io.Reader, _ client.ImageBuildOptions) (client.ImageBuildResult, error) {
+			return client.ImageBuildResult{Body: io.NopCloser(strings.NewReader(`{"stream":"ok"}`))}, nil
+		},
+		containerAttachFunc: func(ctx context.Context, _ string, _ client.ContainerAttachOptions) (client.ContainerAttachResult, error) {
+			return newHijackedResponse(""), nil
+		},
+		containerKillFunc: func(ctx context.Context, _ string, _ client.ContainerKillOptions) (client.ContainerKillResult, error) {
+			// A hung engine: only returns once the caller's context gives up.
+			<-ctx.Done()
+			killSawCancellation <- struct{}{}
+			return client.ContainerKillResult{}, ctx.Err()
+		},
+	}
+	b := NewContainerBackendFromClient(mock)
+
+	proc, err := b.Start(context.Background(), &model.Task{}, nil, &model.ContainerExecution{
+		Script:    "echo test",
+		BaseImage: "alpine",
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		proc.ForceKill()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ForceKill blocked forever against a hung Docker client — the bounded context did not fire")
+	}
+
+	select {
+	case <-killSawCancellation:
+	default:
+		t.Fatal("ContainerKill never observed its context being cancelled")
+	}
+}
+
+// TestGracefulStopContainerHonoursGracePeriod proves the ContainerStop bound
+// added alongside the ForceKill fix never cuts short the operator-configured
+// graceful_stop window: the call must still be in flight (not yet cancelled)
+// once graceful_stop has elapsed, and only the safety margin on top of it may
+// time the call out.
+func TestGracefulStopContainerHonoursGracePeriod(t *testing.T) {
+	original := containerCleanupTimeout
+	containerCleanupTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { containerCleanupTimeout = original })
+
+	const graceful = 200 * time.Millisecond
+	stillWaitingAtGrace := make(chan bool, 1)
+	mock := &mockDockerClient{
+		containerStopFunc: func(ctx context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
+			timer := time.NewTimer(graceful)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				stillWaitingAtGrace <- true
+			case <-ctx.Done():
+				stillWaitingAtGrace <- false
+			}
+			return client.ContainerStopResult{}, nil
+		},
+	}
+	b := NewContainerBackendFromClient(mock)
+
+	done := make(chan struct{})
+	go func() {
+		b.gracefulStopContainer("ctr", &model.Task{GracefulStop: graceful})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gracefulStopContainer never returned")
+	}
+
+	require.True(t, <-stillWaitingAtGrace,
+		"the bounding context must not fire before the configured graceful_stop window elapses")
+}
+
 func TestRemoveContainerLogsError(t *testing.T) {
 	called := false
 	mock := &mockDockerClient{

--- a/apps/runwisp/internal/executor/lazy_container.go
+++ b/apps/runwisp/internal/executor/lazy_container.go
@@ -7,9 +7,18 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/runwisp/runwisp/internal/model"
 )
+
+// containerConnectTimeout bounds the first-connect probe (NewContainerBackend
+// pings the daemon). A hung engine — socket accepts but never answers — must
+// not block the probe indefinitely, because it runs under l.mu and would wedge
+// every other task's container start behind it. A var (not const) so tests can
+// shrink it. Kin to containerCleanupTimeout, which guards the same shared-lock
+// concern on the teardown side.
+var containerConnectTimeout = 10 * time.Second
 
 // LazyContainerBackend defers Docker daemon connection until the first
 // execution attempt. This prevents startup failure when the Docker daemon
@@ -46,7 +55,14 @@ func (l *LazyContainerBackend) ensureConnected(ctx context.Context) (*ContainerB
 	if l.backend != nil {
 		return l.backend, nil
 	}
-	b, err := NewContainerBackend(ctx)
+	// Bound the probe: NewContainerBackend pings the daemon, and the run's ctx
+	// carries no deadline of its own (a service run outlives any timeout), so a
+	// hung engine would block here — and hold l.mu — forever, wedging every other
+	// container task's start behind it. The caller's ctx still cancels earlier if
+	// the run is stopped.
+	probeCtx, cancel := context.WithTimeout(ctx, containerConnectTimeout)
+	defer cancel()
+	b, err := NewContainerBackend(probeCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/runwisp/internal/executor/lazy_container_test.go
+++ b/apps/runwisp/internal/executor/lazy_container_test.go
@@ -5,7 +5,11 @@ package executor
 
 import (
 	"context"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,6 +44,52 @@ func TestLazyContainerBackend_StartWrapsConnectionError(t *testing.T) {
 		t.Skip("docker daemon is reachable on this machine; can't assert error wrapping")
 	}
 	assert.Contains(t, err.Error(), "docker backend unavailable")
+}
+
+// TestLazyContainerBackend_EnsureConnectedBoundsHungEngine models a wedged
+// engine — a socket that accepts connections but never answers — reached under
+// a run context that carries no deadline of its own (a service run). Without
+// bounding, the connect Ping blocks forever while holding l.mu, wedging every
+// other container task's start. ensureConnected must instead fail within the
+// connect timeout.
+func TestLazyContainerBackend_EnsureConnectedBoundsHungEngine(t *testing.T) {
+	// A short dir: the unix socket path must fit the OS sun_path limit (~104
+	// bytes on macOS), which t.TempDir()'s deep path blows past.
+	dir, err := os.MkdirTemp("/tmp", "rw")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "d.sock")
+	ln, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open and never respond: a hung engine, not an
+			// unreachable one (which would fail fast on connect).
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	t.Setenv("DOCKER_HOST", "unix://"+sock)
+	old := containerConnectTimeout
+	containerConnectTimeout = 200 * time.Millisecond
+	defer func() { containerConnectTimeout = old }()
+
+	l := &LazyContainerBackend{}
+	done := make(chan error, 1)
+	// context.Background() has no deadline — only the connect timeout can save us.
+	go func() { _, err := l.ensureConnected(context.Background()); done <- err }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a hung-engine probe must fail, not connect")
+	case <-time.After(3 * time.Second):
+		t.Fatal("ensureConnected did not return: the connect probe is not bounded")
+	}
 }
 
 func TestLazyContainerBackend_EnsureConnectedReturnsCachedBackend(t *testing.T) {

--- a/apps/runwisp/internal/executor/log_writer.go
+++ b/apps/runwisp/internal/executor/log_writer.go
@@ -66,6 +66,11 @@ type LogWriter struct {
 	// defaults to os.Create.
 	createSegment func(path string) (*os.File, error)
 
+	// renameFile moves the current segment into its .prev slot during
+	// rotation. Injected for tests to simulate a rename failure; defaults to
+	// os.Rename.
+	renameFile func(oldpath, newpath string) error
+
 	// State
 	currentOffset  int64
 	lineCount      int64
@@ -138,6 +143,7 @@ func NewLogWriter(opts LogWriterOpts) (*LogWriter, error) {
 		diskCheckInterval: defaultDiskCheckInterval,
 		freeDisk:          freeDiskSpace,
 		createSegment:     os.Create,
+		renameFile:        os.Rename,
 		now:               now,
 	}, nil
 }
@@ -362,6 +368,7 @@ func (w *LogWriter) writeSystemLine(msg string) {
 	n, err := w.file.Write([]byte(line))
 	if err != nil {
 		slog.Warn("Failed to write system log line", "err", err)
+		return
 	}
 	w.currentOffset += int64(n)
 	w.lineCount++
@@ -386,10 +393,13 @@ func (w *LogWriter) rotateTail() error {
 		slog.Warn("Failed to close log file before rotation", "err", err)
 	}
 
+	// os.Rename atomically replaces prevPath if it already exists (POSIX
+	// rename(2)), so there's no need to remove it first — doing so would
+	// destroy the previously rotated segment even when the rename below
+	// then fails, with nothing left to replace it.
 	prevPath := logutil.PrevPath(w.mainPath)
-	os.Remove(prevPath) // drop a previous rotation artifact
 
-	if err := os.Rename(w.mainPath, prevPath); err != nil {
+	if err := w.renameFile(w.mainPath, prevPath); err != nil {
 		// Undo accumulation and re-open the original log for appending.
 		w.rotatedLines -= w.lineCount
 		w.rotatedBytes -= w.currentOffset

--- a/apps/runwisp/internal/executor/log_writer_test.go
+++ b/apps/runwisp/internal/executor/log_writer_test.go
@@ -4,6 +4,7 @@
 package executor
 
 import (
+	"errors"
 	"math"
 	"os"
 	"path/filepath"
@@ -520,4 +521,57 @@ func TestLogWriter_InjectedClockStampsSystemLine(t *testing.T) {
 	want := fixed.Format("2006-01-02 15:04:05")
 	assert.Contains(t, string(data), want,
 		"SYSTEM line must use the injected clock's formatted timestamp")
+}
+
+// TestLogWriter_WriteSystemLine_LeavesCountersOnWriteFailure guards against a
+// desync bug: writeSystemLine used to bump lineCount/currentOffset even when
+// the underlying write failed, unlike writeOneLine which correctly leaves
+// counters untouched on error. A miscounted lineCount throws off every later
+// LineNum handed out on the event bus and recorded in the sidecar index.
+func TestLogWriter_WriteSystemLine_LeavesCountersOnWriteFailure(t *testing.T) {
+	opts := newTestOpts(t.TempDir())
+	w, err := NewLogWriter(opts)
+	require.NoError(t, err)
+	require.NoError(t, w.file.Close()) // force the next write against it to fail
+
+	w.writeSystemLine("disk critically low")
+
+	assert.Equal(t, int64(0), w.lineCount,
+		"a failed system-line write must not be counted as a written line")
+	assert.Equal(t, int64(0), w.currentOffset,
+		"a failed system-line write must not advance the offset")
+}
+
+// TestLogWriter_RotateRenameFailure_PreservesExistingPrev guards against a
+// data-loss bug: rotateTail used to unconditionally os.Remove the .prev slot
+// before attempting the rename that repopulates it. os.Rename already
+// atomically replaces an existing destination, so that remove bought nothing
+// on the happy path — but if the rename then failed, the previously rotated
+// segment was gone with nothing to replace it.
+func TestLogWriter_RotateRenameFailure_PreservesExistingPrev(t *testing.T) {
+	opts := newTestOpts(t.TempDir())
+	opts.MaxSize = 200
+	opts.Overflow = "drop_old"
+	w, err := NewLogWriter(opts)
+	require.NoError(t, err)
+
+	w.WriteLineEvent(strings.Repeat("a", 100), logutil.StreamStdout)
+	w.WriteLineEvent(strings.Repeat("b", 100), logutil.StreamStdout) // triggers the first rotation
+
+	prevPath := logutil.PrevPath(opts.LogPath)
+	firstRotation, err := os.ReadFile(prevPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstRotation, "first rotation must have populated .prev")
+
+	w.renameFile = func(oldpath, newpath string) error {
+		return errors.New("simulated rename failure")
+	}
+
+	w.WriteLineEvent(strings.Repeat("c", 100), logutil.StreamStdout) // attempts a second rotation, which fails to rename
+	require.NoError(t, w.Close())
+
+	afterFailedRotation, err := os.ReadFile(prevPath)
+	require.NoError(t, err)
+	assert.Equal(t, firstRotation, afterFailedRotation,
+		".prev must survive a rotation whose rename fails, not just one whose remove would have failed too")
 }

--- a/apps/runwisp/internal/importer/supervisord.go
+++ b/apps/runwisp/internal/importer/supervisord.go
@@ -51,7 +51,11 @@ type supervisordState struct {
 	res      *Result
 	names    *namer
 	sections []iniSection
-	visited  map[string]bool
+	// byName maps a section's [header] to its index in sections, so a section
+	// that reappears across included files merges into the first rather than
+	// duplicating it — see addSection.
+	byName  map[string]int
+	visited map[string]bool
 }
 
 func newSupervisordState(opts SupervisordOptions) *supervisordState {
@@ -59,6 +63,7 @@ func newSupervisordState(opts SupervisordOptions) *supervisordState {
 	return &supervisordState{
 		res:     res,
 		names:   newNamer(res, opts.Existing, ""),
+		byName:  map[string]int{},
 		visited: map[string]bool{},
 	}
 }
@@ -95,8 +100,27 @@ func (sd *supervisordState) collect(sections []iniSection, baseDir string) {
 			sd.expandInclude(&s, baseDir)
 			continue
 		}
-		sd.sections = append(sd.sections, s)
+		sd.addSection(s)
 	}
+}
+
+// addSection folds one section into the collected set. supervisord assembles its
+// config with Python's ConfigParser, which merges a section that reappears
+// across included files key-by-key with the later value winning — the standard
+// "base config + conf.d override" pattern. Mirror that: merge into the
+// first-seen section (keeping its position) instead of appending a duplicate,
+// which would otherwise import one program twice as `web` and `web-2`.
+func (sd *supervisordState) addSection(s iniSection) {
+	if idx, ok := sd.byName[s.name]; ok {
+		dst := &sd.sections[idx]
+		for _, k := range s.keys {
+			v, _ := s.get(k)
+			dst.set(k, v)
+		}
+		return
+	}
+	sd.byName[s.name] = len(sd.sections)
+	sd.sections = append(sd.sections, s)
 }
 
 func (sd *supervisordState) expandInclude(s *iniSection, baseDir string) {

--- a/apps/runwisp/internal/importer/supervisord_test.go
+++ b/apps/runwisp/internal/importer/supervisord_test.go
@@ -4,6 +4,8 @@
 package importer
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -39,6 +41,47 @@ user=www-data
 
 	if tally := res.Tally(); tally.Tasks != 0 || tally.Services != 1 {
 		t.Fatalf("counts: got %+v, want 0 tasks / 1 service", tally)
+	}
+}
+
+// TestSupervisordIncludeMergesSameProgram proves a [program] that reappears
+// across included files is merged key-by-key, later value winning — the way
+// supervisord's own ConfigParser assembles a base config plus a conf.d
+// override — rather than being imported twice as `web` and `web-2`, which would
+// start the same process on both.
+func TestSupervisordIncludeMergesSameProgram(t *testing.T) {
+	dir := t.TempDir()
+	confd := filepath.Join(dir, "conf.d")
+	if err := os.MkdirAll(confd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(p, content string) {
+		t.Helper()
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(dir, "supervisord.conf"), "[include]\nfiles=conf.d/*.conf\n")
+	write(filepath.Join(confd, "10-base.conf"),
+		"[program:web]\ncommand=/bin/old\nuser=www-data\nautorestart=true\n")
+	// Loads after 10-base.conf (glob sorts), so its command wins and numprocs is added.
+	write(filepath.Join(confd, "20-override.conf"),
+		"[program:web]\ncommand=/bin/new\nnumprocs=3\n")
+
+	res, err := ParseSupervisordFiles([]string{filepath.Join(dir, "supervisord.conf")}, SupervisordOptions{})
+	if err != nil {
+		t.Fatalf("ParseSupervisordFiles: %v", err)
+	}
+
+	out := res.TOML()
+	mustContain(t, out, "[services.web]")
+	mustNotContain(t, out, "web-2")          // one merged program, not a duplicate
+	mustContain(t, out, `run = "/bin/new"`)  // later file wins on a shared key
+	mustContain(t, out, `user = "www-data"`) // base-only key preserved
+	mustContain(t, out, "instances = 3")     // key present only in the override
+
+	if tally := res.Tally(); tally.Services != 1 {
+		t.Fatalf("counts: got %+v, want exactly 1 service", tally)
 	}
 }
 

--- a/apps/runwisp/internal/notify/channel/factory.go
+++ b/apps/runwisp/internal/notify/channel/factory.go
@@ -56,8 +56,13 @@ type NotifierSpec struct {
 	TemplatePath string // optional override
 	// Transport overrides the channel's HTTP transport. Nil means use defaults.
 	// Daemon-level glue uses this to apply a global backoff override on HTTP
-	// providers (Slack, Telegram).
+	// providers (Slack, Discord, Telegram, webhook).
 	Transport *notify.HTTPProvider
+	// Backoff overrides the channel's retry backoff for non-HTTP providers
+	// (SMTP, sendmail), which don't go through Transport. Zero means use
+	// notify.DefaultBackoff(). Daemon-level glue sets this from the same
+	// retry_budget override applied to Transport above.
+	Backoff notify.BackoffConfig
 	// RenderContext binds per-daemon values (external URL, fingerprint, tail
 	// reader) into the template's func map. Zero values produce safe defaults:
 	// missing external URL collapses link blocks, missing fingerprint shortens
@@ -156,6 +161,7 @@ func buildSMTP(spec NotifierSpec) (notify.Channel, error) {
 		Recipients:    spec.Recipients,
 		CC:            spec.CC,
 		BCC:           spec.BCC,
+		Backoff:       spec.Backoff,
 		Renderer:      r,
 	})
 }
@@ -173,6 +179,7 @@ func buildSendmail(spec NotifierSpec) (notify.Channel, error) {
 		Recipients: spec.Recipients,
 		CC:         spec.CC,
 		BCC:        spec.BCC,
+		Backoff:    spec.Backoff,
 		Renderer:   r,
 	})
 }

--- a/apps/runwisp/internal/notify/channel/factory_test.go
+++ b/apps/runwisp/internal/notify/channel/factory_test.go
@@ -4,12 +4,15 @@
 package channel
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/runwisp/runwisp/internal/notify"
+	"github.com/runwisp/runwisp/internal/testutil"
 )
 
 func TestBuild_UnknownTypeReturnsClearError(t *testing.T) {
@@ -136,6 +139,54 @@ func TestBuild_SmtpEmptyHostReturnsError(t *testing.T) {
 	_, err := Build(NotifierSpec{ID: "mail", Type: "smtp"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "host is required")
+}
+
+// TestBuild_SmtpPropagatesBackoff guards against a wiring bug: unlike
+// Transport (Slack/Discord/Telegram/webhook), spec.Backoff used to never
+// reach smtp.Config, so a configured notify.retry_budget silently had no
+// effect on SMTP (and sendmail, which shares the same factory pattern) and
+// every failed send retried for the full 5-minute default instead. Dialing a
+// closed local port fails immediately, so a channel actually honoring a tiny
+// injected MaxElapsedTime gives up in well under a second; one still using
+// the 5-minute default would still be retrying when the safety-net deadline
+// below fires.
+func TestBuild_SmtpPropagatesBackoff(t *testing.T) {
+	port := testutil.PickFreePort(t)
+	ch, err := Build(NotifierSpec{
+		ID:         "mail",
+		Type:       "smtp",
+		Host:       "127.0.0.1",
+		Port:       port,
+		From:       "RunWisp <runwisp@example.test>",
+		Recipients: []string{"oncall@example.test"},
+		Backoff: notify.BackoffConfig{
+			InitialInterval: time.Millisecond,
+			MaxInterval:     5 * time.Millisecond,
+			MaxElapsedTime:  50 * time.Millisecond,
+			Multiplier:      2,
+		},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ch.Execute(ctx, &notify.Event{
+			Kind:      notify.KindRunFailed,
+			Severity:  notify.SevError,
+			TaskName:  "backup-db",
+			Reason:    "exit 1",
+			Timestamp: time.Now().UTC(),
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("smtp channel ignored spec.Backoff and is still retrying under the default 5-minute budget")
+	}
 }
 
 func TestBuild_SlackTemplatePathMissing(t *testing.T) {

--- a/apps/runwisp/internal/notify/render/render.go
+++ b/apps/runwisp/internal/notify/render/render.go
@@ -287,11 +287,36 @@ func triggerPhrase(t model.TriggeredBy) string {
 	}
 }
 
-// eventSentence renders the per-kind body sentence ending in a period. It is
-// the single source of truth for the failure/success phrasing previously
-// duplicated inside the Telegram and Slack templates. Output is plain text;
-// callers apply the provider-specific escape (tgEscape, jsonStr).
+// eventSentence renders the per-kind body sentence ending in a period, plus a
+// coalesced-count suffix when this delivery folded several repeats. It is the
+// single source of truth for the failure/success phrasing previously duplicated
+// inside the Telegram and Slack templates. Output is plain text; callers apply
+// the provider-specific escape (tgEscape, jsonStr).
 func eventSentence(e *notify.Event) string {
+	return kindSentence(e) + coalescedSuffix(e)
+}
+
+// coalescedSuffix discloses that an outbound delivery stands in for several
+// suppressed repeats. The outbound coalescer (internal/notify/coalesce) folds a
+// flapping task's bursts into one delivery and records the fold count on the
+// event's Extra map; without surfacing it here the folded delivery would read
+// exactly like a single occurrence, hiding how bad the flap really is — a silent
+// loss the coalescer's own doc comment promises the renderer discloses. The key
+// is written by coalesce.summarize; a plain (uncoalesced) event has no such key
+// and gets no suffix.
+func coalescedSuffix(e *notify.Event) string {
+	if e == nil || e.Extra == nil {
+		return ""
+	}
+	n, ok := e.Extra["coalesced_count"].(int)
+	if !ok || n < 2 {
+		return ""
+	}
+	return fmt.Sprintf(" (×%d — earlier repeats coalesced into this alert)", n)
+}
+
+// kindSentence renders just the per-kind body sentence, ending in a period.
+func kindSentence(e *notify.Event) string {
 	switch e.Kind {
 	case notify.KindRunFailed:
 		return failedSentence(e)

--- a/apps/runwisp/internal/notify/render/render_test.go
+++ b/apps/runwisp/internal/notify/render/render_test.go
@@ -130,6 +130,22 @@ func TestEventSentence(t *testing.T) {
 	}
 }
 
+// TestEventSentenceCoalescedCount proves a delivery that folded repeats (the
+// outbound coalescer stamps coalesced_count on Extra) discloses the fold in the
+// rendered body. Without it a flap folded into one alert reads identically to a
+// single occurrence — a silent loss.
+func TestEventSentenceCoalescedCount(t *testing.T) {
+	base := &notify.Event{Kind: notify.KindRunFailed}
+	assert.Equal(t, "Exited with code ?.", eventSentence(base), "no Extra means no suffix")
+
+	folded := &notify.Event{Kind: notify.KindRunFailed, Extra: map[string]any{"coalesced_count": 5}}
+	assert.Equal(t, "Exited with code ?. (×5 — earlier repeats coalesced into this alert)", eventSentence(folded))
+
+	// A count of one is a lone event, not a fold: no suffix.
+	single := &notify.Event{Kind: notify.KindRunFailed, Extra: map[string]any{"coalesced_count": 1}}
+	assert.Equal(t, "Exited with code ?.", eventSentence(single))
+}
+
 func TestEventTrigger(t *testing.T) {
 	assert.Equal(t, "Event", eventTrigger(&notify.Event{}))
 	assert.Equal(t, "Scheduled run", eventTrigger(&notify.Event{Run: &model.Run{TriggeredBy: model.TriggeredByCron}}))

--- a/apps/runwisp/internal/runtime/interfaces.go
+++ b/apps/runwisp/internal/runtime/interfaces.go
@@ -70,6 +70,11 @@ type TaskManager interface {
 	RemoveTask(taskName string)
 	GetActiveRuns(taskName string) []*ActiveRun
 	LoadPendingRuns(runs []model.Run) PendingRunsResult
+	// RecycleServiceInstances picks up a reload-changed service definition
+	// without the operator-restart semantics of RestartServiceInstances: a
+	// stopped (or never-autostarted) service, and any FATAL instance, is left
+	// untouched. Used only by the reconciler.
+	RecycleServiceInstances(taskName string) error
 	// ServiceHealthy reports whether a service has at least one instance that
 	// has been running for at least its healthy_after — the live readiness
 	// signal depends_on boot gating waits on. Non-services report false.

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -766,6 +766,38 @@ func (m *defaultTaskManager) RestartServiceInstances(taskName string) error {
 	return nil
 }
 
+// RecycleServiceInstances lets a reload-changed service definition (new
+// command, env, or instance count) take effect without treating the reload
+// as an operator restart: a service the operator stopped, or one never
+// started because Autostart is false, is left exactly as it is — reload adds/
+// changes/removes tasks live, it is not a restart. A FATAL instance likewise
+// stays FATAL; only an explicit restart clears it. When the service is
+// running, every live instance is cancelled so the exit handler respawns it
+// under the new definition, and any slots freed by an instance-count increase
+// are filled.
+func (m *defaultTaskManager) RecycleServiceInstances(taskName string) error {
+	m.mu.Lock()
+	ts, exists := m.tasks[taskName]
+	if !exists {
+		m.mu.Unlock()
+		return fmt.Errorf(errTaskNotFoundFmt, taskName)
+	}
+	if !ts.task.Kind.IsService() {
+		m.mu.Unlock()
+		return fmt.Errorf(errTaskNotServiceFmt, taskName)
+	}
+	if ts.supervisor.IsStopped() {
+		m.mu.Unlock()
+		return nil
+	}
+	for _, ar := range ts.active {
+		ar.Cancel()
+	}
+	m.mu.Unlock()
+
+	return m.StartServiceInstances(taskName, model.TriggeredByService)
+}
+
 // StopService marks the service as operator-stopped (in-memory only, cleared
 // on daemon restart) and cancels every live instance. The exit handler honours
 // the flag and stops refilling slots.

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -192,12 +192,7 @@ func (m *defaultTaskManager) UpsertTask(task *model.Task) {
 	ts.task = &taskCopy
 
 	if task.Kind.IsService() {
-		if ts.supervisor == nil {
-			ts.supervisor = services.NewSupervisor(task.Name, task.Instances, task.HealthyAfter, !task.Autostart, m.clock)
-		} else {
-			ts.supervisor.SetInstances(task.Instances)
-			ts.supervisor.SetHealthyAfter(task.HealthyAfter)
-		}
+		m.upsertSupervisor(ts, task)
 	}
 
 	if task.OnOverlap == model.PolicyQueue {
@@ -228,6 +223,27 @@ func (m *defaultTaskManager) UpsertTask(task *model.Task) {
 		// unconditionally so a loop parked on an already-empty queue wakes too.
 		orphanedRunIDs = m.finalizeOrphanedQueue(ts)
 		ts.cond.Broadcast()
+	}
+}
+
+// upsertSupervisor creates or updates ts's service supervisor for task.
+// Caller holds m.mu.
+func (m *defaultTaskManager) upsertSupervisor(ts *taskState, task *model.Task) {
+	if ts.supervisor == nil {
+		ts.supervisor = services.NewSupervisor(task.Name, task.Instances, task.HealthyAfter, !task.Autostart, m.clock)
+		return
+	}
+	ts.supervisor.SetInstances(task.Instances)
+	ts.supervisor.SetHealthyAfter(task.HealthyAfter)
+	// Reviving a service RemoveTask stopped only as mechanical bookkeeping
+	// (see stoppedByRemoval's doc): resume it exactly as a brand-new
+	// supervisor would — i.e. per the revived definition's own Autostart —
+	// instead of leaving it permanently stopped with no error ever surfaced.
+	if ts.stoppedByRemoval {
+		if task.Autostart {
+			ts.supervisor.MarkRunning()
+		}
+		ts.stoppedByRemoval = false
 	}
 }
 
@@ -287,6 +303,7 @@ func (m *defaultTaskManager) RemoveTask(taskName string) {
 	// the exit handler won't bring them back.
 	if ts.task.Kind.IsService() && ts.supervisor != nil {
 		ts.supervisor.MarkStopped()
+		ts.stoppedByRemoval = true
 		for _, ar := range ts.active {
 			ar.Cancel()
 		}
@@ -737,6 +754,7 @@ func (m *defaultTaskManager) RestartServiceInstances(taskName string) error {
 	wasStopped := ts.supervisor.IsStopped()
 	wasFatal := ts.supervisor.IsAnyFatal()
 	ts.supervisor.MarkRunning()
+	ts.stoppedByRemoval = false
 	for _, ar := range ts.active {
 		ar.Cancel()
 	}
@@ -763,6 +781,7 @@ func (m *defaultTaskManager) StopService(taskName string) error {
 		return fmt.Errorf(errTaskNotServiceFmt, taskName)
 	}
 	ts.supervisor.MarkStopped()
+	ts.stoppedByRemoval = false
 	for _, ar := range ts.active {
 		ar.Cancel()
 	}

--- a/apps/runwisp/internal/runtime/manager_test.go
+++ b/apps/runwisp/internal/runtime/manager_test.go
@@ -405,6 +405,47 @@ func TestReloadDropReAddRevivesQueueTask(t *testing.T) {
 	assert.True(t, ok, "retiring the old run must not delete the revived task")
 }
 
+// TestUpsertTask_RevivesServiceStoppedOnlyByRemoval guards against a reload
+// race: RemoveTask stops a service's supervisor as mechanical bookkeeping
+// before its taskState can be deleted, but the taskState (and supervisor)
+// survive removal when an instance hasn't retired yet. A reload that re-adds
+// the same-named service before that instance retires used to leave the
+// revived supervisor permanently stopped — StartServiceInstances silently
+// no-ops on a stopped supervisor, so the service came back registered with
+// zero live instances and no error surfaced anywhere.
+func TestUpsertTask_RevivesServiceStoppedOnlyByRemoval(t *testing.T) {
+	jm, exec, eb := newGatedManager(t)
+	started := watchRuns(eb, events.EventRunStarted)
+
+	jm.UpsertTask(serviceTask("svc", 1))
+	require.NoError(t, jm.StartServiceInstances("svc", model.TriggeredByService))
+	started.waitFor(t, 1) // the one instance is live; ts.active is non-empty
+
+	// Reproduce RemoveTask's exact effect on a service whose instance hasn't
+	// retired yet, without depending on real cancellation timing — which
+	// would race the goroutine that finalizes the cancelled run (and, once
+	// ts.active empties, deletes the taskState) against this same test
+	// goroutine's next statement.
+	jm.mu.Lock()
+	ts := jm.tasks["svc"]
+	require.NotNil(t, ts)
+	ts.removed = true
+	ts.supervisor.MarkStopped()
+	ts.stoppedByRemoval = true
+	jm.mu.Unlock()
+
+	jm.UpsertTask(serviceTask("svc", 1)) // reload #2 re-adds it before the old instance retires
+
+	jm.mu.Lock()
+	stillStopped := ts.supervisor.IsStopped()
+	jm.mu.Unlock()
+	assert.False(t, stillStopped,
+		"revival must clear a stop RemoveTask itself set, not one the operator asked for — "+
+			"leaving it set makes StartServiceInstances silently no-op forever")
+
+	exec.ReleaseAll()
+}
+
 // TestEphemeralTaskReapedAfterRun is the regression test for Bug 7: a
 // cloud-inline task is marked Ephemeral and never enters the TOML registry, so
 // reconcile can never RemoveTask it. Its taskState (and, for PolicyQueue, its

--- a/apps/runwisp/internal/runtime/reconcile.go
+++ b/apps/runwisp/internal/runtime/reconcile.go
@@ -328,13 +328,12 @@ func (r *Reconciler) anchorUnheld(oldTask, newTask *model.Task) {
 }
 
 // recycleChangedService recycles running instances to pick up the new
-// definition, then fills any slots added by an instance-count increase.
+// definition, then fills any slots added by an instance-count increase. It
+// never revives a service the operator stopped (or one waiting on Autostart)
+// and never clears a FATAL instance — reload is not a restart.
 func (r *Reconciler) recycleChangedService(newTask *model.Task) {
-	if err := r.manager.RestartServiceInstances(newTask.Name); err != nil {
-		slog.Error("Failed to restart changed service", "task", newTask.Name, "err", err)
-	}
-	if err := r.manager.StartServiceInstances(newTask.Name, model.TriggeredByService); err != nil {
-		slog.Error("Failed to start instances for changed service", "task", newTask.Name, "err", err)
+	if err := r.manager.RecycleServiceInstances(newTask.Name); err != nil {
+		slog.Error("Failed to recycle changed service", "task", newTask.Name, "err", err)
 	}
 }
 

--- a/apps/runwisp/internal/runtime/reconcile.go
+++ b/apps/runwisp/internal/runtime/reconcile.go
@@ -281,7 +281,20 @@ func (r *Reconciler) applyChanged(change config.TaskChange, oldTask, newTask *mo
 	}
 
 	if newTask.Kind.IsService() {
-		r.recycleChangedService(newTask)
+		if oldTask.Kind.IsService() {
+			// A genuine service-definition change: bounce the running instances so
+			// the new command, env, or instance count takes effect.
+			r.recycleChangedService(newTask)
+		} else {
+			// A task→service kind flip: the run in flight under the old non-service
+			// definition must finish under it — reload never cancels an in-flight
+			// run — so it is left to drain on its own goroutine. Recycling here would
+			// cancel it (RecycleServiceInstances cancels every active run, and that
+			// old run was never a supervisor-managed instance). Only bring the new
+			// service up to its instance count, exactly as a freshly added service
+			// would; StartServiceInstances honours Autostart / a stopped supervisor.
+			r.startChangedService(newTask)
+		}
 	}
 }
 
@@ -334,6 +347,17 @@ func (r *Reconciler) anchorUnheld(oldTask, newTask *model.Task) {
 func (r *Reconciler) recycleChangedService(newTask *model.Task) {
 	if err := r.manager.RecycleServiceInstances(newTask.Name); err != nil {
 		slog.Error("Failed to recycle changed service", "task", newTask.Name, "err", err)
+	}
+}
+
+// startChangedService brings a task that a reload just turned into a service up
+// to its instance count without disturbing any run still draining under the
+// prior non-service definition. It mirrors applyAdded's service path — a fresh
+// supervisor with no live slots — because to the new definition that is exactly
+// what this is: a service starting from zero live instances.
+func (r *Reconciler) startChangedService(newTask *model.Task) {
+	if err := r.manager.StartServiceInstances(newTask.Name, model.TriggeredByService); err != nil {
+		slog.Error("Failed to start instances for newly-serviced task", "task", newTask.Name, "err", err)
 	}
 }
 

--- a/apps/runwisp/internal/runtime/reconcile_test.go
+++ b/apps/runwisp/internal/runtime/reconcile_test.go
@@ -198,3 +198,24 @@ func TestReconcile_ChangedServiceIsStillRecycled(t *testing.T) {
 	assert.Equal(t, []string{"worker"}, mgr.recycled)
 	assert.Empty(t, mgr.restarted, "reload must not use the operator-restart path")
 }
+
+// TestReconcile_TaskToServiceKindFlipStartsNotRecycles is the reload-invariant
+// regression: when a plain cron/manual task is redefined as a service on reload,
+// the run that was in flight under the old non-service definition must finish
+// under it. Recycling (RecycleServiceInstances) cancels every active run, so it
+// would kill that draining run — a run the supervisor never managed. The flip
+// must instead only bring the new service up to its instance count
+// (StartServiceInstances), exactly as a freshly added service would.
+func TestReconcile_TaskToServiceKindFlipStartsNotRecycles(t *testing.T) {
+	before := &model.Task{Name: "web", Cron: "*/5 * * * *", Run: "web --once"}
+	after := &model.Task{Name: "web", Kind: model.KindService, Run: "web --loop", Instances: 1, Autostart: true}
+
+	mgr, _, diff := applyDiff(taskSet(before), taskSet(after))
+
+	require.Len(t, diff.Changed, 1)
+	assert.True(t, diff.Changed[0].Has(config.ReasonKind), "task→service is a kind change")
+	assert.Equal(t, []string{"web"}, mgr.started, "a newly-serviced task must be started, so the old run drains")
+	assert.Empty(t, mgr.recycled, "recycling would cancel the in-flight non-service run")
+	assert.Empty(t, mgr.restarted)
+	assert.Empty(t, mgr.stopped)
+}

--- a/apps/runwisp/internal/runtime/reconcile_test.go
+++ b/apps/runwisp/internal/runtime/reconcile_test.go
@@ -82,6 +82,7 @@ type recordingManager struct {
 	TaskManager
 	upserted  []string
 	restarted []string
+	recycled  []string
 	started   []string
 	stopped   []string
 	removed   []string
@@ -93,6 +94,11 @@ func (m *recordingManager) UpsertTask(task *model.Task) {
 
 func (m *recordingManager) RestartServiceInstances(name string) error {
 	m.restarted = append(m.restarted, name)
+	return nil
+}
+
+func (m *recordingManager) RecycleServiceInstances(name string) error {
+	m.recycled = append(m.recycled, name)
 	return nil
 }
 
@@ -147,6 +153,7 @@ func TestReconcile_PromotedServiceIsNotRestarted(t *testing.T) {
 	assert.Empty(t, diff.Changed, "provenance is not a task change")
 	assert.Equal(t, []string{"worker"}, diff.Restamped)
 	assert.Empty(t, mgr.restarted, "a promoted service must keep running")
+	assert.Empty(t, mgr.recycled, "a promoted service must keep running")
 	assert.Empty(t, mgr.started)
 	assert.Empty(t, mgr.stopped)
 	assert.Empty(t, mgr.removed)
@@ -173,7 +180,10 @@ func TestReconcile_PromotedTaskIsNotRescheduled(t *testing.T) {
 }
 
 // TestReconcile_ChangedServiceIsStillRecycled guards the masking from going too
-// far: a genuine definition change must still recycle the service.
+// far: a genuine definition change must still recycle the service. It must go
+// through RecycleServiceInstances, not the operator-restart
+// RestartServiceInstances — recycling a changed service on reload must never
+// revive one the operator stopped (see manager package tests for that guard).
 func TestReconcile_ChangedServiceIsStillRecycled(t *testing.T) {
 	before := &model.Task{Name: "worker", Kind: model.KindService, Run: "worker --loop", Source: model.SourceStaged}
 	after := *before
@@ -185,5 +195,6 @@ func TestReconcile_ChangedServiceIsStillRecycled(t *testing.T) {
 	require.Len(t, diff.Changed, 1)
 	assert.True(t, diff.Changed[0].Has(config.ReasonCommand))
 	assert.Empty(t, diff.Restamped, "a real change is reported as a change, not a restamp")
-	assert.Equal(t, []string{"worker"}, mgr.restarted)
+	assert.Equal(t, []string{"worker"}, mgr.recycled)
+	assert.Empty(t, mgr.restarted, "reload must not use the operator-restart path")
 }

--- a/apps/runwisp/internal/runtime/services/supervisor.go
+++ b/apps/runwisp/internal/runtime/services/supervisor.go
@@ -220,11 +220,16 @@ func (s *Supervisor) LiveCount() int {
 }
 
 // MissingSlots returns the indexes in [0, instances) that are not currently
-// live. Used by StartServiceInstances to bring a service up to desired count.
+// live and not FATAL. Used by StartServiceInstances to bring a service up to
+// desired count. A FATAL slot is deliberately excluded: it has exhausted its
+// start-retry budget and only comes back once something clears the flag
+// (MarkRunning/ClearFatal) — treating it as "missing" would silently retry a
+// slot the supervisor already gave up on.
 func (s *Supervisor) MissingSlots() []int {
 	missing := make([]int, 0, s.instances)
 	for i := 0; i < s.instances; i++ {
-		if !s.slot(i).live {
+		st := s.slot(i)
+		if !st.live && !st.fatal {
 			missing = append(missing, i)
 		}
 	}

--- a/apps/runwisp/internal/runtime/services/supervisor_test.go
+++ b/apps/runwisp/internal/runtime/services/supervisor_test.go
@@ -187,6 +187,22 @@ func TestMissingSlots(t *testing.T) {
 	assert.Equal(t, []int{0, 2, 3}, missing)
 }
 
+// TestMissingSlotsExcludesFatal guards a FATAL slot from being reported as
+// spawnable: StartServiceInstances fills every "missing" slot unconditionally,
+// so a FATAL slot showing up here would get silently respawned outside of an
+// explicit restart (MarkRunning/ClearFatal) — the exact thing FATAL exists to
+// prevent.
+func TestMissingSlotsExcludesFatal(t *testing.T) {
+	s := newSupervisorForTest("svc", 1)
+	_, err := s.Reserve(nil)
+	require.NoError(t, err)
+	s.MarkLive(0)
+	_, fatal := s.RecordExit(0, time.Millisecond, 0, true)
+	require.True(t, fatal)
+
+	assert.Empty(t, s.MissingSlots(), "a FATAL slot must not be reported as missing")
+}
+
 func TestIsHealthyTracksLiveUptime(t *testing.T) {
 	const threshold = 30 * time.Second
 	now := time.Unix(0, 0)

--- a/apps/runwisp/internal/runtime/services_test.go
+++ b/apps/runwisp/internal/runtime/services_test.go
@@ -463,3 +463,76 @@ func TestStopServiceHaltsRestarts(t *testing.T) {
 		return len(djm.tasks["svc"].active) == 2
 	}, 2*time.Second, 10*time.Millisecond, "Restart should bring instances back")
 }
+
+// TestRecycleServiceInstances_LeavesStoppedServiceStopped is the regression
+// test for a reload recycling a service the operator stopped: reload adds/
+// changes/removes tasks live, it is never a restart, so it must not revive a
+// service the operator explicitly stopped. Only an operator/cloud-initiated
+// RestartServiceInstances may clear that flag.
+func TestRecycleServiceInstances_LeavesStoppedServiceStopped(t *testing.T) {
+	djm, _, eb := newGatedManager(t)
+	jm := TaskManager(djm)
+
+	task := serviceTask("svc", 2)
+	jm.UpsertTask(task)
+
+	started := watchRuns(eb, events.EventRunStarted)
+	done := watchCompletions(eb)
+	require.NoError(t, jm.StartServiceInstances("svc", model.TriggeredByService))
+	started.waitFor(t, 2)
+
+	require.NoError(t, jm.StopService("svc"))
+	done.waitFor(t, 2)
+
+	// A reload picks up a definition change (e.g. a new command) for this
+	// still-stopped service.
+	require.NoError(t, jm.RecycleServiceInstances("svc"))
+
+	djm.mu.RLock()
+	stillStopped := djm.tasks["svc"].supervisor.IsStopped()
+	active := len(djm.tasks["svc"].active)
+	djm.mu.RUnlock()
+	assert.True(t, stillStopped, "reload must not clear an operator stop")
+	assert.Equal(t, 0, active, "a reload-recycled stopped service must stay at zero instances")
+}
+
+// TestRecycleServiceInstances_LeavesAutostartFalseStopped is the sibling case:
+// a service that never started because Autostart is false must not be
+// force-started just because reload picked up a change to its definition.
+func TestRecycleServiceInstances_LeavesAutostartFalseStopped(t *testing.T) {
+	djm, _, _ := newTestManager(t)
+	jm := TaskManager(djm)
+
+	task := serviceTask("manual", 1)
+	task.Autostart = false
+	jm.UpsertTask(task)
+
+	require.NoError(t, jm.RecycleServiceInstances("manual"))
+	time.Sleep(50 * time.Millisecond)
+
+	djm.mu.RLock()
+	active := len(djm.tasks["manual"].active)
+	djm.mu.RUnlock()
+	assert.Equal(t, 0, active, "reload must not start an autostart=false service")
+}
+
+// TestRecycleServiceInstances_CancelsRunningInstances proves the positive case
+// still works: a running service's instances are cancelled and refilled so a
+// genuine command/env/instance-count change takes effect.
+func TestRecycleServiceInstances_CancelsRunningInstances(t *testing.T) {
+	djm, _, eb := newGatedManager(t)
+	jm := TaskManager(djm)
+
+	task := serviceTask("svc", 3)
+	jm.UpsertTask(task)
+
+	started := watchRuns(eb, events.EventRunStarted)
+	require.NoError(t, jm.StartServiceInstances("svc", model.TriggeredByService))
+	started.waitFor(t, 3)
+
+	require.NoError(t, jm.RecycleServiceInstances("svc"))
+
+	// Each of the three instances is cancelled and refilled; six starts total
+	// proves the refills happened.
+	started.waitFor(t, 6)
+}

--- a/apps/runwisp/internal/runtime/taskstate.go
+++ b/apps/runwisp/internal/runtime/taskstate.go
@@ -66,6 +66,18 @@ type taskState struct {
 	// spawn on cond==nil alone would silently leave a revived queue task with no
 	// drain. Guarded by m.mu.
 	queueDraining bool
+
+	// stoppedByRemoval latches when RemoveTask stops a service's supervisor as
+	// mechanical bookkeeping (the operator never asked to stop it — the task
+	// simply hasn't finished draining yet). UpsertTask's revival branch
+	// consults it to decide whether the resulting stopped flag should clear:
+	// an operator's own StopService must still survive a reload, but
+	// RemoveTask's stop must not silently outlive the removal it was for, or
+	// a revived service task comes back registered with zero live instances
+	// and no error surfaced anywhere. Cleared by StopService/
+	// RestartServiceInstances too, since either one makes the stop (or lack
+	// of it) unambiguously operator-driven from that point on.
+	stoppedByRemoval bool
 }
 
 // concurrencyAction describes what the caller should do after evaluating a

--- a/apps/runwisp/internal/server/daemon_logs.go
+++ b/apps/runwisp/internal/server/daemon_logs.go
@@ -25,7 +25,7 @@ func (srv *Server) registerDaemonLogSSE(api huma.API) {
 }
 
 func (srv *Server) sseDaemonLogHandler(ctx context.Context, _ *struct{}, send sse.Sender) {
-	release, ok := srv.streams.acquire(streamClientIPFromCtx(ctx))
+	release, ok := srv.streams.acquire(ctx)
 	if !ok {
 		return
 	}

--- a/apps/runwisp/internal/server/log_search.go
+++ b/apps/runwisp/internal/server/log_search.go
@@ -188,7 +188,7 @@ func (srv *Server) resolveSearchRuns(ctx context.Context, input *LogSearchInput,
 			if errors.Is(err, errInvalidRunID) {
 				return nil, huma.Error400BadRequest("Invalid run ID")
 			}
-			return nil, huma.Error404NotFound("Run not found")
+			return nil, mapDomainError(ctx, err, "Failed to load run")
 		}
 		// This search is scoped to the task in the URL, so a run_id belonging
 		// to a different task is not found here.
@@ -210,7 +210,7 @@ func (srv *Server) resolveSearchRuns(ctx context.Context, input *LogSearchInput,
 		SortDirection: storage.SortDesc,
 	})
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to list runs")
+		return nil, mapDomainError(ctx, err, "Failed to list runs")
 	}
 	out := make([]logsearch.RunRef, 0, len(runs))
 	for _, r := range runs {

--- a/apps/runwisp/internal/server/log_search_test.go
+++ b/apps/runwisp/internal/server/log_search_test.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -141,6 +142,50 @@ func TestSearchLogs_SingleRun_WrongTask(t *testing.T) {
 	s.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestSearchLogs_RunLookupStorageErrorReturns500 is the regression test for a
+// bug where any non-"not found" failure looking up runId (a locked DB, a disk
+// I/O error) was silently reported as a plain 404, identical to a bad or
+// unknown run ID, with nothing logged. A genuine storage failure must surface
+// as a 500.
+func TestSearchLogs_RunLookupStorageErrorReturns500(t *testing.T) {
+	s, repo, _, _ := setupServer(t)
+
+	id := ulid.Make().String()
+	repo.On("GetRun", mock.Anything, id).Return((*model.Run)(nil), errors.New("disk read error"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/tasks/task1/log/search?q=foo&runId=%s", id), nil)
+	w := httptest.NewRecorder()
+	addAuth(req, s)
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"a storage failure must not masquerade as a 404")
+}
+
+// TestSearchLogs_QueryRunsErrorReturns500 is the sibling regression for the
+// task-wide listing path: a QueryRuns failure must surface as a logged 500,
+// not the same "Failed to list runs" 500 masking whatever actually broke —
+// mapDomainError is what supplies the logging.
+func TestSearchLogs_QueryRunsErrorReturns500(t *testing.T) {
+	s, repo, _, _ := setupServer(t)
+
+	repo.On("QueryRuns", mock.Anything, storage.RunQuery{
+		Filter:        model.RunFilter{TaskName: "task1"},
+		Limit:         LogSearchRunPageSize,
+		SortField:     storage.SortColumnCreatedAt,
+		SortDirection: storage.SortDesc,
+	}).Return([]model.Run(nil), errors.New("disk read error"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/tasks/task1/log/search?q="+url.QueryEscape("connection refused"), nil)
+	w := httptest.NewRecorder()
+	addAuth(req, s)
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestSearchLogs_BadCursor(t *testing.T) {

--- a/apps/runwisp/internal/server/logs.go
+++ b/apps/runwisp/internal/server/logs.go
@@ -251,7 +251,7 @@ func (srv *Server) registerLogSSE(api huma.API) {
 		"dropped": LogDroppedEvent{},
 		"done":    LogDoneEvent{},
 	}, func(ctx context.Context, input *LogStreamInput, send sse.Sender) {
-		release, ok := srv.streams.acquire(streamClientIPFromCtx(ctx))
+		release, ok := srv.streams.acquire(ctx)
 		if !ok {
 			return
 		}

--- a/apps/runwisp/internal/server/logs.go
+++ b/apps/runwisp/internal/server/logs.go
@@ -104,14 +104,16 @@ func (srv *Server) getRunByID(ctx context.Context, runIDStr string) (*model.Run,
 }
 
 // resolveLogPath validates the run ID and computes the log path. Returns
-// an error suitable for huma to map to an HTTP status code.
+// an error suitable for huma to map to an HTTP status code. A genuine storage
+// failure (not just "no such run") is routed through mapDomainError so it
+// surfaces as a logged 500 instead of silently masquerading as a 404.
 func (srv *Server) resolveLogPath(ctx context.Context, runIDStr string) (string, *model.Run, error) {
 	run, err := srv.getRunByID(ctx, runIDStr)
 	if err != nil {
 		if errors.Is(err, errInvalidRunID) {
 			return "", nil, huma.Error400BadRequest("Invalid run ID")
 		}
-		return "", nil, huma.Error404NotFound("Run not found")
+		return "", nil, mapDomainError(ctx, err, "Failed to load run")
 	}
 	return logutil.ResolveRunLogPath(srv.logDir, run.TaskName, run.ID, run.CreatedAt), run, nil
 }

--- a/apps/runwisp/internal/server/logs_test.go
+++ b/apps/runwisp/internal/server/logs_test.go
@@ -92,6 +92,24 @@ func TestResolveLogPath_MissingRunReturns404(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, statusErr.GetStatus())
 }
 
+// TestResolveLogPath_StorageErrorReturns500 is the regression test for a bug
+// where any non-"not found" failure from the run lookup (a locked DB, a disk
+// I/O error) was silently reported as a plain 404 "Run not found", identical
+// to a bad run ID, with nothing logged anywhere. A genuine storage failure
+// must surface as a 500 so the operator can see it.
+func TestResolveLogPath_StorageErrorReturns500(t *testing.T) {
+	srv, db, _ := logsTestServer(t)
+	run := seedTerminalRun(t, db, "task")
+	require.NoError(t, db.Close()) // any query now fails with a non-ErrNoRows error
+
+	_, _, err := srv.resolveLogPath(t.Context(), run.ID)
+	require.Error(t, err)
+	statusErr, ok := err.(huma.StatusError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusInternalServerError, statusErr.GetStatus(),
+		"a storage failure must not masquerade as a 404")
+}
+
 func TestResolveLogPath_Success(t *testing.T) {
 	srv, db, logDir := logsTestServer(t)
 	run := seedTerminalRun(t, db, "task")

--- a/apps/runwisp/internal/server/notifications.go
+++ b/apps/runwisp/internal/server/notifications.go
@@ -278,7 +278,7 @@ func (srv *Server) registerNotificationsSSE(api huma.API) {
 }
 
 func (srv *Server) sseNotificationsHandler(ctx context.Context, _ *struct{}, send sse.Sender) {
-	release, ok := srv.streams.acquire(streamClientIPFromCtx(ctx))
+	release, ok := srv.streams.acquire(ctx)
 	if !ok {
 		return
 	}

--- a/apps/runwisp/internal/server/runs.go
+++ b/apps/runwisp/internal/server/runs.go
@@ -414,7 +414,7 @@ func (srv *Server) registerAppStreamSSE(api huma.API) {
 // connection until the client disconnects. Folding these onto a single stream
 // is what keeps a browser tab to one EventSource instead of three.
 func (srv *Server) appStreamHandler(ctx context.Context, input *AppStreamInput, send sse.Sender) {
-	release, ok := srv.streams.acquire(streamClientIPFromCtx(ctx))
+	release, ok := srv.streams.acquire(ctx)
 	if !ok {
 		// huma owns the response writer here, so we communicate refusal via
 		// the SSE channel and return; the client will see a single ping then

--- a/apps/runwisp/internal/server/stream_limiter.go
+++ b/apps/runwisp/internal/server/stream_limiter.go
@@ -37,26 +37,41 @@ func newStreamLimiter(maxGlobal, maxPerIP int) *streamLimiter {
 	}
 }
 
-// acquire reserves a slot for ip. It returns release (always non-nil when ok)
-// which the caller must invoke when the stream finishes.
-func (l *streamLimiter) acquire(ip string) (release func(), ok bool) {
+// acquire reserves a stream slot for the request carried by ctx. The global
+// cap always applies; the per-IP sub-cap does not, for connections accepted
+// on the local Unix socket (PEERCRED-verified). Those connections have no
+// usable peer address — net.UnixConn.RemoteAddr() is empty for an unnamed
+// client socket — so every local TUI/CLI stream would otherwise collapse
+// into one shared bucket keyed by "", capping all local clients on the
+// machine combined at maxPerIP instead of bounding each one individually.
+// It returns release (always non-nil when ok) which the caller must invoke
+// when the stream finishes.
+func (l *streamLimiter) acquire(ctx context.Context) (release func(), ok bool) {
+	ip := streamClientIPFromCtx(ctx)
+	exempt := IsLocalTrustedCtx(ctx)
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	if l.total >= l.maxGlobal {
 		return nil, false
 	}
-	if l.perIP[ip] >= l.maxPerIP {
+	if !exempt && l.perIP[ip] >= l.maxPerIP {
 		return nil, false
 	}
 
 	l.total++
-	l.perIP[ip]++
+	if !exempt {
+		l.perIP[ip]++
+	}
 
 	return func() {
 		l.mu.Lock()
 		defer l.mu.Unlock()
 		l.total--
+		if exempt {
+			return
+		}
 		if l.perIP[ip] <= 1 {
 			delete(l.perIP, ip)
 		} else {

--- a/apps/runwisp/internal/server/stream_limiter_test.go
+++ b/apps/runwisp/internal/server/stream_limiter_test.go
@@ -4,27 +4,36 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+func ctxWithPeer(addr string) context.Context {
+	return context.WithValue(context.Background(), peerAddrContextKey, addr)
+}
+
+func ctxLocalTrusted(addr string) context.Context {
+	return context.WithValue(ctxWithPeer(addr), localTrustedKey{}, true)
+}
+
 func TestStreamLimiter_PerIPCap(t *testing.T) {
 	l := newStreamLimiter(100, 2)
 
-	r1, ok := l.acquire("203.0.113.1")
+	r1, ok := l.acquire(ctxWithPeer("203.0.113.1:1"))
 	assert.True(t, ok)
-	r2, ok := l.acquire("203.0.113.1")
+	r2, ok := l.acquire(ctxWithPeer("203.0.113.1:2"))
 	assert.True(t, ok)
-	_, ok = l.acquire("203.0.113.1")
+	_, ok = l.acquire(ctxWithPeer("203.0.113.1:3"))
 	assert.False(t, ok, "third concurrent stream from same IP should be refused")
 
 	// A different IP is unaffected.
-	r3, ok := l.acquire("203.0.113.2")
+	r3, ok := l.acquire(ctxWithPeer("203.0.113.2:1"))
 	assert.True(t, ok)
 
 	r1()
-	_, ok = l.acquire("203.0.113.1")
+	_, ok = l.acquire(ctxWithPeer("203.0.113.1:4"))
 	assert.True(t, ok, "after release, the IP can acquire again")
 
 	r2()
@@ -34,13 +43,43 @@ func TestStreamLimiter_PerIPCap(t *testing.T) {
 func TestStreamLimiter_GlobalCap(t *testing.T) {
 	l := newStreamLimiter(2, 100)
 
-	r1, ok := l.acquire("a")
+	r1, ok := l.acquire(ctxWithPeer("a:1"))
 	assert.True(t, ok)
-	r2, ok := l.acquire("b")
+	r2, ok := l.acquire(ctxWithPeer("b:1"))
 	assert.True(t, ok)
-	_, ok = l.acquire("c")
+	_, ok = l.acquire(ctxWithPeer("c:1"))
 	assert.False(t, ok, "third concurrent stream globally should be refused")
 
 	r1()
 	r2()
+}
+
+// TestStreamLimiter_LocalTrustedExemptFromPerIPCap guards against a bug where
+// every Unix-socket client collapsed into one shared per-IP bucket: a local
+// UnixConn's RemoteAddr() is empty for an unnamed client socket, so all local
+// TUI/CLI streams keyed on "" and capped the whole machine's local clients
+// combined at maxPerIP. Local-trusted (PEERCRED-verified) connections must
+// still count toward the global cap, but not toward any shared per-IP cap.
+func TestStreamLimiter_LocalTrustedExemptFromPerIPCap(t *testing.T) {
+	l := newStreamLimiter(100, 2)
+
+	var releases []func()
+	for i := 0; i < 5; i++ {
+		r, ok := l.acquire(ctxLocalTrusted(""))
+		assert.True(t, ok, "local-trusted streams must not be capped by the per-IP sub-limit")
+		releases = append(releases, r)
+	}
+
+	// The global cap still applies to local-trusted streams.
+	l2 := newStreamLimiter(5, 100)
+	for i := 0; i < 5; i++ {
+		_, ok := l2.acquire(ctxLocalTrusted(""))
+		assert.True(t, ok)
+	}
+	_, ok := l2.acquire(ctxLocalTrusted(""))
+	assert.False(t, ok, "the global cap must still bound local-trusted streams")
+
+	for _, r := range releases {
+		r()
+	}
 }

--- a/apps/ui/src/lib/stores/notifications.svelte.ts
+++ b/apps/ui/src/lib/stores/notifications.svelte.ts
@@ -228,7 +228,16 @@ class NotificationStore {
             if (current) {
                 rollback[j] = { ...current, readAt: previous.readAt };
                 this.#items = rollback;
-                this.#unread = Math.max(0, this.#unread + (read ? 1 : -1));
+            }
+            // #unread is always the server's authoritative snapshot (see the
+            // field comment above) — re-fetch it instead of reapplying a
+            // relative delta, which would drift if an authoritative SSE
+            // update (e.g. from this same notification recurring) landed
+            // while the request was in flight.
+            try {
+                this.#unread = await this.#fetchUnread();
+            } catch (refetchErr) {
+                this.#logger.error("Failed to refresh unread count after rollback", refetchErr);
             }
         }
     }

--- a/apps/ui/src/lib/stores/notifications.test.ts
+++ b/apps/ui/src/lib/stores/notifications.test.ts
@@ -359,6 +359,11 @@ describe("NotificationStore", () => {
         // which would have reverted count back to 1 here.
         expect(store.items[0]?.readAt).toBeNull();
         expect(store.items[0]?.count).toBe(5);
+        // The SSE update already set unread to its authoritative value (1)
+        // before the POST failed. The rollback must not layer another delta
+        // on top of that (the old code computed max(0, 1 + 1) = 2) — it
+        // re-fetches the authoritative count instead.
+        expect(store.unread).toBe(1);
     });
 
     it("resyncs items and unread count when connectionStore reports a reconnect", async () => {


### PR DESCRIPTION
Five bug fixes, each with a regression test.

### Fixed

- **Redefining a plain task as a service on `reload`** now starts the new service like any newly-added one and lets the in-flight run finish under its old definition, instead of cancelling that still-draining run.
- **A hung (not merely down) container engine no longer hangs the daemon.** A wedged Docker/Podman engine could pin a run's output streaming, its stop, and daemon shutdown indefinitely; the run now finalizes with a terminal status and shutdown stays bounded.
- **Connecting to a hung engine no longer blocks other container tasks' startup** — the first-connect probe is time-bounded, so one wedged engine can't stall every other container task's start.
- **A coalesced notification now states how many repeats it stands in for** (`×N`), so a folded burst of failures no longer reads as a single occurrence.
- **`import supervisord` now merges a `[program]` that appears in more than one included file** (last value wins, matching how supervisord itself assembles a base config plus a `conf.d` override), instead of importing it twice as `web` and `web-2`.