### PR TITLE
Fix run-lifecycle event loss and races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A run that finishes during a clean daemon shutdown now always has its final status and exit code persisted to run history.**
+- **`import supervisord` now correctly parses an `environment=` value where whitespace separates `=` from the opening quote** (e.g. `FOO= "bar,baz"`).
+- **The TUI's event stream now resumes from where it left off on reconnect** (daemon restart, network blip).
+- **A container task that finishes cleanly no longer sometimes logs a spurious "failed to stop container gracefully" warning.**
+- **A run ended by daemon shutdown, or skipped by the DST fall-back dedup, no longer triggers a false "run failed" notification**, and a daemon-shutdown stop is now described as such in the notification body instead of always reading "Stopped manually."
+- **A queued run under `on_overlap = "queue"` now keeps its restart attempt count when it restarts from the queue**, instead of resetting to attempt zero and skipping the configured backoff escalation.
+- **A run left queued when its task is removed, redefined, or the daemon restarts now always gets a final `run.failed` event and a terminal status in run history**, instead of sometimes vanishing from the live view with no end state recorded.
+- **Missed-run catch-up across a DST fall-back no longer double-counts the repeated wall-clock hour as extra missed runs.**
+- **A run search filter longer than the length cap no longer risks splitting a multi-byte character mid-codepoint when truncating.**
+- **A genuine disk error while capturing a task's output now stops the writer and marks where output was lost**, instead of silently dropping output line by line for the rest of the run.
+- **Fixed two log-rendering bugs affecting tasks with progress bars/redraws or a pager-style alternate screen (`less`, `htop`, `vim`): a cursor-down move no longer reorders surrounding lines, and exiting the alternate screen no longer leaves later output stuck as ephemeral and never saved to the log.**
+
 ## [0.16.2] - 2026-08-29
 
 ### Fixed

