### PR TITLE
v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-08-29
+
 ### Fixed
 
 - **A task removed by `reload` and then re-added by a later `reload` now resumes as a normal running service**, instead of coming back with all instances stopped.
@@ -638,7 +640,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CHAP authentication for the HTTP API.
 - Deterministic human-readable instance fingerprint based on machine-id and working directory.
 
-[Unreleased]: https://github.com/runwisp/runwisp/compare/v0.16.1...main
+[Unreleased]: https://github.com/runwisp/runwisp/compare/v0.16.2...main
+[0.16.2]: https://github.com/runwisp/runwisp/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/runwisp/runwisp/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/runwisp/runwisp/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/runwisp/runwisp/compare/v0.15.0...v0.15.1


### PR DESCRIPTION

### Fixed

- **Missed-run catch-up no longer misses gaps on tasks with `run_on_start`.** The daemon now anchors catch-up detection to the last run recorded before boot, rather than a run created during startup.
- **`reload` and `SIGHUP` now apply a task's `treat_missed_as_failure` change immediately**, instead of requiring a full daemon restart.
- **Fixed line numbering on `.log.prev` after 2+ log rotations**, once the run had finished.
- **`import cron`/`import supervisord` no longer drop or corrupt data on plausible input.** A supervisord `environment=` value containing an apostrophe or stray quote (an English contraction, `O'Brien`) no longer swallows every subsequent `KEY=value` pair; a system crontab's user column now accepts uppercase account names (`Deploy`, not just `deploy`).
- **The optional cloud integration's task list now reflects `reload`/`SIGHUP` on the next reconnect**, instead of staying frozen at whatever the daemon's task set looked like at startup.
- **A jittered task with `on_overlap = "queue"` no longer leaks a stale in-flight slot when its queued run is orphaned by a `reload`** that removes or reconfigures the task.
- **Fixed the runs list occasionally showing a duplicate or skipping a row** when a run started, finished, or was deleted live while the list was loading its next page.