--- a/apps/runwisp/internal/apiclient/client_test.go
+++ b/apps/runwisp/internal/apiclient/client_test.go
@@ -360,8 +360,10 @@ func TestGetLogRaw(t *testing.T) {
 func TestStreamRunEvents(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/events/stream", r.URL.Path)
+		assert.Equal(t, "", r.URL.RawQuery, "a fresh subscribe must not send a resume cursor")
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "id: 5")
 		fmt.Fprintln(w, "event: run.created")
 		fmt.Fprintln(w, `data: {"type":"run.created","timestamp":"2025-01-01T00:00:00Z","data":{}}`)
 		fmt.Fprintln(w, "")
@@ -372,11 +374,32 @@ func TestStreamRunEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch, err := c.StreamRunEvents(ctx)
+	ch, err := c.StreamRunEvents(ctx, "")
 	require.NoError(t, err)
 
 	evt := <-ch
 	assert.Equal(t, "run.created", evt.Type)
+	assert.Equal(t, "5", evt.ID, "the id: line must be captured so a reconnect can resume from it")
+}
+
+// TestStreamRunEvents_ResumesFromLastEventID guards against a reconnect
+// silently losing every event that fired during the gap: the client must
+// forward the caller's last-seen event ID as the lastEventId query param so
+// the server's replay ring resumes instead of starting live-only.
+func TestStreamRunEvents_ResumesFromLastEventID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "42", r.URL.Query().Get("lastEventId"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := c.StreamRunEvents(ctx, "42")
+	require.NoError(t, err)
 }
 
 func TestBaseURL(t *testing.T) {

--- a/apps/runwisp/internal/apiclient/events.go
+++ b/apps/runwisp/internal/apiclient/events.go
@@ -18,14 +18,24 @@ import (
 const (
 	ssePrefixEvent = "event: "
 	ssePrefixData  = "data: "
+	ssePrefixID    = "id: "
 )
 
 // StreamRunEvents opens an SSE connection to the unified /api/events/stream feed and
 // delivers parsed run events on the returned channel. The stream also carries
 // system/config/notification events, which the parser ignores. The channel is
 // closed when the context is cancelled or the stream ends.
-func (c *Client) StreamRunEvents(ctx context.Context) (<-chan RunStreamEvent, error) {
-	resp, err := c.doSSE(ctx, "/api/events/stream")
+//
+// lastEventID, when non-empty, is sent as the lastEventId query param so a
+// reconnecting caller resumes the replay from the last event it saw instead
+// of silently losing everything that fired during the gap — pass the ID
+// field of the last RunStreamEvent this caller received.
+func (c *Client) StreamRunEvents(ctx context.Context, lastEventID string) (<-chan RunStreamEvent, error) {
+	path := "/api/events/stream"
+	if lastEventID != "" {
+		path += "?lastEventId=" + lastEventID
+	}
+	resp, err := c.doSSE(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -196,9 +206,12 @@ func parseLogStreamFrame(event, data string) (LogStreamMsg, bool) {
 	return LogStreamMsg{}, false
 }
 
-// SSEEvent is the client-side SSE dispatch frame: event type + raw JSON payload.
+// SSEEvent is the client-side SSE dispatch frame: event type + raw JSON
+// payload, plus the frame's id (empty when the server sent none — pings and
+// notification updates carry no id and stay out of the resume sequence).
 type SSEEvent struct {
 	Type string
+	ID   string
 	Data json.RawMessage
 }
 
@@ -206,17 +219,23 @@ type SSEEvent struct {
 type RunStreamEvent = SSEEvent
 
 // simpleSSELoop is the shared parse loop for SSE streams that deliver
-// single-line data frames. It reads lines from body, pairs event:/data: into
-// SSEEvent values, and sends them on ch until the body closes or ctx cancels.
+// single-line data frames. It reads lines from body, pairs id:/event:/data:
+// into SSEEvent values, and sends them on ch until the body closes or ctx
+// cancels.
 func simpleSSELoop(ctx context.Context, body io.ReadCloser, ch chan<- SSEEvent) {
 	defer close(ch)
 	defer body.Close()
 
 	scanner := bufio.NewScanner(body)
-	var eventType string
+	var eventType, eventID string
 
 	for scanner.Scan() {
 		line := scanner.Text()
+
+		if strings.HasPrefix(line, ssePrefixID) {
+			eventID = strings.TrimPrefix(line, ssePrefixID)
+			continue
+		}
 
 		if strings.HasPrefix(line, ssePrefixEvent) {
 			eventType = strings.TrimPrefix(line, ssePrefixEvent)
@@ -227,17 +246,19 @@ func simpleSSELoop(ctx context.Context, body io.ReadCloser, ch chan<- SSEEvent) 
 			data := strings.TrimPrefix(line, ssePrefixData)
 			if eventType != "" {
 				select {
-				case ch <- SSEEvent{Type: eventType, Data: json.RawMessage(data)}:
+				case ch <- SSEEvent{Type: eventType, ID: eventID, Data: json.RawMessage(data)}:
 				case <-ctx.Done():
 					return
 				}
 				eventType = ""
+				eventID = ""
 			}
 			continue
 		}
 
 		if line == "" {
 			eventType = ""
+			eventID = ""
 		}
 	}
 }

--- a/apps/runwisp/internal/executor/container.go
+++ b/apps/runwisp/internal/executor/container.go
@@ -239,6 +239,19 @@ func (b *ContainerBackend) Start(ctx context.Context, task *model.Task, run *mod
 		case <-done:
 			return
 		}
+		// The wake above can fire for ctx.Done() even when done was actually
+		// closed first: Execute cancels ctx unconditionally on return (after
+		// Wait closes done and Cleanup removes the container), so if this
+		// goroutine hasn't been scheduled since done closed, both channels
+		// are ready by the time it runs and select ties uniformly at random.
+		// Re-check done on its own before treating this as a stop/timeout —
+		// a run that already exited cleanly must never attempt a graceful
+		// stop against a container Cleanup has already removed.
+		select {
+		case <-done:
+			return
+		default:
+		}
 		// A stop/timeout/shutdown asked the run to end. Run Docker's native
 		// graceful ladder first (stop_signal, then SIGKILL after graceful_stop);
 		// if the container still hasn't exited afterwards — a wedged engine that

--- a/apps/runwisp/internal/executor/container_test.go
+++ b/apps/runwisp/internal/executor/container_test.go
@@ -13,7 +13,9 @@ import (
 	"io"
 	"net"
 	"os"
+	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -573,6 +575,59 @@ func TestStartGracefulStopUsesSignalAndTimeout(t *testing.T) {
 	case <-killed:
 		t.Fatal("the graceful stop path must not SIGKILL the container")
 	default:
+	}
+}
+
+// TestStartWatcherDoesNotGracefulStopAfterCleanSuccess guards against the same
+// race class fixed in internal/runtime/persistence.go this session: the stop
+// watcher's select blocks on <-ctx.Done() and <-done (closed by a successful
+// Wait). Execute closes done (inside Wait) strictly before it cancels ctx (a
+// deferred cancelFunc that fires only after Cleanup has already removed the
+// container) — but if the watcher goroutine hasn't been scheduled since done
+// closed, ctx may already be cancelled too by the time it finally runs, and
+// both cases are simultaneously ready: select ties uniformly at random. A
+// purely successful run could then still call gracefulStopContainer
+// (ContainerStop) against a container Cleanup already removed, logging a
+// false "failed to stop gracefully" warning for a run that actually
+// succeeded. GOMAXPROCS(1) forces the race window open: the test goroutine
+// runs Wait+Cleanup+cancel with no blocking call in between, so the watcher
+// goroutine spawned by Start cannot run until we explicitly yield afterward —
+// by which point both channels are already closed, exactly reproducing the
+// tie. Repeated because a single trial can pass by luck.
+func TestStartWatcherDoesNotGracefulStopAfterCleanSuccess(t *testing.T) {
+	prevProcs := runtime.GOMAXPROCS(1)
+	t.Cleanup(func() { runtime.GOMAXPROCS(prevProcs) })
+
+	for i := 0; i < 200; i++ {
+		var stopCalled atomic.Bool
+		mock := &mockDockerClient{
+			containerStopFunc: func(ctx context.Context, _ string, _ client.ContainerStopOptions) (client.ContainerStopResult, error) {
+				stopCalled.Store(true)
+				return client.ContainerStopResult{}, nil
+			},
+		}
+		b := NewContainerBackendFromClient(mock)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		task := &model.Task{StopSignal: "SIGTERM", GracefulStop: time.Second}
+		proc, err := b.Start(ctx, task, nil, &model.ContainerExecution{Script: "echo hi", BaseImage: "alpine"})
+		require.NoError(t, err)
+
+		// No blocking call between Wait and cancel: under GOMAXPROCS(1) the
+		// watcher goroutine spawned inside Start cannot preempt this sequence.
+		_, waitErr := proc.Wait() // closes done
+		require.NoError(t, waitErr)
+		proc.Cleanup()
+		cancel() // mirrors Execute's deferred cancelFunc firing right after Cleanup
+
+		// Let the watcher goroutine finally run, now that both channels are
+		// already closed.
+		runtime.Gosched()
+		time.Sleep(5 * time.Millisecond)
+
+		if stopCalled.Load() {
+			t.Fatalf("iteration %d: watcher called gracefulStopContainer (ContainerStop) after the run had already exited cleanly via done", i)
+		}
 	}
 }
 

--- a/apps/runwisp/internal/executor/log_writer.go
+++ b/apps/runwisp/internal/executor/log_writer.go
@@ -151,8 +151,9 @@ func NewLogWriter(opts LogWriterOpts) (*LogWriter, error) {
 // WriteLineEvent appends a single line for the given stream and returns the
 // absolute line number assigned by the writer (rotated_lines + line_count).
 // Returns -1 when the line is silently dropped (writer stopped, drop_new,
-// kill, disk-low). The returned number is monotonically non-decreasing
-// across rotations and is the canonical `n` for log events on the bus.
+// kill, disk-low, write error). The returned number is monotonically
+// non-decreasing across rotations and is the canonical `n` for log events on
+// the bus.
 func (w *LogWriter) WriteLineEvent(text, stream string) (int64, error) {
 	formatted := []byte(logutil.FormatLine(text, stream))
 	lineNum, _, err := w.writeOneLine(formatted)
@@ -189,8 +190,10 @@ func (w *LogWriter) WriteFrameHistory(anchor int64, frames [][]string) error {
 }
 
 // writeOneLine is the single mutex-guarded write path. Returns the absolute
-// line number assigned (or -1 if the line was dropped) plus the io.Writer
-// `n` (always len(p) for drop cases, matching the prior contract).
+// line number assigned (or -1 if the line was dropped, including a genuine
+// write error — treated as a drop like disk-pressure and size-overflow, not
+// surfaced as an error to the caller) plus the io.Writer `n` (always len(p)
+// for drop cases, matching the prior contract).
 func (w *LogWriter) writeOneLine(p []byte) (lineNum int64, written int, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -215,7 +218,16 @@ func (w *LogWriter) writeOneLine(p []byte) (lineNum int64, written int, err erro
 
 	n, err := w.file.Write(p)
 	if err != nil {
-		return -1, n, err
+		// A genuine write error gets the same treatment as disk-pressure and
+		// size-overflow: stop the writer so every later line drops cheaply
+		// instead of repeating the same failing syscall for the rest of the
+		// run, and leave a SYSTEM line marking where output was lost (best
+		// effort — if the file is truly unusable this write fails too and is
+		// swallowed, same as any other writeSystemLine caller).
+		w.stopped = true
+		w.truncated = true
+		w.writeSystemLine(fmt.Sprintf("Log output stopped: write error (%v). Process continues running.", err))
+		return -1, len(p), nil
 	}
 
 	if n > 0 {

--- a/apps/runwisp/internal/executor/log_writer_test.go
+++ b/apps/runwisp/internal/executor/log_writer_test.go
@@ -575,3 +575,28 @@ func TestLogWriter_RotateRenameFailure_PreservesExistingPrev(t *testing.T) {
 	assert.Equal(t, firstRotation, afterFailedRotation,
 		".prev must survive a rotation whose rename fails, not just one whose remove would have failed too")
 }
+
+// TestLogWriter_WriteError_StopsWriterInsteadOfRetryingForever guards against a
+// prime-directive violation: a genuine OS-level write error (disk failure,
+// revoked permissions, closed fd) used to fall through writeOneLine as a
+// one-off error with the writer left believing it was still healthy. Every
+// subsequent line for the rest of the run would then repeat the same failing
+// syscall and vanish with nothing durable in the run's own log — unlike the
+// disk-pressure and size-overflow paths, which stop the writer and leave a
+// SYSTEM line marking exactly where output was lost.
+func TestLogWriter_WriteError_StopsWriterInsteadOfRetryingForever(t *testing.T) {
+	opts := newTestOpts(t.TempDir())
+	w, err := NewLogWriter(opts)
+	require.NoError(t, err)
+	require.NoError(t, w.file.Close()) // force the next write against it to fail
+
+	n, err := w.WriteLineEvent("first line lost to the write error", logutil.StreamStdout)
+	require.NoError(t, err, "a write failure is a drop, like disk-pressure and size-overflow, not a caller-visible error")
+	assert.Equal(t, int64(-1), n)
+	assert.True(t, w.stopped, "writer must stop after a genuine write error instead of retrying the same failing syscall on every later line")
+	assert.True(t, w.truncated, "a lost line must count as truncation like every other drop reason")
+
+	n2, err2 := w.WriteLineEvent("second line", logutil.StreamStdout)
+	require.NoError(t, err2)
+	assert.Equal(t, int64(-1), n2, "once stopped, later lines are dropped too rather than re-attempting the broken write")
+}

--- a/apps/runwisp/internal/executor/terminal_renderer.go
+++ b/apps/runwisp/internal/executor/terminal_renderer.go
@@ -315,6 +315,13 @@ func (tr *TerminalRenderer) handlePrivateMode(set bool) {
 			// Entering the alternate screen: clear and redraw in place.
 			tr.resetScreen()
 			tr.screenLocked = true
+		case (p == 1049 || p == 47 || p == 1047) && !set:
+			// Exiting the alternate screen: finalize whatever it left showing
+			// and return to durable forward output on the main screen,
+			// symmetric with entry. Without this the region stays locked
+			// forever and everything printed afterwards is only ever
+			// ephemeral (provisional), never persisted.
+			tr.resetScreen()
 		case p == 25 && !set:
 			// Hiding the cursor almost always precedes an in-place redraw.
 			tr.screenLocked = true
@@ -408,6 +415,8 @@ func (tr *TerminalRenderer) cursorUp(n int) {
 }
 
 func (tr *TerminalRenderer) cursorDown(n int) {
+	tr.recordRegionFrame()
+	tr.screenLocked = true
 	tr.curRow += n
 	tr.cur()
 	tr.scrollIfNeeded()

--- a/apps/runwisp/internal/executor/terminal_renderer_test.go
+++ b/apps/runwisp/internal/executor/terminal_renderer_test.go
@@ -466,6 +466,21 @@ func TestRendererCursorPositionRedraw(t *testing.T) {
 	}
 }
 
+func TestRendererCursorDownLocksRegionLikeOtherCursorMoves(t *testing.T) {
+	// CSI B (cursor down) is a region-addressing move exactly like CSI A (up)
+	// and CSI H (position), which both lock the region so a following '\n'
+	// stays inside the live redraw instead of finalizing a forward line out of
+	// order. Without the cursor down here ever locking, the '\n' after "row1"
+	// would forward-commit whatever sits at the cursor's row instead of
+	// leaving both rows for a single, correctly ordered region commit.
+	h := newHarness()
+	h.feed("row0\x1b[1B\rrow1\n", 0)
+	h.tr.Close()
+	if !eq(h.committed, []string{"row0", "row1"}) {
+		t.Fatalf("cursor-down redraw render = %q, want [row0 row1] in original order", h.committed)
+	}
+}
+
 func TestRendererEraseLineModes(t *testing.T) {
 	// CSI 2K clears the whole line; the cursor keeps its column, so a following
 	// write lands padded at that column.
@@ -509,6 +524,21 @@ func TestRendererAltScreenEntryResets(t *testing.T) {
 	}
 	if startEpoch == 0 {
 		t.Fatalf("alt-screen entry should advance the epoch")
+	}
+}
+
+func TestRendererAltScreenExitUnlocksForwardMode(t *testing.T) {
+	// Exiting the alternate screen (CSI ?1049l) must finalize whatever the
+	// alt-screen left showing and return to forward mode, symmetric with
+	// entry. Without this, everything printed after a pager (less, vim,
+	// htop) exits stays locked in redraw mode and is never durably committed
+	// until the process eventually exits — a long-running task that leaves
+	// the alt screen keeps producing output that is only ever ephemeral
+	// (provisional), never persisted to the log.
+	h := newHarness()
+	h.feed("before\n\x1b[?1049hinside\x1b[?1049lafter\n", 0)
+	if !eq(h.committed, []string{"before", "inside", "after"}) {
+		t.Fatalf("alt-screen exit render = %q", h.committed)
 	}
 }
 

--- a/apps/runwisp/internal/importer/supervisord.go
+++ b/apps/runwisp/internal/importer/supervisord.go
@@ -586,14 +586,17 @@ func parseSupervisordEnv(value string) map[string]string {
 			} else {
 				val.WriteByte(c)
 			}
-		case (c == '"' || c == '\'') && !inKey && val.Len() == 0:
-			inQuote = c
 		case c == '=' && inKey:
 			inKey = false
 		case c == ',':
 			flush()
 		case inKey:
 			key.WriteByte(c)
+		case (c == '"' || c == '\'') && val.Len() == 0:
+			inQuote = c
+		case (c == ' ' || c == '\t') && val.Len() == 0:
+			// Leading whitespace between `=` and the value hasn't committed
+			// the value yet, so it must not disqualify a quote that follows.
 		default:
 			val.WriteByte(c)
 		}

--- a/apps/runwisp/internal/importer/supervisord_test.go
+++ b/apps/runwisp/internal/importer/supervisord_test.go
@@ -336,3 +336,22 @@ func TestParseSupervisordEnvQuotedValueStillHonored(t *testing.T) {
 		}
 	}
 }
+
+// TestParseSupervisordEnvQuotedValueWithLeadingSpace guards against a space
+// between the `=` and the opening quote (legal, common supervisord INI
+// style) disqualifying the quote from being recognized — which previously
+// left the quote characters in the value and, because commas were then no
+// longer protected, split the quoted value's internal comma into a bogus
+// extra key/value pair.
+func TestParseSupervisordEnvQuotedValueWithLeadingSpace(t *testing.T) {
+	got := parseSupervisordEnv(`FOO= "bar,baz",OTHER=x`)
+	want := map[string]string{"FOO": "bar,baz", "OTHER": "x"}
+	if len(got) != len(want) {
+		t.Fatalf("parseSupervisordEnv(...) = %#v, want %#v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("parseSupervisordEnv(...) = %#v, want %#v", got, want)
+		}
+	}
+}

--- a/apps/runwisp/internal/notify/bridge.go
+++ b/apps/runwisp/internal/notify/bridge.go
@@ -97,7 +97,7 @@ func mapRunEventType(t events.EventType, run *model.Run) (Kind, Severity, bool) 
 			return KindRunFailed, SevError, true
 		case model.ReasonTimeout:
 			return KindRunTimeout, SevError, true
-		case model.ReasonStopped:
+		case model.ReasonStopped, model.ReasonDaemonStopped:
 			return KindRunStopped, SevWarn, true
 		case model.ReasonCrashed:
 			return KindRunCrashed, SevError, true
@@ -107,10 +107,10 @@ func mapRunEventType(t events.EventType, run *model.Run) (Kind, Severity, bool) 
 			// (treat_missed_as_failure = false) is applied downstream at ingress, not
 			// here, so the browsable run row is always recorded regardless.
 			return KindRunMissed, SevError, true
-		case model.ReasonSkipped:
-			// PolicySkip is the policy doing its job, not a failure: never
-			// route it through the notification system. Operators who care
-			// about chronic skips read the run history.
+		case model.ReasonSkipped, model.ReasonDSTSkipped:
+			// PolicySkip and the DST fall-back dedup are the scheduler doing
+			// its job, not a failure: never route either through the
+			// notification system. Operators who care read the run history.
 			return "", "", false
 		case model.ReasonStartFailed:
 			// The give-up is announced by the dedicated EventServiceFatal →

--- a/apps/runwisp/internal/notify/bridge_test.go
+++ b/apps/runwisp/internal/notify/bridge_test.go
@@ -183,6 +183,33 @@ func TestMapRunEventType_RunFailed_ReasonMissed(t *testing.T) {
 	assert.Equal(t, SevError, sev, "a missed run alerts at failure level")
 }
 
+// TestMapRunEventType_RunFailed_ReasonDaemonStopped guards against a routine
+// daemon restart/upgrade posing as a task failure: manager.go explicitly
+// records "a daemon-stopped exit is not a failure", and the cloud tracker
+// maps it to ExecutionStatusStopped alongside ReasonStopped — the bridge must
+// agree instead of falling through to its default KindRunFailed/SevError.
+func TestMapRunEventType_RunFailed_ReasonDaemonStopped(t *testing.T) {
+	r := model.ReasonDaemonStopped
+	run := &model.Run{EndReason: &r}
+	kind, sev, ok := mapRunEventType(events.EventRunFailed, run)
+	assert.True(t, ok)
+	assert.Equal(t, KindRunStopped, kind)
+	assert.Equal(t, SevWarn, sev)
+}
+
+// TestMapRunEventType_RunFailed_ReasonDSTSkipped guards against the annual
+// DST fall-back dedup posing as a task failure. It's produced by the same
+// RecordSkippedFiring path as ReasonSkipped (the policy doing its job, never
+// routed through notifications) and the cloud tracker maps it to
+// ExecutionStatusSkipped, not Failed — the bridge must mute it the same way
+// it mutes ReasonSkipped instead of falling through to its default.
+func TestMapRunEventType_RunFailed_ReasonDSTSkipped(t *testing.T) {
+	r := model.ReasonDSTSkipped
+	run := &model.Run{EndReason: &r}
+	_, _, ok := mapRunEventType(events.EventRunFailed, run)
+	assert.False(t, ok, "a DST dedup is not a failure and must not notify")
+}
+
 func TestMapRunEventType_RunFailed_DefaultReason(t *testing.T) {
 	r := model.ReasonSuccess // not a typical failure reason, hits default branch
 	run := &model.Run{EndReason: &r}

--- a/apps/runwisp/internal/notify/render/render.go
+++ b/apps/runwisp/internal/notify/render/render.go
@@ -371,10 +371,14 @@ func timeoutSentence(e *notify.Event) string {
 
 // stoppedSentence reports a manually stopped run, including duration when known.
 func stoppedSentence(e *notify.Event) string {
-	if d := runDuration(e.Run); d != "" {
-		return fmt.Sprintf("Stopped manually after %s.", d)
+	verb := "Stopped manually"
+	if e.Run != nil && e.Run.EndReason != nil && *e.Run.EndReason == model.ReasonDaemonStopped {
+		verb = "Stopped by daemon shutdown"
 	}
-	return "Stopped manually."
+	if d := runDuration(e.Run); d != "" {
+		return fmt.Sprintf("%s after %s.", verb, d)
+	}
+	return verb + "."
 }
 
 // crashedSentence reports a process that couldn't start, including the reason when present.

--- a/apps/runwisp/internal/notify/render/render_test.go
+++ b/apps/runwisp/internal/notify/render/render_test.go
@@ -97,6 +97,8 @@ func TestEventSentence(t *testing.T) {
 	end := start.Add(300 * time.Millisecond)
 	withDur := &model.Run{StartedAt: &start, EndedAt: &end, ExitCode: 1}
 	noDur := &model.Run{ExitCode: 2}
+	daemonStoppedReason := model.ReasonDaemonStopped
+	daemonStopped := &model.Run{StartedAt: &start, EndedAt: &end, EndReason: &daemonStoppedReason}
 
 	cases := []struct {
 		name string
@@ -112,6 +114,7 @@ func TestEventSentence(t *testing.T) {
 		{"timeout without duration", &notify.Event{Kind: notify.KindRunTimeout}, "The task was killed after the configured timeout."},
 		{"stopped with duration", &notify.Event{Kind: notify.KindRunStopped, Run: withDur}, "Stopped manually after 0.3s."},
 		{"stopped without duration", &notify.Event{Kind: notify.KindRunStopped}, "Stopped manually."},
+		{"stopped by daemon shutdown", &notify.Event{Kind: notify.KindRunStopped, Run: daemonStopped}, "Stopped by daemon shutdown after 0.3s."},
 		{"crashed with reason", &notify.Event{Kind: notify.KindRunCrashed, Reason: "exec format error"}, "The process couldn't start: exec format error."},
 		{"crashed without reason", &notify.Event{Kind: notify.KindRunCrashed}, "The process couldn't start."},
 		{"missed with reason", &notify.Event{Kind: notify.KindRunMissed, Reason: "3 scheduled runs missed since 2026-06-09 03:00 (daemon was down)"}, "3 scheduled runs missed since 2026-06-09 03:00 (daemon was down)"},

--- a/apps/runwisp/internal/runtime/catchup.go
+++ b/apps/runwisp/internal/runtime/catchup.go
@@ -247,9 +247,36 @@ const catchupCountDisplayFloor = 1000
 // when count is 0. Counting stops once count reaches maxCount, returning
 // truncated=true so callers can report the gap as "at least N+" rather than
 // walking an unbounded per-second backlog.
+//
+// A tick whose wall-clock reading (year/month/day/hour/minute/second, per
+// robfig/cron.Schedule.Next returning ticks in lastRunTime's location) repeats
+// one already seen within the same wall-hour is the DST fall-back duplicate
+// fireOnce suppresses live as ReasonDSTSkipped: on a schedule with more than
+// one tick per hour (e.g. "0,30 2 * * *"), the rewound hour replays every one
+// of them — 02:00 CEST, 02:30 CEST, then 02:00 CET, 02:30 CET — so the
+// duplicate of a tick is not necessarily the one immediately before it. This
+// mirrors fireOnce's firedHour exactly (same wall-hour scoping, reset when the
+// hour changes) so catch-up and the live scheduler agree on what would have
+// fired. Even if the daemon had been running through the gap, a duplicate
+// firing would never have executed as a real run — it isn't a missed one, so
+// it is walked past without being counted or becoming lastTick.
 func countMissedTicks(schedule cron.Schedule, lastRunTime, now time.Time, maxCount int) (count int, lastTick time.Time, truncated bool) {
 	next := schedule.Next(lastRunTime)
+	var curHour wallHour
+	var seen map[wallSecond]struct{}
 	for !next.After(now) {
+		wall := newWallSecond(next)
+		hour := wall.inHour()
+		if seen == nil || hour != curHour {
+			curHour = hour
+			seen = make(map[wallSecond]struct{})
+		}
+		if _, duplicate := seen[wall]; duplicate {
+			next = schedule.Next(next)
+			continue
+		}
+		seen[wall] = struct{}{}
+
 		count++
 		lastTick = next
 		if count >= maxCount {

--- a/apps/runwisp/internal/runtime/catchup_test.go
+++ b/apps/runwisp/internal/runtime/catchup_test.go
@@ -223,6 +223,36 @@ func TestCountMissedTicks(t *testing.T) {
 	}
 }
 
+// TestCountMissedTicks_DSTFallbackDuplicateNotDoubleCounted guards against
+// catch-up over-reporting the 2026-10-25 Europe/Bratislava fall-back as twice
+// as many missed runs as ever could have fired. schedule.Next walks in
+// absolute time, so it yields four ticks across the rewound hour — 02:00 CEST,
+// 02:30 CEST, 02:00 CET, 02:30 CET — but only the first two wall-clock
+// readings are real: the live scheduler's fireOnce would suppress the CET
+// pair as ReasonDSTSkipped, never a genuine missed run. Before the fix,
+// countMissedTicks counted all four.
+func TestCountMissedTicks_DSTFallbackDuplicateNotDoubleCounted(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Bratislava")
+	assert.NoError(t, err)
+
+	parser := cronspec.NewScheduleParser()
+	sched, err := parser.Parse("CRON_TZ=Europe/Bratislava 0,30 2 * * *")
+	assert.NoError(t, err)
+
+	// Anchor the day before, in the same location countupOneTask would use
+	// (anchor.In(loc)) — well before any of the fall-back day's ticks.
+	lastRun := time.Date(2026, 10, 24, 12, 0, 0, 0, time.UTC).In(loc)
+	// After all four absolute ticks (00:00, 00:30, 01:00, 01:30 UTC) have passed.
+	now := time.Date(2026, 10, 25, 3, 0, 0, 0, time.UTC).In(loc)
+
+	got, lastTick, truncated := countMissedTicks(sched, lastRun, now, 1000)
+	assert.False(t, truncated)
+	assert.Equal(t, 2, got,
+		"only the two distinct wall-clock ticks (02:00, 02:30) are real misses; the DST-rewound duplicates must not double the count")
+	assert.Equal(t, 2, lastTick.In(loc).Hour())
+	assert.Equal(t, 30, lastTick.In(loc).Minute())
+}
+
 func TestRunMissedTickCatchUp(t *testing.T) {
 	t.Run("policy=latest triggers one run", func(t *testing.T) {
 		db := new(testutil.MockRunRepository)

--- a/apps/runwisp/internal/runtime/manager.go
+++ b/apps/runwisp/internal/runtime/manager.go
@@ -165,13 +165,15 @@ func (m *defaultTaskManager) registerForceKill(runID string, forceKill func()) {
 func (m *defaultTaskManager) UpsertTask(task *model.Task) {
 	// A run orphaned out of the queue below may have been recorded as
 	// in-flight by the jitter gate (a breached fire that queued behind the
-	// concurrency limit). Retiring it from the gate must happen after m.mu is
+	// concurrency limit), and its terminal event must not publish while m.mu is
+	// still held (see TriggerRunWithOptions). Both must happen after m.mu is
 	// released (gateMu -> mu lock order; see jitterGate's doc), so the flush
 	// is deferred ahead of the lock — LIFO defer order runs it after Unlock.
-	var orphanedRunIDs []string
+	var orphanedRuns []*model.Run
 	defer func() {
-		for _, id := range orphanedRunIDs {
-			m.gate.onComplete(id)
+		for _, r := range orphanedRuns {
+			m.gate.onComplete(r.ID)
+			m.publishTerminal(events.EventRunFailed, r)
 		}
 	}()
 	m.mu.Lock()
@@ -197,7 +199,7 @@ func (m *defaultTaskManager) UpsertTask(task *model.Task) {
 
 	if task.OnOverlap == model.PolicyQueue {
 		if ts.queue == nil {
-			ts.queue = make([]*model.Run, 0)
+			ts.queue = make([]queuedRun, 0)
 		}
 		if ts.cond == nil {
 			ts.cond = sync.NewCond(&m.mu)
@@ -221,7 +223,7 @@ func (m *defaultTaskManager) UpsertTask(task *model.Task) {
 		// 'pending' with no goroutine left to start or finalize them. Finalize
 		// whatever is queued the same way RemoveTask does, then broadcast
 		// unconditionally so a loop parked on an already-empty queue wakes too.
-		orphanedRunIDs = m.finalizeOrphanedQueue(ts)
+		orphanedRuns = m.finalizeOrphanedQueue(ts)
 		ts.cond.Broadcast()
 	}
 }
@@ -248,21 +250,23 @@ func (m *defaultTaskManager) upsertSupervisor(ts *taskState, task *model.Task) {
 }
 
 // finalizeOrphanedQueue ends every run still sitting in ts.queue (a policy
-// change or task removal left them with no drain loop to ever start them)
-// and reports their IDs, so the caller can retire them from the jitter gate
-// once m.mu is released — a queued run can be one it marked in-flight (see
-// jitterGate.fire). Caller holds m.mu.
-func (m *defaultTaskManager) finalizeOrphanedQueue(ts *taskState) []string {
+// change or task removal left them with no drain loop to ever start them) and
+// returns them, so the caller can retire them from the jitter gate and publish
+// their terminal events once m.mu is released — a queued run can be one the
+// gate marked in-flight (see jitterGate.fire), and publishing a terminal event
+// while still holding the write lock risks deadlocking a re-entrant subscriber
+// (see TriggerRunWithOptions). Caller holds m.mu.
+func (m *defaultTaskManager) finalizeOrphanedQueue(ts *taskState) []*model.Run {
 	if len(ts.queue) == 0 {
 		return nil
 	}
-	ids := make([]string, 0, len(ts.queue))
-	for _, r := range ts.queue {
-		m.endOrphanedPending(r)
-		ids = append(ids, r.ID)
+	runs := make([]*model.Run, 0, len(ts.queue))
+	for _, q := range ts.queue {
+		m.endOrphanedPending(q.run)
+		runs = append(runs, q.run)
 	}
 	ts.queue = nil
-	return ids
+	return runs
 }
 
 // RemoveTask drops a task from the manager when a reload removes it.
@@ -275,11 +279,13 @@ func (m *defaultTaskManager) finalizeOrphanedQueue(ts *taskState) []string {
 // recordRunOutcome deletes it on retirement (single-writer-per-task preserved).
 func (m *defaultTaskManager) RemoveTask(taskName string) {
 	// See UpsertTask: a queued run orphaned below may be tracked in-flight by
-	// the jitter gate, and retiring it must happen after m.mu is released.
-	var orphanedRunIDs []string
+	// the jitter gate, and both retiring it and publishing its terminal event
+	// must happen after m.mu is released.
+	var orphanedRuns []*model.Run
 	defer func() {
-		for _, id := range orphanedRunIDs {
-			m.gate.onComplete(id)
+		for _, r := range orphanedRuns {
+			m.gate.onComplete(r.ID)
+			m.publishTerminal(events.EventRunFailed, r)
 		}
 	}()
 	m.mu.Lock()
@@ -295,7 +301,7 @@ func (m *defaultTaskManager) RemoveTask(taskName string) {
 	// Queued runs were already persisted as 'pending'; finalize them here so a
 	// reload that removes the task never leaves a permanent non-terminal row.
 	if ts.cond != nil {
-		orphanedRunIDs = m.finalizeOrphanedQueue(ts)
+		orphanedRuns = m.finalizeOrphanedQueue(ts)
 		ts.cond.Broadcast()
 	}
 
@@ -360,6 +366,18 @@ type PendingRunsResult struct {
 // the configured Instances count instead. Pending service rows are marked
 // failed so they don't linger in the database.
 func (m *defaultTaskManager) LoadPendingRuns(runs []model.Run) PendingRunsResult {
+	// A pending run this pass ends immediately (never resumed) gets its
+	// terminal event published after m.mu is released, same as every other
+	// path that can end a run without executing it (see TriggerRunWithOptions)
+	// — harmless this early in boot (nothing subscribes yet), but the run
+	// still deserves one instead of silently going straight from 'pending' to
+	// an ended row no live subscriber ever heard about.
+	var endedRuns []*model.Run
+	defer func() {
+		for _, r := range endedRuns {
+			m.publishTerminal(events.EventRunFailed, r)
+		}
+	}()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -369,10 +387,13 @@ func (m *defaultTaskManager) LoadPendingRuns(runs []model.Run) PendingRunsResult
 		ts, exists := m.tasks[r.TaskName]
 		if !exists {
 			m.endOrphanedPending(&r)
+			endedRuns = append(endedRuns, &r)
 			result.Skipped++
 			continue
 		}
-		m.resumePendingRun(ts, &r, &result)
+		if ended := m.resumePendingRun(ts, &r, &result); ended != nil {
+			endedRuns = append(endedRuns, ended)
+		}
 	}
 	return result
 }
@@ -390,44 +411,51 @@ func (m *defaultTaskManager) endOrphanedPending(r *model.Run) {
 // are marked failed (the supervisor spawns fresh instances on boot), queued
 // tasks rejoin their queue (or fail when it is full), and concurrent tasks
 // either restart immediately or fail when capacity is exhausted.
-func (m *defaultTaskManager) resumePendingRun(ts *taskState, r *model.Run, result *PendingRunsResult) {
+// resumePendingRun applies the per-run policy from LoadPendingRuns and
+// returns the run if it ended immediately (for the caller to publish once
+// m.mu is released), or nil if it started or joined the queue instead.
+func (m *defaultTaskManager) resumePendingRun(ts *taskState, r *model.Run, result *PendingRunsResult) *model.Run {
 	if ts.task.Kind.IsService() {
 		r.End(model.ReasonFailed, -1, m.clock())
 		m.persistence.PersistExisting(r)
 		result.Skipped++
-		return
+		return r
 	}
 
 	if ts.task.OnOverlap == model.PolicyQueue {
-		m.requeuePendingRun(ts, r, result)
-		return
+		return m.requeuePendingRun(ts, r, result)
 	}
-	m.restartOrFailPendingRun(ts, r, result)
+	return m.restartOrFailPendingRun(ts, r, result)
 }
 
-func (m *defaultTaskManager) requeuePendingRun(ts *taskState, r *model.Run, result *PendingRunsResult) {
+func (m *defaultTaskManager) requeuePendingRun(ts *taskState, r *model.Run, result *PendingRunsResult) *model.Run {
 	maxQueued := ts.task.MaxQueued
 	if maxQueued > 0 && len(ts.queue) >= maxQueued {
 		r.End(model.ReasonQueueFull, -1, m.clock())
 		m.persistence.PersistExisting(r)
 		result.Failed++
-		return
+		return r
 	}
-	ts.queue = append(ts.queue, r)
+	// Restart-chain depth can't survive a crash (ActiveRun.RestartAttempt is
+	// in-memory only, never persisted), so a boot-resumed queued run always
+	// restarts its backoff from zero.
+	ts.queue = append(ts.queue, queuedRun{run: r})
 	ts.cond.Signal()
 	result.Queued++
+	return nil
 }
 
-func (m *defaultTaskManager) restartOrFailPendingRun(ts *taskState, r *model.Run, result *PendingRunsResult) {
+func (m *defaultTaskManager) restartOrFailPendingRun(ts *taskState, r *model.Run, result *PendingRunsResult) *model.Run {
 	concurrencyLimit := m.getConcurrencyLimit(ts.task)
 	if len(ts.active) < concurrencyLimit {
 		m.startRun(ts.task, r, 0)
 		result.Resumed++
-		return
+		return nil
 	}
 	r.End(model.ReasonFailed, -1, m.clock())
 	m.persistence.PersistExisting(r)
 	result.Failed++
+	return r
 }
 
 func (m *defaultTaskManager) TriggerRun(taskName string, triggeredBy model.TriggeredBy) (*model.Run, error) {
@@ -541,7 +569,7 @@ func (m *defaultTaskManager) TriggerRunWithOptions(taskName string, options Trig
 	m.publishRun(events.EventRunCreated, run)
 
 	concurrencyLimit := m.getConcurrencyLimit(ts.task)
-	action, actionErr := m.evaluateConcurrency(ts, run, concurrencyLimit)
+	action, actionErr := m.evaluateConcurrency(ts, run, concurrencyLimit, options.RestartAttempt)
 
 	switch action {
 	case actionRejected:

--- a/apps/runwisp/internal/runtime/manager_test.go
+++ b/apps/runwisp/internal/runtime/manager_test.go
@@ -228,16 +228,16 @@ func TestEvaluateConcurrency_QueuePreservesFIFOWhenSlotFree(t *testing.T) {
 	ts := &taskState{
 		task:  testTask("t", model.PolicyQueue, 2),
 		cond:  sync.NewCond(&sync.Mutex{}),
-		queue: []*model.Run{{ID: "queued-1"}}, // one run already waiting
+		queue: []queuedRun{{run: &model.Run{ID: "queued-1"}}}, // one run already waiting
 	}
 
 	// A slot is free (0 active < limit 2), but the queue is non-empty.
-	action, err := m.evaluateConcurrency(ts, &model.Run{ID: "new"}, 2)
+	action, err := m.evaluateConcurrency(ts, &model.Run{ID: "new"}, 2, 0)
 	require.NoError(t, err)
 	assert.Equal(t, actionQueued, action, "a free slot must not let a new trigger jump the queue")
 	require.Len(t, ts.queue, 2)
-	assert.Equal(t, "queued-1", ts.queue[0].ID, "the existing queued run stays at the head")
-	assert.Equal(t, "new", ts.queue[1].ID, "the new trigger goes to the back")
+	assert.Equal(t, "queued-1", ts.queue[0].run.ID, "the existing queued run stays at the head")
+	assert.Equal(t, "new", ts.queue[1].run.ID, "the new trigger goes to the back")
 }
 
 // TestEvaluateConcurrency_TerminateSkipsAlreadyCancelled pins the terminate fix:
@@ -254,7 +254,7 @@ func TestEvaluateConcurrency_TerminateSkipsAlreadyCancelled(t *testing.T) {
 		active: []*ActiveRun{r1, r2},
 	}
 
-	action, err := m.evaluateConcurrency(ts, &model.Run{ID: "r3"}, 1)
+	action, err := m.evaluateConcurrency(ts, &model.Run{ID: "r3"}, 1, 0)
 	require.NoError(t, err)
 	assert.Equal(t, actionStart, action)
 	assert.Equal(t, 0, r1cancels, "an already-cancelled run must not be re-cancelled")
@@ -1026,6 +1026,68 @@ func TestNonServiceRestartBackoffEscalates(t *testing.T) {
 		"escalated gap must clearly exceed the flat base delay, got %v (base %v)", gap3, base)
 }
 
+// TestQueuedRestartPreservesRestartAttempt guards the queue-policy sibling of
+// TestNonServiceRestartBackoffEscalates: a non-service restart racing a
+// concurrent trigger under OnOverlap=queue must carry its restart-chain depth
+// into the queue and out again, not reset to 0. Before the fix, ts.queue held
+// bare *model.Run values with nowhere to carry the depth, so
+// queueProcessLoop always called startRun with a hardcoded 0 — collapsing the
+// escalating backoff back to the flat base delay for any restart unlucky
+// enough to queue instead of starting immediately.
+func TestQueuedRestartPreservesRestartAttempt(t *testing.T) {
+	exec := new(testutil.MockExecutor)
+	eb := events.NewEventBus()
+	jm := NewTaskManager(exec, eb, time.Now)
+	defer jm.Shutdown()
+
+	task := testTask("task1", model.PolicyQueue, 1)
+	jm.UpsertTask(task)
+
+	firstStarted := make(chan struct{})
+	holdFirst := make(chan struct{})
+	exec.On("Execute", mock.Anything, task, mock.Anything).Once().Run(func(mock.Arguments) {
+		close(firstStarted)
+		<-holdFirst
+	}).Return(&executor.ExecuteResult{ExitCode: 0})
+
+	var capturedAttempt int
+	secondDone := make(chan struct{})
+	exec.On("Execute", mock.Anything, task, mock.Anything).Once().Run(func(args mock.Arguments) {
+		run, _ := args.Get(2).(*model.Run)
+		for _, ar := range jm.GetActiveRuns("task1") {
+			if ar.Run.ID == run.ID {
+				capturedAttempt = ar.RestartAttempt
+			}
+		}
+		close(secondDone)
+	}).Return(&executor.ExecuteResult{ExitCode: 0})
+
+	_, err := jm.TriggerRun("task1", model.TriggeredByAPI)
+	require.NoError(t, err)
+	<-firstStarted // run1 holds the only slot
+
+	// Simulate what scheduleRestart sends on a non-service restart: the
+	// escalating attempt depth, arriving while the slot is still held by run1
+	// (a concurrent trigger racing the restart chain), so it must queue.
+	queuedRunSnapshot, err := jm.TriggerRunWithOptions("task1", TriggerRunOptions{
+		TriggeredBy:    model.TriggeredByService,
+		RestartAttempt: 3,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, model.PhasePending, queuedRunSnapshot.Status, "must queue behind the active run")
+
+	close(holdFirst) // run1 finishes, freeing the slot for queueProcessLoop to promote the queued run
+
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the queued restart to execute")
+	}
+
+	assert.Equal(t, 3, capturedAttempt,
+		"the queued run must start with the restart-chain depth it was queued with, not reset to 0")
+}
+
 // TestLoadPendingRunsResumed: a pending cron task with a free slot is
 // resumed and starts execution.
 func TestLoadPendingRunsResumed(t *testing.T) {
@@ -1148,9 +1210,12 @@ func TestLoadPendingRunsSkippedTaskNotFound(t *testing.T) {
 
 // TestRemoveTask_FinalizesQueuedRuns: removing a task on reload must finalize any
 // still-queued (persisted 'pending') run instead of dropping the slice and
-// leaving a permanent non-terminal row that retention never sweeps.
+// leaving a permanent non-terminal row that retention never sweeps. It must
+// also publish the terminal event, exactly like TestPolicySkipPublishesTerminalEvent
+// — otherwise the run ends in storage but a live SSE/notify subscriber never
+// sees it leave 'pending'.
 func TestRemoveTask_FinalizesQueuedRuns(t *testing.T) {
-	jm, exec, _ := newGatedManager(t)
+	jm, exec, eb := newGatedManager(t)
 
 	var mu sync.Mutex
 	ended := map[string]model.EndReason{}
@@ -1161,6 +1226,9 @@ func TestRemoveTask_FinalizesQueuedRuns(t *testing.T) {
 			ended[run.ID] = *run.EndReason
 		}
 	})
+
+	// Subscribe before triggering so we never race the publish.
+	failed := watchRuns(eb, events.EventRunFailed)
 
 	// Queue-policy task at concurrency 1: first run occupies the slot, second
 	// waits in the queue.
@@ -1181,6 +1249,11 @@ func TestRemoveTask_FinalizesQueuedRuns(t *testing.T) {
 	defer mu.Unlock()
 	assert.Equal(t, model.ReasonSkipped, ended[queued.ID],
 		"queued run must be finalized when its task is removed")
+
+	failed.waitFor(t, 1)
+	published := failed.snapshot()[0]
+	assert.Equal(t, queued.ID, published.ID,
+		"the finalized run must publish a terminal event, not just persist silently")
 }
 
 func TestResolveRunOutcomeKilledByPolicy(t *testing.T) {
@@ -1514,7 +1587,7 @@ func TestUpsertTask_PolicyChangeAwayFromQueueExitsQueueLoop(t *testing.T) {
 // just return without ever popping it, leaving the persisted 'pending' row
 // stranded forever with nothing to start or end it.
 func TestUpsertTask_PolicyChangeAwayFromQueueFinalizesQueuedRuns(t *testing.T) {
-	jm, exec, _ := newGatedManager(t)
+	jm, exec, eb := newGatedManager(t)
 
 	var mu sync.Mutex
 	ended := map[string]model.EndReason{}
@@ -1525,6 +1598,9 @@ func TestUpsertTask_PolicyChangeAwayFromQueueFinalizesQueuedRuns(t *testing.T) {
 			ended[run.ID] = *run.EndReason
 		}
 	})
+
+	// Subscribe before triggering so we never race the publish.
+	failed := watchRuns(eb, events.EventRunFailed)
 
 	// Queue-policy task at concurrency 1: first run occupies the slot, second
 	// waits in the queue.
@@ -1553,6 +1629,13 @@ func TestUpsertTask_PolicyChangeAwayFromQueueFinalizesQueuedRuns(t *testing.T) {
 	jm.mu.RLock()
 	assert.Empty(t, jm.tasks["q"].queue, "the stale queue must be cleared, not left to strand a later upsert")
 	jm.mu.RUnlock()
+
+	// It must also publish the terminal event — persisting alone leaves a live
+	// SSE/notify subscriber seeing the run stuck in 'pending'.
+	failed.waitFor(t, 1)
+	published := failed.snapshot()[0]
+	assert.Equal(t, queued.ID, published.ID,
+		"the finalized run must publish a terminal event, not just persist silently")
 }
 
 // TestScheduleJitteredRun_HeldTaskFireDroppedNotDoubleRun pins the fix for the

--- a/apps/runwisp/internal/runtime/persistence.go
+++ b/apps/runwisp/internal/runtime/persistence.go
@@ -11,9 +11,10 @@ import (
 	"github.com/runwisp/runwisp/internal/model"
 )
 
-// RunPersistenceHook persists run state transitions. ctx is the
-// coordinator's worker context — cancelled at Shutdown so in-flight DB
-// writes can abort cleanly when the daemon is stopping.
+// RunPersistenceHook persists run state transitions. ctx is cancelled at
+// Shutdown so a write already in flight at that moment can abort cleanly
+// instead of hanging the daemon on a wedged DB. A task that hasn't started
+// applying yet never sees an already-cancelled ctx — see worker.
 type RunPersistenceHook func(ctx context.Context, run *model.Run, isNew bool)
 
 // persistTask is the unit of work dispatched through the buffered channel.
@@ -113,15 +114,23 @@ func (pc *PersistenceCoordinator) enqueue(task persistTask) {
 
 func (pc *PersistenceCoordinator) worker(ctx context.Context) {
 	defer pc.wg.Done()
-	// Drain pending tasks with an uncancellable derivative of ctx after
-	// cancellation so in-flight persistence still completes during shutdown —
-	// the worker ctx is only the "stop accepting new work" signal.
+	// drainCtx is what a task applies under once ctx is already cancelled —
+	// whether because we're in the drain loop below, or because the select
+	// case that read a queued task happened to fire in the same instant
+	// ctx.Done() became ready (select picks between ready cases at random, so
+	// that queued task must not be at the mercy of the coin flip: it hasn't
+	// started applying yet, so cancelling it here would only drop data, never
+	// bound a hang).
+	drainCtx := context.WithoutCancel(ctx)
 	for {
 		select {
 		case task := <-pc.ch:
-			pc.apply(ctx, task)
+			applyCtx := ctx
+			if ctx.Err() != nil {
+				applyCtx = drainCtx
+			}
+			pc.apply(applyCtx, task)
 		case <-ctx.Done():
-			drainCtx := context.WithoutCancel(ctx)
 			for {
 				select {
 				case task := <-pc.ch:

--- a/apps/runwisp/internal/runtime/persistence_test.go
+++ b/apps/runwisp/internal/runtime/persistence_test.go
@@ -86,6 +86,49 @@ func TestPersistenceCoordinatorAfterShutdown(t *testing.T) {
 	})
 }
 
+// TestPersistenceCoordinatorShutdownDoesNotCancelAlreadyQueuedTask guards
+// against a clean shutdown silently dropping a completed run's final write.
+// The worker's select race is between "apply the queued task" and "ctx just
+// got cancelled" — when both fire at once (a task already sitting in the
+// buffered channel at the exact moment Shutdown cancels), Go's select picks
+// between them pseudo-randomly. A task that hasn't started applying yet must
+// never observe an already-cancelled context: there is nothing in-flight for
+// the cancellation to bound, so applying it with a cancelled ctx only drops
+// data. Runs the race window many times since a single trial can pass by luck.
+func TestPersistenceCoordinatorShutdownDoesNotCancelAlreadyQueuedTask(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		var gotCancelled atomic.Bool
+		first := make(chan struct{})
+		release := make(chan struct{})
+
+		pc := NewPersistenceCoordinator(4)
+		pc.hook = func(ctx context.Context, run *model.Run, isNew bool) {
+			if run.TaskName == "first" {
+				close(first)
+				<-release // hold the worker here so "second" queues up behind it
+				return
+			}
+			if ctx.Err() != nil {
+				gotCancelled.Store(true)
+			}
+		}
+
+		pc.PersistExisting(&model.Run{TaskName: "first"})
+		<-first // worker is now blocked applying "first" with a still-live ctx
+
+		pc.PersistExisting(&model.Run{TaskName: "second"}) // queues behind, unapplied
+
+		pc.cancel() // ctx.Done() and pc.ch (holding "second") are now both ready
+
+		close(release) // let "first" return; the worker's select re-evaluates
+		pc.wg.Wait()   // drain "second" and exit
+
+		if gotCancelled.Load() {
+			t.Fatalf("iteration %d: a task queued before Shutdown was applied with an already-cancelled context", i)
+		}
+	}
+}
+
 func TestPublishRunNilBus(t *testing.T) {
 	jm := NewTaskManager(new(testutil.MockExecutor), nil, time.Now).(*defaultTaskManager)
 	assert.NotPanics(t, func() {

--- a/apps/runwisp/internal/runtime/taskstate.go
+++ b/apps/runwisp/internal/runtime/taskstate.go
@@ -39,13 +39,23 @@ type ActiveRun struct {
 	cancelled bool
 }
 
+// queuedRun pairs a run sitting in ts.queue with the non-service
+// restart-chain depth it was triggered with. model.Run has no field for this
+// — it's runtime-only bookkeeping that lives on ActiveRun once a run starts —
+// so a queued restart needs somewhere to carry it until queueProcessLoop
+// finally calls startRun.
+type queuedRun struct {
+	run            *model.Run
+	restartAttempt int
+}
+
 // taskState holds all per-task runtime state under the manager mutex.
 type taskState struct {
 	task   *model.Task
 	active []*ActiveRun
 
 	// queue is populated only when task.OnOverlap == PolicyQueue.
-	queue []*model.Run
+	queue []queuedRun
 	// cond signals the queue-drain goroutine. Allocated alongside queue.
 	cond *sync.Cond
 
@@ -92,8 +102,10 @@ const (
 )
 
 // evaluateConcurrency decides whether a run can start and mutates queue state
-// accordingly. Must be called with m.mu held.
-func (m *defaultTaskManager) evaluateConcurrency(ts *taskState, run *model.Run, concurrencyLimit int) (concurrencyAction, error) {
+// accordingly. restartAttempt is the non-service restart-chain depth to carry
+// onto the run if it ends up queued (see queuedRun). Must be called with m.mu
+// held.
+func (m *defaultTaskManager) evaluateConcurrency(ts *taskState, run *model.Run, concurrencyLimit, restartAttempt int) (concurrencyAction, error) {
 	// A free slot starts immediately — except under queue policy with runs
 	// already waiting: a fresh trigger must join the back of the queue rather
 	// than race ahead of runs the drain loop hasn't picked up yet. Without this,
@@ -112,7 +124,7 @@ func (m *defaultTaskManager) evaluateConcurrency(ts *taskState, run *model.Run, 
 		if maxQueued > 0 && len(ts.queue) >= maxQueued {
 			return actionQueueFull, fmt.Errorf("queue full (%d pending) for task %s", maxQueued, ts.task.Name)
 		}
-		ts.queue = append(ts.queue, run)
+		ts.queue = append(ts.queue, queuedRun{run: run, restartAttempt: restartAttempt})
 		ts.cond.Signal()
 		slog.Debug("Task queued", "name", ts.task.Name, "active", len(ts.active), "limit", concurrencyLimit, "queue", len(ts.queue))
 		return actionQueued, nil
@@ -177,9 +189,9 @@ func (m *defaultTaskManager) queueProcessLoop(taskName string) {
 		if m.isShutdown.Load() || ts.removed || ts.task.OnOverlap != model.PolicyQueue {
 			return
 		}
-		run := ts.queue[0]
+		queued := ts.queue[0]
 		ts.queue = ts.queue[1:]
-		m.startRun(ts.task, run, 0)
+		m.startRun(ts.task, queued.run, queued.restartAttempt)
 	}
 }
 

--- a/apps/runwisp/internal/storage/run_selector.go
+++ b/apps/runwisp/internal/storage/run_selector.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/runwisp/runwisp/internal/model"
 )
@@ -102,7 +103,11 @@ func buildRunFilterArgs(f model.RunFilter) runFilterArgs {
 	if f.Search != "" {
 		s := f.Search
 		if len(s) > MaxSearchQueryLength {
-			s = s[:MaxSearchQueryLength]
+			cut := MaxSearchQueryLength
+			for cut > 0 && !utf8.RuneStart(s[cut]) {
+				cut--
+			}
+			s = s[:cut]
 		}
 		s = strings.ReplaceAll(s, "%", "")
 		s = strings.ReplaceAll(s, "_", "")

--- a/apps/runwisp/internal/storage/run_selector_test.go
+++ b/apps/runwisp/internal/storage/run_selector_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/runwisp/runwisp/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -108,6 +109,16 @@ func TestBuildRunFilterArgs_SearchTruncatedToMaxLength(t *testing.T) {
 	long := strings.Repeat("a", MaxSearchQueryLength+50)
 	args := buildRunFilterArgs(model.RunFilter{Search: long})
 	assert.Len(t, args.SearchPattern, MaxSearchQueryLength+2, "pattern is truncated body wrapped in %%")
+}
+
+func TestBuildRunFilterArgs_SearchTruncationRespectsUTF8Boundary(t *testing.T) {
+	// A 3-byte rune repeated so the byte-100 cut point lands mid-rune: 33 full
+	// runes take 99 bytes, so a raw s[:100] slice would keep only the first
+	// byte of the 34th rune, producing an invalid UTF-8 tail.
+	long := strings.Repeat("中", 40)
+	args := buildRunFilterArgs(model.RunFilter{Search: long})
+
+	assert.True(t, utf8.ValidString(args.SearchPattern), "search pattern must not split a multi-byte rune")
 }
 
 func TestExceptIDsForSlice_EmptyInputYieldsSentinelOnly(t *testing.T) {

--- a/apps/runwisp/internal/tui/model_update.go
+++ b/apps/runwisp/internal/tui/model_update.go
@@ -578,6 +578,7 @@ func (m Model) handleSSEConnected(msg uikit.SSEConnectedMsg) (tea.Model, tea.Cmd
 }
 
 func (m Model) handleSSEEventMsg(msg uikit.SSEEventMsg) (tea.Model, tea.Cmd) {
+	m.streams.RecordEventID(msg.Event.ID)
 	cmd := m.handleSSEEvent(msg.Event)
 	return m, tea.Batch(cmd, m.streams.ContinueListeningSSE())
 }

--- a/apps/runwisp/internal/tui/stream_manager.go
+++ b/apps/runwisp/internal/tui/stream_manager.go
@@ -39,6 +39,11 @@ type StreamManager struct {
 	// old run's ID, silently misattributing/dropping the new run's log lines.
 	logRunID string
 	sseCh    <-chan apiclient.RunStreamEvent
+	// lastEventID is the ID of the last app-stream event delivered to the
+	// caller. SubscribeEvents sends it back as the resume cursor on
+	// reconnect, so a daemon restart or network blip replays what the TUI
+	// missed instead of silently skipping it.
+	lastEventID string
 
 	daemonLogCh    <-chan string
 	notificationCh <-chan apiclient.NotificationStreamEvent
@@ -58,17 +63,28 @@ func (sm *StreamManager) Shutdown() {
 	sm.cancel()
 }
 
-// SubscribeEvents connects to the SSE run-events stream.
+// SubscribeEvents connects to the SSE run-events stream, resuming from
+// lastEventID (set via RecordEventID) so a reconnect after a daemon restart
+// or network blip replays whatever fired during the gap instead of losing it.
 func (sm *StreamManager) SubscribeEvents() tea.Cmd {
 	return func() tea.Msg {
 		if sm.client == nil {
 			return nil
 		}
-		ch, err := sm.client.StreamRunEvents(sm.streamCtx)
+		ch, err := sm.client.StreamRunEvents(sm.streamCtx, sm.lastEventID)
 		if err != nil {
 			return uikit.DebugLogMsg{Message: "Events stream failed: " + err.Error()}
 		}
 		return uikit.SSEConnectedMsg{Ch: ch}
+	}
+}
+
+// RecordEventID updates the resume cursor SubscribeEvents sends on its next
+// reconnect. Call it with the ID of every app-stream event as it's consumed;
+// events without an ID (pings, notification updates) don't advance it.
+func (sm *StreamManager) RecordEventID(id string) {
+	if id != "" {
+		sm.lastEventID = id
 	}
 }
 

--- a/apps/runwisp/internal/tui/stream_manager_test.go
+++ b/apps/runwisp/internal/tui/stream_manager_test.go
@@ -481,6 +481,37 @@ func TestStreamManager_SubscribeEvents_ConnectedReturnsChannel(t *testing.T) {
 	assert.True(t, ok, "expected SSEConnectedMsg, got %T", msg)
 }
 
+// TestStreamManager_SubscribeEvents_ResumesFromRecordedEventID guards against
+// a reconnect silently dropping every event that fired during the gap: once
+// RecordEventID has recorded the last event the caller saw, the next
+// SubscribeEvents call must send it back as the resume cursor.
+func TestStreamManager_SubscribeEvents_ResumesFromRecordedEventID(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("lastEventId")
+		w.Header().Set("Content-Type", "text/event-stream")
+	}))
+	defer srv.Close()
+	sm := NewStreamManager(apiclient.New(srv.URL, ""))
+	t.Cleanup(sm.Shutdown)
+
+	sm.RecordEventID("42")
+	cmd := sm.SubscribeEvents()
+	require.NotNil(t, cmd)
+	cmd()
+
+	assert.Equal(t, "42", gotQuery, "reconnect must resume from the last recorded event ID")
+}
+
+func TestStreamManager_RecordEventID_IgnoresEmpty(t *testing.T) {
+	sm := newNilClientSM()
+	t.Cleanup(sm.Shutdown)
+
+	sm.RecordEventID("7")
+	sm.RecordEventID("")
+	assert.Equal(t, "7", sm.lastEventID, "an empty id (ping/notification) must not clear the resume cursor")
+}
+
 func TestStreamManager_SubscribeDaemonLogs_ConnectedReturnsChannel(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/apps/runwisp/tests/e2e/golden_path_test.go
+++ b/apps/runwisp/tests/e2e/golden_path_test.go
@@ -46,7 +46,7 @@ func TestGoldenPathFireAppearsInAPILogAndSSE(t *testing.T) {
 
 	streamCtx, cancelStream := context.WithCancel(context.Background())
 	t.Cleanup(cancelStream)
-	stream, err := client.StreamRunEvents(streamCtx)
+	stream, err := client.StreamRunEvents(streamCtx, "")
 	require.NoError(t, err, "StreamRunEvents should connect")
 
 	// Drain the initial keepalive ping the server emits to flush response

--- a/apps/runwisp/tests/e2e/log_search_test.go
+++ b/apps/runwisp/tests/e2e/log_search_test.go
@@ -37,7 +37,7 @@ func TestLogSearchEndpointFindsLine(t *testing.T) {
 
 	streamCtx, cancelStream := context.WithCancel(context.Background())
 	t.Cleanup(cancelStream)
-	stream, err := client.StreamRunEvents(streamCtx)
+	stream, err := client.StreamRunEvents(streamCtx, "")
 	require.NoError(t, err)
 	waitForRunStreamPing(t, stream, 5*time.Second)
 


### PR DESCRIPTION
## Summary

A batch of run-lifecycle correctness fixes:

- A run that finishes during a clean daemon shutdown now always has its final status and exit code persisted to run history.
- `import supervisord` now correctly parses an `environment=` value where whitespace separates `=` from the opening quote (e.g. `FOO= "bar,baz"`).
- The TUI's event stream now resumes from where it left off on reconnect (daemon restart, network blip).
- A container task that finishes cleanly no longer sometimes logs a spurious "failed to stop container gracefully" warning.
- A run ended by daemon shutdown, or skipped by the DST fall-back dedup, no longer triggers a false "run failed" notification, and a daemon-shutdown stop is now described as such in the notification body instead of always reading "Stopped manually."
- A queued run under `on_overlap = "queue"` now keeps its restart attempt count when it restarts from the queue, instead of resetting to attempt zero and skipping the configured backoff escalation.
- A run left queued when its task is removed, redefined, or the daemon restarts now always gets a final `run.failed` event and a terminal status in run history, instead of sometimes vanishing from the live view with no end state recorded.
- Missed-run catch-up across a DST fall-back no longer double-counts the repeated wall-clock hour as extra missed runs.
- A run search filter longer than the length cap no longer risks splitting a multi-byte character mid-codepoint when truncating.
- A genuine disk error while capturing a task's output now stops the writer and marks where output was lost, instead of silently dropping output line by line for the rest of the run.
- Fixed two log-rendering bugs affecting tasks with progress bars/redraws or a pager-style alternate screen (`less`, `htop`, `vim`): a cursor-down move no longer reorders surrounding lines, and exiting the alternate screen no longer leaves later output stuck as ephemeral and never saved to the log.

## Test plan

- [x] Unit tests added alongside each fix
- [ ] CI green