### PR TITLE
Add in-app update check and self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The Web UI and TUI now show when a newer RunWisp release is available and can update the daemon in place.** Standalone binary installs get a one-click/one-key self-update (checksum-verified, smoke-tested, with automatic rollback); Docker and npm installs show the right upgrade command instead. The background check is opt-out via `[daemon] check_updates = false`.
+
 ## [0.16.3] - 2026-09-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Full configuration reference, REST API docs, and operational guides live at **[d
 - Local-first, offline-complete. No signup, no telemetry, no account required.
 - TOML configuration: one file, version-controllable, reviewable in pull requests
 - Live config reload via `runwisp reload` or `SIGHUP`: pick up `runwisp.toml` edits without a restart; validate-first, so a bad edit leaves the running task set untouched
+- In-app updates: the Web UI and TUI show when a newer release is out and self-update the binary in place for standalone installs (checksum-verified, with rollback); optional and off-path (`check_updates`, default on)
 
 <div align="center">
 <img alt="RunWisp terminal UI screenshot: task sidebar, live log output, and execution controls over SSH" src="apps/docs/src/assets/screenshots/tui-home.png" width="780">

--- a/apps/docs/src/agents/reference.md
+++ b/apps/docs/src/agents/reference.md
@@ -41,6 +41,8 @@ shutdown_timeout:     dur  =10s   — SIGTERM→SIGKILL drain budget for in-flig
 external_url:         string      — public Web UI base for notification deep-links; absolute http(s) w/ host
 metrics_enabled:      bool =false — master switch for /metrics
 metrics_listen:       host:port   — dedicated metrics listener; REQUIRES metrics_enabled=true
+check_updates:        bool =true  — background-poll GitHub for a newer release; shows in Web UI/TUI (self-update
+                                    for standalone installs). false = fully offline, no outbound call
 include:              []string    — glob(s) of extra TOML files merged at load; root config only, no nesting
 include_cron:         []string    — glob(s) of REAL crontabs read as live task defs at every load/reload; root
                                     config only. Format is PATH-DERIVED, never flagged: /etc/crontab + **/cron.d/*
@@ -418,6 +420,7 @@ Trigger / stop / mutate runs (POST/DELETE — never touches definitions):
 
 ```
 POST   /api/daemon/reload                        re-read runwisp.toml + reconcile live task set (validate-first; reads from disk, never edits definitions)
+POST   /api/daemon/update                         download+verify+swap the latest release and restart into it (standalone installs only; 400 on docker/npm/manual). GET /api/daemon carries updateAvailable/latestVersion/updateMethod
 POST   /api/tasks/{task}/run                     trigger a new run
 POST   /api/tasks/{task}/stop                    stop service (for daemon lifetime)
 POST   /api/tasks/{task}/restart                 restart all service instances

--- a/apps/docs/src/content/docs/configuration/daemon.mdx
+++ b/apps/docs/src/content/docs/configuration/daemon.mdx
@@ -28,6 +28,7 @@ tls_cert         = ""
 tls_key          = ""
 metrics_enabled  = false
 metrics_listen   = ""
+check_updates    = true
 include          = ["conf.d/*.toml"]
 # include_cron   = ["/etc/crontab", "/etc/cron.d/*"]
 ```
@@ -41,6 +42,7 @@ include          = ["conf.d/*.toml"]
 | `tls_key`              | _unset_ | Path to the PEM private key matching `tls_cert`. Both keys are set together or not at all.                                                                                                                                                          |
 | `metrics_enabled`      | `false` | Master switch for the Prometheus-compatible `/metrics` endpoint. Off by default — task names and the daemon version label are visible to anyone who can reach the endpoint, so it stays closed until you turn it on.                                |
 | `metrics_listen`       | _unset_ | Optional `host:port` for a dedicated metrics listener (e.g. `"127.0.0.1:9478"`). When set, `/metrics` is **only** reachable on this address — never on the main UI/REST listener. Only consulted when `metrics_enabled = true`.                     |
+| `check_updates`        | `true`  | Poll GitHub in the background for a newer release and surface it in the Web UI and TUI. Set `false` to keep the daemon fully offline. See [`check_updates`](#check_updates) below.                                                                  |
 | `allow_cloud_dispatch` | `false` | Opt in to ad-hoc runs requested by a connected control-plane peer. Off by default. Dispatched runs are one-shot and never modify your task set — see [the control-plane section](#allow_cloud_dispatch) below.                                      |
 | `include`              | _unset_ | Glob patterns for extra TOML files to merge into this config at load. Lets you split tasks across `conf.d/*.toml` instead of one giant file. Only valid in the root config.                                                                         |
 | `include_cron`         | _unset_ | Glob patterns for real crontabs (system, `cron.d`, or per-user spool) to read as live task definitions at every load and reload. Point RunWisp at what cron already reads instead of converting everything up front. Only valid in the root config. |
@@ -157,6 +159,32 @@ locally or through a proxy; don't expose it on a public interface.
 
 And if you set `metrics_listen` but never turned `metrics_enabled` on,
 the daemon rejects it at boot instead of quietly ignoring it.
+
+### `check_updates`
+
+Every few hours the daemon asks GitHub whether there's a newer RunWisp
+release, and if there is, the Web UI and TUI both show a small banner. It's
+the only thing RunWisp reaches out over the network for on its own, so if you
+want a daemon that never phones home, turn it off:
+
+```toml
+[daemon]
+check_updates = false
+```
+
+The check is best-effort — if you're offline or GitHub is unreachable, it
+fails silently and tries again next time. Nothing in the daemon waits on it,
+and disabling it takes the network call away entirely.
+
+When there **is** an update and you installed the plain binary (from the
+install script or a direct download), the banner offers an **Update now**
+button — the daemon downloads the new release, verifies its checksum, smoke-
+tests it, atomically swaps its own binary, and restarts into it. It only
+ever swaps a verified, runnable binary, so a bad download or a half-written
+file leaves your working install untouched (the previous binary is kept
+alongside as `runwisp.bak`). Docker and npm installs can't swap themselves,
+so there the banner just shows the right upgrade command
+(`docker pull runwisp/runwisp` or `npm update -g runwisp`) instead.
 
 ### `allow_cloud_dispatch`
 

--- a/apps/runwisp/cmd/runwisp/cmd_cloud.go
+++ b/apps/runwisp/cmd/runwisp/cmd_cloud.go
@@ -27,7 +27,7 @@ The local scheduler is not started — task scheduling is managed by the cloud.`
 		if err := resolveCloudEnv(cloudFlags.EnvFile, cmd.Flags().Changed("env-file"), cloudFlags.Token, cloudFlags.URL); err != nil {
 			return err
 		}
-		return runDaemon(modeCloud, flags, noTUI)
+		return runDaemonAndReexec(modeCloud, flags, noTUI)
 	},
 }
 

--- a/apps/runwisp/cmd/runwisp/cmd_daemon.go
+++ b/apps/runwisp/cmd/runwisp/cmd_daemon.go
@@ -12,6 +12,6 @@ var daemonCmd = &cobra.Command{
 	Short: "Start RunWisp in headless mode (no TUI)",
 	Long:  `Starts the scheduler, HTTP API, and web UI without the interactive terminal interface. Ideal for Docker containers and background services. For an attached TUI, run 'runwisp' with no subcommand.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runDaemon(modeStandalone, flags, true)
+		return runDaemonAndReexec(modeStandalone, flags, true)
 	},
 }

--- a/apps/runwisp/cmd/runwisp/cmd_daemon_run.go
+++ b/apps/runwisp/cmd/runwisp/cmd_daemon_run.go
@@ -160,6 +160,8 @@ func runDaemon(mode daemonMode, f Flags, headless bool) (err error) {
 		TLSCert:           tlsCfg.CertPath,
 		TLSKey:            tlsCfg.KeyPath,
 		Reload:            reloadFn,
+		UpdateStatus:      updateStatusHook(svc.UpdateChecker),
+		SelfUpdate:        selfUpdateHook(cfg),
 	})
 	if err != nil {
 		return err

--- a/apps/runwisp/cmd/runwisp/cmd_default.go
+++ b/apps/runwisp/cmd/runwisp/cmd_default.go
@@ -58,7 +58,7 @@ func runDefault(f Flags) error {
 
 	if err := spawnDaemon(f); err != nil {
 		slog.Warn("Failed to spawn background daemon, running inline", "err", err)
-		return runDaemon(modeStandalone, f, false)
+		return runDaemonAndReexec(modeStandalone, f, false)
 	}
 
 	if err := waitForDaemon(client, logPath, 10*time.Second, f); err != nil {

--- a/apps/runwisp/cmd/runwisp/cmd_update_restart.go
+++ b/apps/runwisp/cmd/runwisp/cmd_update_restart.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"log/slog"
+
+	"github.com/runwisp/runwisp/internal/model"
+	"github.com/runwisp/runwisp/internal/runtime"
+	"github.com/runwisp/runwisp/internal/update"
+	"github.com/runwisp/runwisp/internal/version"
+)
+
+// updateApplyTimeout bounds the whole self-update (resolve latest + download +
+// verify + smoke test). Generous: it's an explicit operator action, not a hot path.
+const updateApplyTimeout = 10 * time.Minute
+
+// reexecRequested is set by the self-update flow so the daemon, after its normal
+// SIGTERM-driven graceful shutdown, replaces its process image with the freshly
+// swapped-in binary instead of exiting. Same PID keeps the pid file and any
+// service-manager supervision valid; a clean exit(0) would NOT be restarted
+// (both systemd and launchd units restart only on failure), so re-exec is the
+// only path that works standalone and service-managed alike.
+var reexecRequested atomic.Bool
+
+func updateHTTPClient() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+// updatesEnabled reports whether background checking and self-update should run
+// at all: opted in via [daemon] check_updates (default on) and this is a real
+// release build, not a dev binary.
+func updatesEnabled(cfg *daemonConfig) bool {
+	return cfg.Config.Daemon.CheckUpdates && update.IsRelease(version.Version)
+}
+
+// startUpdateChecker builds and starts the background release poller, or returns
+// nil when updates are disabled or this is a dev build.
+func startUpdateChecker(cfg *daemonConfig) *runtime.UpdateChecker {
+	if !updatesEnabled(cfg) {
+		return nil
+	}
+	checker := runtime.NewUpdateChecker(version.Version, updateHTTPClient())
+	checker.Start()
+	return checker
+}
+
+// updateStatusHook exposes the poller's cached snapshot to /api/daemon, or nil
+// when no checker is running.
+func updateStatusHook(checker *runtime.UpdateChecker) func() (bool, string) {
+	if checker == nil {
+		return nil
+	}
+	return checker.Status
+}
+
+// selfUpdateHook returns the POST /api/daemon/update action for a writable
+// standalone binary install, or nil otherwise — docker/npm/manual installs are
+// upgraded through their package manager, and the UI shows that command instead.
+func selfUpdateHook(cfg *daemonConfig) func() (model.UpdateResult, error) {
+	if !updatesEnabled(cfg) || update.DetectMethod() != update.MethodSelf {
+		return nil
+	}
+	return func() (model.UpdateResult, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), updateApplyTimeout)
+		defer cancel()
+
+		client := updateHTTPClient()
+		tag, err := update.LatestRelease(ctx, client)
+		if err != nil {
+			return model.UpdateResult{}, fmt.Errorf("check latest release: %w", err)
+		}
+		if update.Compare(version.Version, tag) >= 0 {
+			return model.UpdateResult{}, fmt.Errorf("already up to date (running %s, latest %s)",
+				version.Version, strings.TrimPrefix(tag, "v"))
+		}
+		if err := update.Apply(ctx, client, tag, requestReexecRestart); err != nil {
+			return model.UpdateResult{}, err
+		}
+		return model.UpdateResult{
+			OldVersion: version.Version,
+			NewVersion: strings.TrimPrefix(tag, "v"),
+		}, nil
+	}
+}
+
+// requestReexecRestart flags a post-shutdown re-exec and delivers SIGTERM to
+// self, funnelling into the identical graceful-shutdown path a `runwisp stop`
+// uses. Called by update.Apply only after a verified new binary is already on
+// disk, so the shutdown that follows comes up on the new version.
+func requestReexecRestart() error {
+	reexecRequested.Store(true)
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		reexecRequested.Store(false)
+		return fmt.Errorf("locate own process: %w", err)
+	}
+	slog.Info("restarting into updated binary; graceful shutdown then re-exec")
+	if err := p.Signal(syscall.SIGTERM); err != nil {
+		reexecRequested.Store(false)
+		return fmt.Errorf("signal self for restart: %w", err)
+	}
+	return nil
+}
+
+// runDaemonAndReexec runs the daemon and, once it and all its defers have
+// unwound cleanly, re-execs into a freshly self-updated binary if one was
+// requested. Every daemon entry point routes through here.
+func runDaemonAndReexec(mode daemonMode, f Flags, headless bool) error {
+	if err := runDaemon(mode, f, headless); err != nil {
+		return err
+	}
+	return maybeReexec()
+}
+
+// maybeReexec replaces the current process image with the on-disk binary when a
+// self-update requested it. Called after runDaemon has fully returned and its
+// defers (DB close, flock release) have unwound, so the new image starts against
+// a clean data dir with the same args. syscall.Exec only returns on error.
+func maybeReexec() error {
+	if !reexecRequested.Load() {
+		return nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate executable for re-exec: %w", err)
+	}
+	slog.Info("re-exec into updated binary", "path", exe)
+	return syscall.Exec(exe, os.Args, os.Environ())
+}

--- a/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
+++ b/apps/runwisp/cmd/runwisp/daemon_lifecycle.go
@@ -121,6 +121,9 @@ func gracefulShutdown(cancelCloud context.CancelFunc, cloudWG *sync.WaitGroup, s
 	if svc.MemoryReclaimer != nil {
 		svc.MemoryReclaimer.Stop()
 	}
+	if svc.UpdateChecker != nil {
+		svc.UpdateChecker.Stop()
+	}
 	// nil receiver when the pprof endpoint was never enabled — Close handles it.
 	svc.DebugServer.Close()
 

--- a/apps/runwisp/cmd/runwisp/daemon_services.go
+++ b/apps/runwisp/cmd/runwisp/daemon_services.go
@@ -20,6 +20,7 @@ import (
 	"github.com/runwisp/runwisp/internal/runtime"
 	"github.com/runwisp/runwisp/internal/storage"
 	"github.com/runwisp/runwisp/internal/tui/uikit"
+	"github.com/runwisp/runwisp/internal/update"
 	"github.com/runwisp/runwisp/internal/version"
 )
 
@@ -34,6 +35,7 @@ type daemonServices struct {
 	RetentionCleaner    *runtime.RetentionCleaner
 	SoftDeletePurger    *runtime.SoftDeletePurger
 	MemoryReclaimer     *runtime.MemoryReclaimer
+	UpdateChecker       *runtime.UpdateChecker
 	DebugServer         *debugServer
 	Notify              notifyBundle
 	ScheduleResult      runtime.ScheduleResult
@@ -106,6 +108,8 @@ func initDaemonServices(ctx context.Context, cfg *daemonConfig, db storage.Datab
 	memoryReclaimer := runtime.NewMemoryReclaimer(sqliteShrinkHook(db))
 	memoryReclaimer.Start()
 
+	updateChecker := startUpdateChecker(cfg)
+
 	debugSrv := startDebugServer()
 
 	notifyB := startNotify(ctx, cfg, db, eventBus, tasksMap, addWarning)
@@ -128,6 +132,7 @@ func initDaemonServices(ctx context.Context, cfg *daemonConfig, db storage.Datab
 		RetentionCleaner:    retentionCleaner,
 		SoftDeletePurger:    softDeletePurger,
 		MemoryReclaimer:     memoryReclaimer,
+		UpdateChecker:       updateChecker,
 		DebugServer:         debugSrv,
 		Notify:              notifyB,
 		ScheduleResult:      boot.schedResult,
@@ -485,6 +490,9 @@ func buildDaemonInfo(cfg *daemonConfig, svc *daemonServices, configLoadedAt time
 		TimezoneSource:   cfg.Config.Scheduler.Source,
 		Tasks:            tasks,
 		Capabilities:     capInfos,
+		// Boot-static: the install location doesn't move at runtime, so classify
+		// once here rather than probing the filesystem per /api/daemon request.
+		UpdateMethod: string(update.DetectMethod()),
 	}
 }
 

--- a/apps/runwisp/internal/apiclient/system.go
+++ b/apps/runwisp/internal/apiclient/system.go
@@ -69,6 +69,18 @@ func (c *Client) Reload() (*model.ReloadResult, error) {
 	return &result, nil
 }
 
+// TriggerUpdate asks the daemon to download, verify, and swap in the latest
+// release, then restart into it. Returns the old/new versions on success. A
+// non-self install (docker/npm) or a download/verify failure comes back as an
+// error from the daemon.
+func (c *Client) TriggerUpdate() (*model.UpdateResult, error) {
+	var result model.UpdateResult
+	if err := c.doJSON("POST", "/api/daemon/update", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // AuthStatus reports whether the daemon requires authentication, via the public
 // GET /api/auth/status endpoint. A remote client probes it before prompting for
 // a password so a RUNWISP_AUTH=off daemon connects without one.

--- a/apps/runwisp/internal/config/config.schema.json
+++ b/apps/runwisp/internal/config/config.schema.json
@@ -128,6 +128,7 @@
         "tls": { "type": "string", "default": "off", "description": "TLS mode for the HTTP server." },
         "tls_cert": { "type": "string", "description": "Path to the TLS certificate." },
         "tls_key": { "type": "string", "description": "Path to the TLS private key." },
+        "check_updates": { "type": "boolean", "default": true, "description": "Poll GitHub in the background for a newer release and show it in the Web UI/TUI. Set false to keep the daemon fully offline." },
         "include": {
           "type": "array",
           "description": "Glob(s) of extra TOML files merged at load. Root config only, no nesting.",

--- a/apps/runwisp/internal/config/schema.go
+++ b/apps/runwisp/internal/config/schema.go
@@ -247,6 +247,10 @@ type Daemon struct {
 	TLS                string
 	TLSCert            string
 	TLSKey             string
+	// CheckUpdates polls GitHub in the background for a newer release and
+	// surfaces it in the Web UI / TUI. Default on; disable to keep the daemon
+	// fully offline. Restart-only, like every other [daemon] key.
+	CheckUpdates bool
 }
 
 // Defaults provides fallback values applied to every task.

--- a/apps/runwisp/internal/config/wire.go
+++ b/apps/runwisp/internal/config/wire.go
@@ -597,16 +597,19 @@ func (w *storageWire) toStorage() (Storage, error) {
 // make adding a crontab require a restart. Only the root config may set them;
 // either key in an included file is a hard error.
 type daemonWire struct {
-	AllowCloudDispatch bool     `toml:"allow_cloud_dispatch,omitempty"`
-	ShutdownTimeout    string   `toml:"shutdown_timeout,omitempty"`
-	ExternalURL        string   `toml:"external_url,omitempty"`
-	MetricsEnabled     bool     `toml:"metrics_enabled,omitempty"`
-	MetricsListen      string   `toml:"metrics_listen,omitempty"`
-	TLS                string   `toml:"tls,omitempty"`
-	TLSCert            string   `toml:"tls_cert,omitempty"`
-	TLSKey             string   `toml:"tls_key,omitempty"`
-	Include            []string `toml:"include,omitempty"`
-	IncludeCron        []string `toml:"include_cron,omitempty"`
+	AllowCloudDispatch bool   `toml:"allow_cloud_dispatch,omitempty"`
+	ShutdownTimeout    string `toml:"shutdown_timeout,omitempty"`
+	ExternalURL        string `toml:"external_url,omitempty"`
+	MetricsEnabled     bool   `toml:"metrics_enabled,omitempty"`
+	MetricsListen      string `toml:"metrics_listen,omitempty"`
+	TLS                string `toml:"tls,omitempty"`
+	TLSCert            string `toml:"tls_cert,omitempty"`
+	TLSKey             string `toml:"tls_key,omitempty"`
+	// CheckUpdates is *bool so an unset key means default-on; false must be
+	// distinguishable from omitted.
+	CheckUpdates *bool    `toml:"check_updates,omitempty"`
+	Include      []string `toml:"include,omitempty"`
+	IncludeCron  []string `toml:"include_cron,omitempty"`
 }
 
 func (w *daemonWire) toDaemon() (Daemon, error) {
@@ -638,6 +641,7 @@ func (w *daemonWire) toDaemon() (Daemon, error) {
 		TLS:                tlsMode,
 		TLSCert:            strings.TrimSpace(w.TLSCert),
 		TLSKey:             strings.TrimSpace(w.TLSKey),
+		CheckUpdates:       w.CheckUpdates == nil || *w.CheckUpdates,
 	}, nil
 }
 

--- a/apps/runwisp/internal/model/model.go
+++ b/apps/runwisp/internal/model/model.go
@@ -453,6 +453,20 @@ type DaemonInfo struct {
 	TimezoneSource   string      `json:"timezoneSource" enum:"config,system"`
 	Tasks            []TaskBrief `json:"tasks"`
 	Capabilities     []CapInfo   `json:"capabilities"`
+	// UpdateAvailable/LatestVersion come from the background update checker; both
+	// zero when checking is disabled, offline, or already current. UpdateMethod
+	// tells UIs whether to offer an in-app self-update ("self") or the right
+	// upgrade command for a docker/npm/manual install.
+	UpdateAvailable bool   `json:"updateAvailable"`
+	LatestVersion   string `json:"latestVersion,omitempty"`
+	UpdateMethod    string `json:"updateMethod" enum:"self,docker,npm,manual"`
+}
+
+// UpdateResult is returned by POST /api/daemon/update after a verified binary
+// swap; the daemon then re-execs into NewVersion.
+type UpdateResult struct {
+	OldVersion string `json:"oldVersion"`
+	NewVersion string `json:"newVersion"`
 }
 
 // InstanceInfo is the local-only identity of a running daemon, returned by

--- a/apps/runwisp/internal/model/model_test.go
+++ b/apps/runwisp/internal/model/model_test.go
@@ -86,6 +86,8 @@ func TestDaemonInfo_JSONShapeIsLocked(t *testing.T) {
 		"serviceManaged",
 		"tasks",
 		"timezoneSource",
+		"updateAvailable",
+		"updateMethod",
 		"version",
 	}
 	got := make([]string, 0, len(decoded))

--- a/apps/runwisp/internal/runtime/updatecheck.go
+++ b/apps/runwisp/internal/runtime/updatecheck.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"log/slog"
+
+	"github.com/runwisp/runwisp/internal/update"
+)
+
+// DefaultUpdateCheckInterval is how often the daemon polls GitHub for a newer
+// release at steady state. Rare on purpose — a new release is a slow-moving fact
+// and this is a background, best-effort, opt-out-able outbound call.
+const DefaultUpdateCheckInterval = 6 * time.Hour
+
+// updateCheckTimeout bounds a single poll so a hung GitHub connection can never
+// pile up goroutines across ticks.
+const updateCheckTimeout = 15 * time.Second
+
+// UpdateStatus is the cached result of the most recent successful check.
+type UpdateStatus struct {
+	Available bool
+	Latest    string
+	CheckedAt time.Time
+}
+
+// UpdateChecker periodically asks GitHub for the newest release and caches
+// whether it is newer than the running build. Best-effort: a failed check (no
+// network, rate limit) is logged at debug and leaves the last good result in
+// place — it never surfaces as an error and never blocks anything. Construct it
+// only for release builds (see update.IsRelease).
+type UpdateChecker struct {
+	current  string
+	interval time.Duration
+	// fetch resolves the latest release tag; a field so tests inject a stub
+	// instead of hitting the network.
+	fetch  func(context.Context) (string, error)
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	status UpdateStatus
+}
+
+// NewUpdateChecker builds a checker for the given running version. client is used
+// for the outbound GitHub call (nil transport honors HTTP(S)_PROXY).
+func NewUpdateChecker(current string, client *http.Client) *UpdateChecker {
+	return &UpdateChecker{
+		current:  current,
+		interval: DefaultUpdateCheckInterval,
+		fetch: func(ctx context.Context) (string, error) {
+			return update.LatestRelease(ctx, client)
+		},
+	}
+}
+
+func (c *UpdateChecker) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+	// One check shortly after boot so the indicator is fresh without waiting a
+	// full interval; its own goroutine so Start never blocks daemon startup.
+	go c.checkOnce(ctx)
+	startTicker(ctx, c.interval, "Stopping update checker", c.checkOnce)
+}
+
+func (c *UpdateChecker) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func (c *UpdateChecker) checkOnce(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, updateCheckTimeout)
+	defer cancel()
+
+	latest, err := c.fetch(ctx)
+	if err != nil {
+		slog.Debug("update check failed", "err", err)
+		return
+	}
+	available := update.Compare(c.current, latest) < 0
+
+	c.mu.Lock()
+	first := c.status.CheckedAt.IsZero()
+	c.status = UpdateStatus{Available: available, Latest: latest, CheckedAt: time.Now()}
+	c.mu.Unlock()
+
+	if available && first {
+		slog.Info("a newer RunWisp release is available",
+			"current", c.current, "latest", latest, "hint", "update via the Web UI/TUI or re-run the installer")
+	}
+}
+
+// Status returns the last cached check result for /api/daemon. Zero-value
+// (Available=false, empty Latest) until the first successful check.
+func (c *UpdateChecker) Status() (available bool, latest string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.status.Available, c.status.Latest
+}

--- a/apps/runwisp/internal/runtime/updatecheck_test.go
+++ b/apps/runwisp/internal/runtime/updatecheck_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestUpdateCheckerAvailable(t *testing.T) {
+	c := &UpdateChecker{
+		current: "0.16.0",
+		fetch:   func(context.Context) (string, error) { return "v0.17.0", nil },
+	}
+	c.checkOnce(context.Background())
+
+	available, latest := c.Status()
+	if !available {
+		t.Error("expected update available")
+	}
+	if latest != "v0.17.0" {
+		t.Errorf("latest=%q want v0.17.0", latest)
+	}
+}
+
+func TestUpdateCheckerUpToDate(t *testing.T) {
+	c := &UpdateChecker{
+		current: "0.17.0",
+		fetch:   func(context.Context) (string, error) { return "v0.17.0", nil },
+	}
+	c.checkOnce(context.Background())
+
+	if available, _ := c.Status(); available {
+		t.Error("did not expect an update when on the latest version")
+	}
+}
+
+func TestUpdateCheckerFetchErrorKeepsLastGood(t *testing.T) {
+	c := &UpdateChecker{
+		current: "0.16.0",
+		fetch:   func(context.Context) (string, error) { return "v0.17.0", nil },
+	}
+	c.checkOnce(context.Background()) // seed a good result
+
+	c.fetch = func(context.Context) (string, error) { return "", errors.New("offline") }
+	c.checkOnce(context.Background()) // must not clobber the cached status
+
+	available, latest := c.Status()
+	if !available || latest != "v0.17.0" {
+		t.Errorf("failed check overwrote cached status: available=%v latest=%q", available, latest)
+	}
+}

--- a/apps/runwisp/internal/server/api_types.go
+++ b/apps/runwisp/internal/server/api_types.go
@@ -215,6 +215,10 @@ type ReloadOutput struct {
 	Body model.ReloadResult
 }
 
+type UpdateOutput struct {
+	Body model.UpdateResult
+}
+
 // ---------- Auth types ----------
 
 type AuthStatusOutput struct {

--- a/apps/runwisp/internal/server/runs.go
+++ b/apps/runwisp/internal/server/runs.go
@@ -56,6 +56,15 @@ func (srv *Server) registerProtectedHumaRoutes(r chi.Router) {
 	}, srv.humaReload)
 
 	huma.Register(protectedAPI, huma.Operation{
+		OperationID: "selfUpdate",
+		Method:      http.MethodPost,
+		Path:        "/api/daemon/update",
+		Summary:     "Update the daemon to the latest release",
+		Description: "Downloads, checksum-verifies, and swaps in the newest GitHub release, then restarts the daemon into it. Standalone binary installs only; docker/npm installs are rejected with a 400 and should upgrade via their package manager.",
+		Tags:        []string{"System"},
+	}, srv.humaUpdate)
+
+	huma.Register(protectedAPI, huma.Operation{
 		OperationID: "getMetricsHistory",
 		Method:      http.MethodGet,
 		Path:        "/api/system/metrics",

--- a/apps/runwisp/internal/server/server.go
+++ b/apps/runwisp/internal/server/server.go
@@ -87,6 +87,14 @@ type Server struct {
 	// outside standalone mode (cloud mode has no local scheduler to reconcile),
 	// in which case POST /api/daemon/reload reports the operation is unavailable.
 	reload func() (model.ReloadResult, error)
+	// updateStatus is the background checker's cached snapshot for /api/daemon.
+	// nil when update checking is disabled (reports never-available).
+	updateStatus func() (available bool, latest string)
+	// selfUpdate downloads, verifies, and swaps in the newest release, then
+	// restarts the daemon into it. nil unless this is a writable standalone
+	// binary install, in which case POST /api/daemon/update reports it as
+	// unavailable and the UI shows the right upgrade command instead.
+	selfUpdate func() (model.UpdateResult, error)
 }
 
 // DaemonInfo, TaskBrief, and CapInfo live in the model package.
@@ -105,20 +113,22 @@ type Options struct {
 	SocketPath        string // Unix socket path for local CLI/TUI; empty disables socket listener
 	LogDir            string
 	EventBus          *events.Bus
-	Password          string                             // Authentication password (required even with NoAuth — keeps the cookie/launch-ticket machinery alive)
-	PasswordEphemeral bool                               // True when the daemon minted Password in memory at boot (no RUNWISP_PASSWORD)
-	JWTSecret         string                             // JWT signing secret (derived in-memory)
-	NoAuth            bool                               // RUNWISP_AUTH=off: serve all /api/* routes over TCP without JWT/CHAP
-	TrustedProxies    string                             // RUNWISP_TRUSTED_PROXIES value (comma-separated CIDRs/IPs); read by the caller, parsed here
-	DaemonInfo        *model.DaemonInfo                  // Static identity/config info for /api/daemon
-	ConfigStale       func() bool                        // Per-request staleness probe for /api/daemon (optional; nil reports never-stale)
-	ConfigWarnings    func() []string                    // Per-request live-config warnings for /api/daemon (optional; nil reports none)
-	DaemonLogBuffer   *DaemonLogBuffer                   // Ring buffer for daemon log streaming (optional)
-	MetricsEnabled    bool                               // When false, /metrics is not mounted anywhere
-	MetricsListen     string                             // When non-empty, bind /metrics on a separate listener (e.g. "127.0.0.1:9478")
-	TLSCert           string                             // PEM cert path; when set with TLSKey the main listener serves HTTPS
-	TLSKey            string                             // PEM key path; paired with TLSCert
-	Reload            func() (model.ReloadResult, error) // Reconciles the live task set against runwisp.toml; nil disables POST /api/daemon/reload
+	Password          string                                 // Authentication password (required even with NoAuth — keeps the cookie/launch-ticket machinery alive)
+	PasswordEphemeral bool                                   // True when the daemon minted Password in memory at boot (no RUNWISP_PASSWORD)
+	JWTSecret         string                                 // JWT signing secret (derived in-memory)
+	NoAuth            bool                                   // RUNWISP_AUTH=off: serve all /api/* routes over TCP without JWT/CHAP
+	TrustedProxies    string                                 // RUNWISP_TRUSTED_PROXIES value (comma-separated CIDRs/IPs); read by the caller, parsed here
+	DaemonInfo        *model.DaemonInfo                      // Static identity/config info for /api/daemon
+	ConfigStale       func() bool                            // Per-request staleness probe for /api/daemon (optional; nil reports never-stale)
+	ConfigWarnings    func() []string                        // Per-request live-config warnings for /api/daemon (optional; nil reports none)
+	DaemonLogBuffer   *DaemonLogBuffer                       // Ring buffer for daemon log streaming (optional)
+	MetricsEnabled    bool                                   // When false, /metrics is not mounted anywhere
+	MetricsListen     string                                 // When non-empty, bind /metrics on a separate listener (e.g. "127.0.0.1:9478")
+	TLSCert           string                                 // PEM cert path; when set with TLSKey the main listener serves HTTPS
+	TLSKey            string                                 // PEM key path; paired with TLSCert
+	Reload            func() (model.ReloadResult, error)     // Reconciles the live task set against runwisp.toml; nil disables POST /api/daemon/reload
+	UpdateStatus      func() (available bool, latest string) // Background update-checker snapshot for /api/daemon; nil reports never-available
+	SelfUpdate        func() (model.UpdateResult, error)     // Verified binary swap + restart; nil disables POST /api/daemon/update (non-standalone installs)
 }
 
 func New(opts Options) (*Server, error) {
@@ -165,6 +175,8 @@ func New(opts Options) (*Server, error) {
 		metricsEnabled:    opts.MetricsEnabled,
 		metricsListen:     opts.MetricsListen,
 		reload:            opts.Reload,
+		updateStatus:      opts.UpdateStatus,
+		selfUpdate:        opts.SelfUpdate,
 		ready:             make(chan struct{}),
 	}
 

--- a/apps/runwisp/internal/server/system.go
+++ b/apps/runwisp/internal/server/system.go
@@ -89,7 +89,30 @@ func (srv *Server) humaGetInfo(ctx context.Context, input *struct{}) (*DaemonInf
 	if tasks := srv.currentTaskBriefs(); tasks != nil {
 		info.Tasks = tasks
 	}
+	// Update availability is polled in the background; read the latest cached
+	// answer per request so the indicator clears itself the moment a check finds
+	// we're current again. UpdateMethod is boot-static (install location doesn't
+	// move) and already set on the provider's DaemonInfo.
+	if srv.updateStatus != nil {
+		info.UpdateAvailable, info.LatestVersion = srv.updateStatus()
+	}
 	return &DaemonInfoOutput{Body: info}, nil
+}
+
+// humaUpdate downloads, verifies, and swaps in the newest release, then restarts
+// the daemon into it. A nil hook means this install can't self-update (docker /
+// npm / a non-writable location) — a 400 tells the operator to use their package
+// manager instead. A download/verify/smoke-test failure surfaces as a 500 with
+// the real cause: the running binary is always left intact (see internal/update).
+func (srv *Server) humaUpdate(ctx context.Context, input *struct{}) (*UpdateOutput, error) {
+	if srv.selfUpdate == nil {
+		return nil, huma.Error400BadRequest("self-update is not available for this installation")
+	}
+	result, err := srv.selfUpdate()
+	if err != nil {
+		return nil, huma.Error500InternalServerError(err.Error())
+	}
+	return &UpdateOutput{Body: result}, nil
 }
 
 // currentTaskBriefs rebuilds /api/daemon's task list from the live registry, in the

--- a/apps/runwisp/internal/server/system_test.go
+++ b/apps/runwisp/internal/server/system_test.go
@@ -64,6 +64,38 @@ func TestHumaGetInfo(t *testing.T) {
 	assert.Equal(t, "test-fp", out.Body.Fingerprint)
 }
 
+func TestHumaGetInfo_SurfacesUpdateStatus(t *testing.T) {
+	srv := &Server{
+		stats:        newStatsProvider(&model.DaemonInfo{UpdateMethod: "self"}, time.Now()),
+		updateStatus: func() (bool, string) { return true, "v9.9.9" },
+	}
+	out, err := srv.humaGetInfo(context.Background(), &struct{}{})
+	require.NoError(t, err)
+	assert.True(t, out.Body.UpdateAvailable)
+	assert.Equal(t, "v9.9.9", out.Body.LatestVersion)
+	assert.Equal(t, "self", out.Body.UpdateMethod)
+}
+
+func TestHumaUpdate_UnavailableWithoutHook(t *testing.T) {
+	srv := &Server{} // no selfUpdate hook: docker/npm/manual install
+	_, err := srv.humaUpdate(context.Background(), &struct{}{})
+	require.Error(t, err)
+}
+
+func TestHumaUpdate_InvokesHook(t *testing.T) {
+	called := false
+	srv := &Server{
+		selfUpdate: func() (model.UpdateResult, error) {
+			called = true
+			return model.UpdateResult{OldVersion: "0.16.0", NewVersion: "0.17.0"}, nil
+		},
+	}
+	out, err := srv.humaUpdate(context.Background(), &struct{}{})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "0.17.0", out.Body.NewVersion)
+}
+
 // TestHumaGetInfo_TasksComeFromTheLiveRegistry is the reporting half of the cron
 // hold releasing itself. The scheduler picking a job back up is invisible if
 // /api/daemon keeps serving the task list built at boot: `runwisp status` and the

--- a/apps/runwisp/internal/tui/keys/keys.go
+++ b/apps/runwisp/internal/tui/keys/keys.go
@@ -39,6 +39,7 @@ var (
 	Quit         = Binding{Keys: "q / ctrl+c", Desc: "quit", Bar: "q/^C quit"}
 	NotifPanel   = Binding{Keys: "n", Desc: "notifications panel (Home)", Bar: "n notifications"}
 	ReloadConfig = Binding{Keys: "R", Desc: "reload runwisp.toml", Bar: "R reload"}
+	Update       = Binding{Keys: "U", Desc: "update RunWisp (when a newer release is available)", Bar: "U update"}
 	SearchLogs   = Binding{Keys: "/", Desc: "search logs of the focused task"}
 	// FilterTasks shares `/` with SearchLogs; it applies when the sidebar is
 	// focused, SearchLogs applies in an exec view / on the main panel.
@@ -119,7 +120,7 @@ var (
 // Each row's Keys/Desc come from the bindings above, so the overlay and the
 // contextual bars are guaranteed consistent.
 var OverlaySections = []Section{
-	{Title: "Global", Bindings: []Binding{Help, Quit, NotifPanel, ReloadConfig, SearchLogs}},
+	{Title: "Global", Bindings: []Binding{Help, Quit, NotifPanel, ReloadConfig, Update, SearchLogs}},
 	{Title: "Navigate", Bindings: []Binding{Move, SwitchPanel, Open, Back, FilterTasks}},
 	{Title: "Task", Bindings: []Binding{Run, OpenRun, TaskInfo, Undo}},
 	{Title: "Run list", Bindings: []Binding{Filter, Select, SelectAll, BulkDelete, BulkCancel, BulkRerun, ClearSelect}},

--- a/apps/runwisp/internal/tui/model_key.go
+++ b/apps/runwisp/internal/tui/model_key.go
@@ -35,6 +35,7 @@ var globalKeyHandlers = map[string]keyHandlerFn{
 	"enter":     handleKeyEnter,
 	"r":         handleKeyR,
 	"R":         handleKeyR,
+	"U":         handleKeyUpdate,
 	"i":         handleKeyI,
 	"u":         handleKeyU,
 	"s":         handleKeyS,
@@ -368,6 +369,15 @@ func handleKeyR(m Model, msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 		return handleKeyRExecView(m)
 	}
 	return m, m.confirmAction(confirmActionTrigger), true
+}
+
+// handleKeyUpdate triggers a self-update when the header is advertising a newer
+// release; otherwise it's a no-op so "U" stays free elsewhere.
+func handleKeyUpdate(m Model, _ tea.KeyPressMsg) (Model, tea.Cmd, bool) {
+	if !m.info.UpdateAvailable {
+		return m, nil, false
+	}
+	return m, m.triggerUpdate(), true
 }
 
 func handleKeyRExecView(m Model) (Model, tea.Cmd, bool) {

--- a/apps/runwisp/internal/tui/model_update.go
+++ b/apps/runwisp/internal/tui/model_update.go
@@ -17,6 +17,7 @@ import (
 	"github.com/runwisp/runwisp/internal/tui/views/execlist"
 	"github.com/runwisp/runwisp/internal/tui/views/logpane"
 	"github.com/runwisp/runwisp/internal/tui/views/logsearch"
+	"github.com/runwisp/runwisp/internal/update"
 )
 
 const keyCtrlC = "ctrl+c"
@@ -251,6 +252,9 @@ func (m Model) dispatchLifecycleMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return model, cmd, true
 	case uikit.ReloadResultMsg:
 		model, cmd := m.handleReloadResult(msg)
+		return model, cmd, true
+	case uikit.UpdateResultMsg:
+		model, cmd := m.handleUpdateResult(msg)
 		return model, cmd, true
 	case uikit.MetricsHistoryMsg:
 		model, cmd := m.handleMetricsHistory(msg)
@@ -899,8 +903,42 @@ func (m Model) handleDaemonInfo(msg uikit.DaemonInfoMsg) (tea.Model, tea.Cmd) {
 		m.info.ConfigStale = msg.Info.ConfigStale
 		m.info.ConfigWarnings = msg.Info.ConfigWarnings
 		m.info.ServiceManaged = msg.Info.ServiceManaged
+		m.info.UpdateAvailable = msg.Info.UpdateAvailable
+		m.info.LatestVersion = msg.Info.LatestVersion
+		m.info.UpdateMethod = msg.Info.UpdateMethod
 	}
 	return m, nil
+}
+
+// triggerUpdate asks the daemon to self-update from inside the TUI. Only wired
+// for a self-updatable install (UpdateMethod "self"); other installs get a hint
+// pointing at the right upgrade command instead. The result arrives as an
+// UpdateResultMsg.
+func (m *Model) triggerUpdate() tea.Cmd {
+	if m.client == nil || !m.info.UpdateAvailable {
+		return nil
+	}
+	if m.info.UpdateMethod != "self" {
+		return m.dialogs.Flash("Update available: "+m.info.LatestVersion+" — "+update.UpgradeCommand(update.Method(m.info.UpdateMethod)), 8*time.Second)
+	}
+	return tea.Batch(
+		m.dialogs.Flash("Updating to "+m.info.LatestVersion+"… the daemon will restart", 6*time.Second),
+		m.streams.TriggerUpdate(),
+	)
+}
+
+// handleUpdateResult reports a self-update outcome. On success the daemon
+// re-execs into the new binary, so the TUI drops its connection and reconnects
+// on the next poll; on failure the running daemon is untouched.
+func (m Model) handleUpdateResult(msg uikit.UpdateResultMsg) (tea.Model, tea.Cmd) {
+	if msg.Err != nil {
+		return m, m.dialogs.Flash("Update failed: "+msg.Err.Error(), 8*time.Second)
+	}
+	summary := "✓ Update applied — daemon restarting"
+	if msg.Result != nil {
+		summary = "✓ Updated to " + msg.Result.NewVersion + " — daemon restarting"
+	}
+	return m, m.dialogs.Flash(summary, 6*time.Second)
 }
 
 // reloadConfig triggers an explicit config reload from inside the TUI. The

--- a/apps/runwisp/internal/tui/stream_manager.go
+++ b/apps/runwisp/internal/tui/stream_manager.go
@@ -303,6 +303,21 @@ func (sm *StreamManager) Reload() tea.Cmd {
 	}
 }
 
+// TriggerUpdate asks the daemon to self-update (POST /api/daemon/update). On
+// success the daemon re-execs into the new binary; the result comes back as an
+// UpdateResultMsg. A non-self install or a download/verify failure is reported
+// as-is — the running daemon is left intact.
+func (sm *StreamManager) TriggerUpdate() tea.Cmd {
+	if sm.client == nil {
+		return nil
+	}
+	client := sm.client
+	return func() tea.Msg {
+		result, err := client.TriggerUpdate()
+		return uikit.UpdateResultMsg{Result: result, Err: err}
+	}
+}
+
 // RestoreRuns un-deletes every run matched by sel (the inverse of a delete).
 func (sm *StreamManager) RestoreRuns(sel model.RunSelector) tea.Cmd {
 	return sm.bulkAction("Restored", func(c *apiclient.Client) (int, error) {

--- a/apps/runwisp/internal/tui/uikit/messages.go
+++ b/apps/runwisp/internal/tui/uikit/messages.go
@@ -238,6 +238,14 @@ type ReloadResultMsg struct {
 	Err    error
 }
 
+// UpdateResultMsg delivers the outcome of an operator-triggered self-update
+// (POST /api/daemon/update). On success the daemon re-execs into NewVersion, so
+// the TUI briefly loses its connection and reconnects on the next poll.
+type UpdateResultMsg struct {
+	Result *model.UpdateResult
+	Err    error
+}
+
 // MetricsHistoryMsg delivers historical metrics for sparkline pre-fill.
 type MetricsHistoryMsg struct {
 	Samples []model.MetricsSample

--- a/apps/runwisp/internal/tui/uikit/startup.go
+++ b/apps/runwisp/internal/tui/uikit/startup.go
@@ -71,6 +71,14 @@ type StartupInfo struct {
 	// the TUI can mention it at all.
 	ConfigWarnings []string
 
+	// UpdateAvailable/LatestVersion/UpdateMethod mirror /api/daemon's update
+	// fields, refreshed by the periodic poll. When UpdateAvailable, the header
+	// shows a chip: "press U to update" for a self-updatable install, else the
+	// upgrade command for the detected UpdateMethod (docker/npm/manual).
+	UpdateAvailable bool
+	LatestVersion   string
+	UpdateMethod    string
+
 	// Headless is set when the daemon runs without an interactive TUI. The
 	// startup banner renders one extra dim line ("Press Ctrl+C to stop.") in
 	// that case, replacing what used to be a separate timestamped slog INFO.

--- a/apps/runwisp/internal/tui/views/home/header.go
+++ b/apps/runwisp/internal/tui/views/home/header.go
@@ -14,6 +14,7 @@ import (
 	"github.com/runwisp/runwisp/internal/model"
 	"github.com/runwisp/runwisp/internal/textutil"
 	"github.com/runwisp/runwisp/internal/tui/uikit"
+	"github.com/runwisp/runwisp/internal/update"
 )
 
 // Field identifies a focusable field in the home header.
@@ -90,6 +91,19 @@ func RenderHeader(info uikit.StartupInfo, hasLaunchTicket bool, w, homeCursor, h
 			Foreground(uikit.ColorWarning).
 			Render("\u26a0 runwisp.toml changed \u2014 press R to reload")
 		parts = append(parts, warn)
+	}
+	if info.UpdateAvailable && info.LatestVersion != "" {
+		// Success color: a new release is good, actionable news. Self-updatable
+		// installs get the keystroke; docker/npm/manual get the right command.
+		action := "press U to update"
+		if info.UpdateMethod != "self" {
+			action = update.UpgradeCommand(update.Method(info.UpdateMethod))
+		}
+		up := lipgloss.NewStyle().
+			Background(uikit.ColorBgLight).
+			Foreground(uikit.ColorSuccess).
+			Render(fmt.Sprintf("⬆ %s available — %s", info.LatestVersion, action))
+		parts = append(parts, up)
 	}
 	if n := HeldTaskCount(info.Tasks); n > 0 {
 		// Warning color: these are the operator's own jobs, loaded and listed, that

--- a/apps/runwisp/internal/tui/views/info/info.go
+++ b/apps/runwisp/internal/tui/views/info/info.go
@@ -333,6 +333,9 @@ func (v *InfoView) renderQuickInfoSection(w int) []string {
 	if v.info.CloudEnabled {
 		fields = append(fields, kv{"Cloud", "Connected"})
 	}
+	if v.info.UpdateAvailable && v.info.LatestVersion != "" {
+		fields = append(fields, kv{"Update", v.info.LatestVersion + " available (press U)"})
+	}
 
 	for _, f := range fields {
 		if f.value == "" {

--- a/apps/runwisp/internal/update/update.go
+++ b/apps/runwisp/internal/update/update.go
@@ -1,0 +1,460 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package update discovers newer RunWisp releases on GitHub and, for standalone
+// binary installs, replaces the running binary in place — safely. The live
+// binary is never touched until a fully downloaded, checksum-verified,
+// smoke-tested candidate exists, so no failure mode (network drop, partial
+// write, corrupt/wrong-arch artifact, failed rename) can leave the installation
+// without a working executable.
+//
+// Distribution shape (see scripts/install.sh): GitHub releases carry
+// runwisp-<os>-<arch>.tar.gz plus checksums-sha256.txt at the same URL, with
+// tags of the form v<semver>. Docker and npm installs are detected and refused
+// for in-place swap — those are upgraded through their own package managers.
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"log/slog"
+)
+
+const (
+	// DevVersion mirrors version.Version's ldflag default. A binary still
+	// carrying it was not built from a release, so update checks are skipped —
+	// keep this in sync with internal/version.Version's zero value.
+	DevVersion = "0.0.0-dev"
+
+	binaryName = "runwisp"
+
+	maxTarballBytes = 100 << 20 // generous cap; the real binary is a few MiB
+	maxMetaBytes    = 1 << 20   // release JSON + checksums file
+)
+
+// GitHub endpoints. Package vars (not consts) only so tests can point them at a
+// local httptest server; production never reassigns them.
+var (
+	latestReleaseURL    = "https://api.github.com/repos/runwisp/runwisp/releases/latest"
+	releaseDownloadBase = "https://github.com/runwisp/runwisp/releases/download"
+)
+
+// applying is a process-wide single-flight guard: only one Apply runs at a time.
+var applying atomic.Bool
+
+// osExecutable is os.Executable, overridable in tests so Apply/DetectMethod
+// don't operate on the test runner's own binary.
+var osExecutable = os.Executable
+
+// Method is how this installation should be upgraded.
+type Method string
+
+const (
+	MethodSelf   Method = "self"   // writable standalone binary → in-place swap
+	MethodDocker Method = "docker" // immutable image → docker pull
+	MethodNpm    Method = "npm"    // package-manager owned → npm/bun update
+	MethodManual Method = "manual" // binary dir not writable → re-run installer
+)
+
+// IsRelease reports whether v looks like a released version (parseable semver and
+// not the dev default). Callers skip update checks entirely for dev builds.
+func IsRelease(v string) bool {
+	if v == DevVersion {
+		return false
+	}
+	_, ok := parseVersion(v)
+	return ok
+}
+
+// Compare returns -1, 0, or 1 as a is older than, equal to, or newer than b,
+// on X.Y.Z (leading "v" and any -prerelease/+build suffix ignored). Unparseable
+// input compares equal (0) so a garbled version never triggers an "update".
+func Compare(a, b string) int {
+	av, aok := parseVersion(a)
+	bv, bok := parseVersion(b)
+	if !aok || !bok {
+		return 0
+	}
+	for i := range 3 {
+		switch {
+		case av[i] < bv[i]:
+			return -1
+		case av[i] > bv[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+func parseVersion(s string) ([3]int, bool) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "v")
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return [3]int{}, false
+	}
+	var v [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return [3]int{}, false
+		}
+		v[i] = n
+	}
+	return v, true
+}
+
+// DetectMethod classifies how this installation should be upgraded. Cheap enough
+// to call once at boot; it probes the executable path and its directory.
+func DetectMethod() Method {
+	exe, err := osExecutable()
+	if err != nil {
+		return MethodManual
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved // npm ships the binary behind a node_modules/.bin symlink
+	}
+	switch {
+	case inContainer():
+		return MethodDocker
+	case strings.Contains(exe, "node_modules"):
+		return MethodNpm
+	case !dirWritable(filepath.Dir(exe)):
+		return MethodManual
+	default:
+		return MethodSelf
+	}
+}
+
+// UpgradeCommand is the one-line instruction a non-self install should show
+// instead of an in-app "update" button.
+func UpgradeCommand(m Method) string {
+	switch m {
+	case MethodDocker:
+		return "docker pull runwisp/runwisp"
+	case MethodNpm:
+		return "npm update -g runwisp"
+	default:
+		return "re-run the installer: curl -fsSL https://get.runwisp.com | sh"
+	}
+}
+
+func inContainer() bool {
+	if os.Getenv("RUNWISP_CONTAINER") == "1" {
+		return true
+	}
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
+}
+
+// dirWritable reports whether we can create (and thus rename) files in dir.
+// Probes with a temp file rather than checking mode bits so it respects the
+// effective uid/gid and any read-only mount. Note the running binary itself
+// can't be opened for write on Linux (ETXTBSY), so directory writability — what
+// an atomic rename actually needs — is the right thing to test.
+func dirWritable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".runwisp-wtest-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return true
+}
+
+// LatestRelease returns the newest stable release tag (e.g. "v0.17.0"). The
+// GitHub /releases/latest endpoint already excludes drafts and prereleases.
+func LatestRelease(ctx context.Context, client *http.Client) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github releases API returned %s", resp.Status)
+	}
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxMetaBytes)).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode release metadata: %w", err)
+	}
+	if payload.TagName == "" {
+		return "", errors.New("release metadata had no tag_name")
+	}
+	return payload.TagName, nil
+}
+
+// AssetName is the release asset for the running platform, e.g.
+// "runwisp-linux-x64.tar.gz". Mirrors scripts/install.sh's target scheme.
+func AssetName() string {
+	arch := runtime.GOARCH
+	if arch == "amd64" {
+		arch = "x64"
+	}
+	return fmt.Sprintf("%s-%s-%s.tar.gz", binaryName, runtime.GOOS, arch)
+}
+
+// Apply downloads release `tag`, verifies it, atomically swaps it in for the
+// running binary, and calls reexec to restart into it. reexec is injected so it
+// can trigger the daemon's own graceful-shutdown-then-exec path (and so tests
+// can observe the swap without replacing their own process). Every step before
+// the swap is reversible; see the package doc for the safety guarantee.
+func Apply(ctx context.Context, client *http.Client, tag string, reexec func() error) error {
+	if !applying.CompareAndSwap(false, true) {
+		return errors.New("an update is already in progress")
+	}
+	defer applying.Store(false)
+
+	exe, err := osExecutable()
+	if err != nil {
+		return fmt.Errorf("locate executable: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+
+	base := releaseDownloadBase + "/" + tag
+	asset := AssetName()
+
+	tarball, err := downloadToTemp(ctx, client, base+"/"+asset)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tarball)
+
+	want, err := fetchChecksum(ctx, client, base+"/checksums-sha256.txt", asset)
+	if err != nil {
+		return err
+	}
+	if err := verifySHA256(tarball, want); err != nil {
+		return err
+	}
+
+	candidate, err := extractBinary(tarball, filepath.Dir(exe))
+	if err != nil {
+		return err
+	}
+	// Removed only if the swap below never consumes it (rename moves it to exe).
+	defer os.Remove(candidate)
+
+	if err := smokeTest(ctx, candidate, tag); err != nil {
+		return err
+	}
+
+	backup := exe + ".bak"
+	if err := swapBinary(exe, candidate, backup); err != nil {
+		return err
+	}
+
+	if err := reexec(); err != nil {
+		// Restarting failed after the swap; put the old binary back so a manual
+		// restart doesn't come up on a half-applied state.
+		if rbErr := os.Rename(backup, exe); rbErr != nil {
+			return fmt.Errorf("restart after update failed: %w (and restoring %s failed: %v)", err, backup, rbErr)
+		}
+		return fmt.Errorf("restart after update failed, restored previous binary: %w", err)
+	}
+	return nil
+}
+
+func downloadToTemp(ctx context.Context, client *http.Client, url string) (path string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download %s: %s", url, resp.Status)
+	}
+
+	f, err := os.CreateTemp("", "runwisp-update-*.tar.gz")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = f.Close()
+		if err != nil {
+			_ = os.Remove(f.Name())
+		}
+	}()
+
+	n, err := io.Copy(f, io.LimitReader(resp.Body, maxTarballBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", url, err)
+	}
+	if n > maxTarballBytes {
+		return "", fmt.Errorf("download %s: exceeds %d byte cap", url, maxTarballBytes)
+	}
+	if err = f.Sync(); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+// fetchChecksum returns the expected sha256 hex for asset from a
+// "sha256  filename" checksums file.
+func fetchChecksum(ctx context.Context, client *http.Client, url, asset string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch checksums: %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxMetaBytes))
+	if err != nil {
+		return "", err
+	}
+	for line := range strings.SplitSeq(string(body), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && filepath.Base(fields[1]) == asset {
+			return strings.ToLower(fields[0]), nil
+		}
+	}
+	return "", fmt.Errorf("no checksum for %s in checksums file", asset)
+}
+
+func verifySHA256(path, want string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("checksum mismatch: got %s, want %s", got, want)
+	}
+	return nil
+}
+
+// extractBinary pulls the "runwisp" entry out of the gzipped tarball and writes
+// it, executable, to a temp file in destDir (same filesystem as the target so
+// the final rename is atomic). Returns the candidate path.
+func extractBinary(tarball, destDir string) (path string, err error) {
+	f, err := os.Open(tarball)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("open gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return "", fmt.Errorf("archive did not contain %q", binaryName)
+		}
+		if err != nil {
+			return "", fmt.Errorf("read archive: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg || filepath.Base(hdr.Name) != binaryName {
+			continue
+		}
+		return writeCandidateBinary(tr, destDir)
+	}
+}
+
+// writeCandidateBinary copies the current tar entry (the matched binaryName
+// header) into an executable temp file in destDir (same filesystem as the
+// target so the final rename is atomic). Returns the candidate path.
+func writeCandidateBinary(tr *tar.Reader, destDir string) (path string, err error) {
+	out, err := os.CreateTemp(destDir, ".runwisp.new-*")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = out.Close()
+		if err != nil {
+			_ = os.Remove(out.Name())
+		}
+	}()
+	if _, err = io.Copy(out, io.LimitReader(tr, maxTarballBytes)); err != nil {
+		return "", fmt.Errorf("extract binary: %w", err)
+	}
+	if err = out.Chmod(0o755); err != nil {
+		return "", err
+	}
+	if err = out.Sync(); err != nil {
+		return "", err
+	}
+	return out.Name(), nil
+}
+
+// smokeTest runs `<candidate> --version` and requires it to exit 0 and report
+// the version we think we downloaded. This is the last line of defense: a
+// corrupt, truncated, or wrong-architecture binary fails here, before it can
+// ever replace the live one.
+func smokeTest(ctx context.Context, bin, tag string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin, "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("candidate binary failed to run: %w (output: %q)", err, string(out))
+	}
+	want := strings.TrimPrefix(tag, "v")
+	if !strings.Contains(string(out), want) {
+		return fmt.Errorf("candidate binary reported the wrong version (wanted %s): %q", want, string(out))
+	}
+	return nil
+}
+
+// swapBinary atomically replaces exe with candidate, keeping a .bak rollback.
+// On Unix, renaming over a running executable is safe: the running process keeps
+// the old inode while new starts get the new one.
+func swapBinary(exe, candidate, backup string) error {
+	_ = os.Remove(backup) // clear a stale backup from a previous update
+	if err := os.Rename(exe, backup); err != nil {
+		return fmt.Errorf("back up current binary: %w", err)
+	}
+	if err := os.Rename(candidate, exe); err != nil {
+		if rbErr := os.Rename(backup, exe); rbErr != nil {
+			return fmt.Errorf("install new binary: %w (ROLLBACK FAILED: %v — restore %s manually)", err, rbErr, backup)
+		}
+		return fmt.Errorf("install new binary: %w (rolled back)", err)
+	}
+	slog.Info("swapped in updated binary", "path", exe, "backup", backup)
+	return nil
+}

--- a/apps/runwisp/internal/update/update_test.go
+++ b/apps/runwisp/internal/update/update_test.go
@@ -1,0 +1,339 @@
+// SPDX-FileCopyrightText: PoppyCake, s.r.o.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"0.16.3", "0.17.0", -1},
+		{"0.17.0", "0.16.3", 1},
+		{"1.0.0", "1.0.0", 0},
+		{"v1.2.3", "1.2.3", 0},
+		{"0.0.0-dev", "0.17.0", -1}, // dev parses as 0.0.0; gating happens via IsRelease
+		{"1.2.3-rc1", "1.2.3", 0},   // prerelease suffix ignored
+		{"1.10.0", "1.9.0", 1},      // numeric, not lexical
+		{"garbage", "1.0.0", 0},     // unparseable => equal, never "update"
+		{"1.0.0", "garbage", 0},
+	}
+	for _, c := range cases {
+		if got := Compare(c.a, c.b); got != c.want {
+			t.Errorf("Compare(%q,%q)=%d want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestIsRelease(t *testing.T) {
+	for v, want := range map[string]bool{
+		"0.17.0":     true,
+		"v0.17.0":    true,
+		"0.0.0-dev":  false,
+		"":           false,
+		"not-semver": false,
+	} {
+		if got := IsRelease(v); got != want {
+			t.Errorf("IsRelease(%q)=%v want %v", v, got, want)
+		}
+	}
+}
+
+func TestAssetName(t *testing.T) {
+	arch := runtime.GOARCH
+	if arch == "amd64" {
+		arch = "x64"
+	}
+	want := fmt.Sprintf("runwisp-%s-%s.tar.gz", runtime.GOOS, arch)
+	if got := AssetName(); got != want {
+		t.Errorf("AssetName()=%q want %q", got, want)
+	}
+}
+
+func TestDetectMethod(t *testing.T) {
+	t.Run("docker via env", func(t *testing.T) {
+		t.Setenv("RUNWISP_CONTAINER", "1")
+		if got := DetectMethod(); got != MethodDocker {
+			t.Errorf("got %q want docker", got)
+		}
+	})
+
+	skipIfContainer := func(t *testing.T) {
+		if inContainer() {
+			t.Skip("running inside a container")
+		}
+	}
+
+	t.Run("npm via path", func(t *testing.T) {
+		skipIfContainer(t)
+		withExecutable(t, filepath.Join(t.TempDir(), "node_modules", ".bin", "runwisp"))
+		if got := DetectMethod(); got != MethodNpm {
+			t.Errorf("got %q want npm", got)
+		}
+	})
+
+	t.Run("self when writable", func(t *testing.T) {
+		skipIfContainer(t)
+		dir := t.TempDir()
+		exe := filepath.Join(dir, "runwisp")
+		if err := os.WriteFile(exe, []byte("x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		withExecutable(t, exe)
+		if got := DetectMethod(); got != MethodSelf {
+			t.Errorf("got %q want self", got)
+		}
+	})
+
+	t.Run("manual when dir read-only", func(t *testing.T) {
+		skipIfContainer(t)
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		dir := t.TempDir()
+		exe := filepath.Join(dir, "runwisp")
+		if err := os.WriteFile(exe, []byte("x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(dir, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+		withExecutable(t, exe)
+		if got := DetectMethod(); got != MethodManual {
+			t.Errorf("got %q want manual", got)
+		}
+	})
+}
+
+func TestLatestRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v0.17.0","name":"ignored"}`))
+	}))
+	defer srv.Close()
+	swapVar(t, &latestReleaseURL, srv.URL)
+
+	got, err := LatestRelease(context.Background(), srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v0.17.0" {
+		t.Errorf("got %q want v0.17.0", got)
+	}
+}
+
+func TestLatestReleaseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	swapVar(t, &latestReleaseURL, srv.URL)
+
+	if _, err := LatestRelease(context.Background(), srv.Client()); err == nil {
+		t.Fatal("expected error on non-200")
+	}
+}
+
+// --- Apply safety ---
+
+const oldBinary = "OLD-BINARY-CONTENT"
+
+func TestApplyHappyPath(t *testing.T) {
+	exe := setupFakeInstall(t)
+	srv := serveRelease(t, "v9.9.9", script("9.9.9"))
+	defer srv.Close()
+
+	reexecCalled := false
+	err := Apply(context.Background(), srv.Client(), "v9.9.9", func() error {
+		reexecCalled = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !reexecCalled {
+		t.Error("reexec was not called")
+	}
+	if !fileContains(t, exe, "9.9.9") {
+		t.Error("live binary was not replaced")
+	}
+	if _, err := os.Stat(exe + ".bak"); err != nil {
+		t.Errorf("expected .bak rollback copy: %v", err)
+	}
+}
+
+func TestApplyChecksumMismatchLeavesBinary(t *testing.T) {
+	exe := setupFakeInstall(t)
+	srv := serveReleaseBadChecksum(t, "v9.9.9", script("9.9.9"))
+	defer srv.Close()
+
+	err := Apply(context.Background(), srv.Client(), "v9.9.9", func() error {
+		t.Fatal("reexec must not run on checksum mismatch")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected checksum error")
+	}
+	assertUntouched(t, exe)
+}
+
+func TestApplySmokeTestFailureLeavesBinary(t *testing.T) {
+	exe := setupFakeInstall(t)
+	// Valid checksum, but the binary reports the wrong version.
+	srv := serveRelease(t, "v9.9.9", script("1.1.1"))
+	defer srv.Close()
+
+	err := Apply(context.Background(), srv.Client(), "v9.9.9", func() error {
+		t.Fatal("reexec must not run when the smoke test fails")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected smoke-test error")
+	}
+	assertUntouched(t, exe)
+}
+
+func TestApplyReexecFailureRestoresBinary(t *testing.T) {
+	exe := setupFakeInstall(t)
+	srv := serveRelease(t, "v9.9.9", script("9.9.9"))
+	defer srv.Close()
+
+	err := Apply(context.Background(), srv.Client(), "v9.9.9", func() error {
+		return fmt.Errorf("boom")
+	})
+	if err == nil {
+		t.Fatal("expected error from failed reexec")
+	}
+	// The swap happened, then reexec failed, so the old binary must be restored.
+	if !fileContains(t, exe, oldBinary) {
+		t.Error("old binary was not restored after reexec failure")
+	}
+}
+
+// --- helpers ---
+
+func withExecutable(t *testing.T, path string) {
+	t.Helper()
+	orig := osExecutable
+	osExecutable = func() (string, error) { return path, nil }
+	t.Cleanup(func() { osExecutable = orig })
+}
+
+func swapVar(t *testing.T, p *string, v string) {
+	t.Helper()
+	orig := *p
+	*p = v
+	t.Cleanup(func() { *p = orig })
+}
+
+// setupFakeInstall creates a throwaway "install dir" with an old runwisp binary
+// and points osExecutable at it, returning the exe path.
+func setupFakeInstall(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "runwisp")
+	if err := os.WriteFile(exe, []byte(oldBinary), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withExecutable(t, exe)
+	return exe
+}
+
+// script returns a tiny executable shell script that emulates `runwisp
+// --version` reporting the given version.
+func script(version string) []byte {
+	return []byte("#!/bin/sh\necho \"runwisp version " + version + "\"\n")
+}
+
+func buildTarball(t *testing.T, binary []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "runwisp",
+		Mode:     0o755,
+		Size:     int64(len(binary)),
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func sha256hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func serveRelease(t *testing.T, tag string, binary []byte) *httptest.Server {
+	return serveReleaseWith(t, tag, binary, true)
+}
+
+func serveReleaseBadChecksum(t *testing.T, tag string, binary []byte) *httptest.Server {
+	return serveReleaseWith(t, tag, binary, false)
+}
+
+func serveReleaseWith(t *testing.T, tag string, binary []byte, goodChecksum bool) *httptest.Server {
+	t.Helper()
+	tarball := buildTarball(t, binary)
+	asset := AssetName()
+	sum := sha256hex(tarball)
+	if !goodChecksum {
+		sum = sha256hex([]byte("something else"))
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+tag+"/"+asset, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(tarball)
+	})
+	mux.HandleFunc("/"+tag+"/checksums-sha256.txt", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, "%s  %s\n", sum, asset)
+	})
+	srv := httptest.NewServer(mux)
+	swapVar(t, &releaseDownloadBase, srv.URL)
+	return srv
+}
+
+func assertUntouched(t *testing.T, exe string) {
+	t.Helper()
+	if !fileContains(t, exe, oldBinary) {
+		t.Error("live binary was modified despite failed update")
+	}
+	if _, err := os.Stat(exe + ".bak"); err == nil {
+		t.Error("a .bak was left behind by a failed update")
+	}
+}
+
+func fileContains(t *testing.T, path, substr string) bool {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes.Contains(b, []byte(substr))
+}

--- a/apps/runwisp/openapi.json
+++ b/apps/runwisp/openapi.json
@@ -131,6 +131,9 @@
           "fingerprint": {
             "type": "string"
           },
+          "latestVersion": {
+            "type": "string"
+          },
           "port": {
             "format": "int64",
             "type": "integer"
@@ -160,6 +163,18 @@
             ],
             "type": "string"
           },
+          "updateAvailable": {
+            "type": "boolean"
+          },
+          "updateMethod": {
+            "enum": [
+              "self",
+              "docker",
+              "npm",
+              "manual"
+            ],
+            "type": "string"
+          },
           "version": {
             "type": "string"
           }
@@ -178,7 +193,9 @@
           "resolvedTimezone",
           "timezoneSource",
           "tasks",
-          "capabilities"
+          "capabilities",
+          "updateAvailable",
+          "updateMethod"
         ],
         "type": "object"
       },
@@ -2007,6 +2024,31 @@
           "runId"
         ],
         "type": "object"
+      },
+      "UpdateResult": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "http://localhost:9477/schemas/UpdateResult.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "newVersion": {
+            "type": "string"
+          },
+          "oldVersion": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "oldVersion",
+          "newVersion"
+        ],
+        "type": "object"
       }
     }
   },
@@ -2170,6 +2212,38 @@
           }
         },
         "summary": "Reload runwisp.toml",
+        "tags": [
+          "System"
+        ]
+      }
+    },
+    "/api/daemon/update": {
+      "post": {
+        "description": "Downloads, checksum-verifies, and swaps in the newest GitHub release, then restarts the daemon into it. Standalone binary installs only; docker/npm installs are rejected with a 400 and should upgrade via their package manager.",
+        "operationId": "selfUpdate",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateResult"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Update the daemon to the latest release",
         "tags": [
           "System"
         ]

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -327,7 +327,23 @@ export const systemApi = {
         if (!response.ok) throw new Error("Failed to fetch metrics history");
         return metricsHistoryResponseSchema.parse(await response.json()).items;
     },
+
+    triggerUpdate: async () => {
+        const { data, error } = await apiClient.POST("/api/daemon/update");
+        if (error) throw new Error(errorDetail(error) || "Failed to update");
+        return data;
+    },
 };
+
+// errorDetail pulls the daemon's huma error message ({ detail }) out of an
+// openapi-fetch error body, falling back to "" so callers can supply their own.
+function errorDetail(e: unknown): string {
+    if (typeof e === "object" && e && "detail" in e) {
+        const detail = e.detail;
+        if (typeof detail === "string") return detail;
+    }
+    return "";
+}
 
 export const metricsSampleSchema = z.object({
     timestamp: z.number(),

--- a/apps/ui/src/lib/components/UpdateAvailableBanner.svelte
+++ b/apps/ui/src/lib/components/UpdateAvailableBanner.svelte
@@ -1,0 +1,95 @@
+<!-- SPDX-FileCopyrightText: PoppyCake, s.r.o. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+<script lang="ts">
+    import { CircleArrowUp, X } from "@lucide/svelte";
+    import Button from "@runwisp/ui/components/Button.svelte";
+    import { systemStore } from "$lib/stores/system.svelte";
+    import { systemApi } from "$lib/api";
+    import { createLogger } from "$lib/utils/logger";
+
+    const logger = createLogger("UpdateBanner");
+
+    let dismissed = $state(false);
+    let updating = $state(false);
+    let restarting = $state(false);
+    let errorMsg = $state("");
+
+    // Re-arm the banner once the update is no longer offered (daemon restarted
+    // into the new version, so the check now reports current), so a later release
+    // shows it again even after a dismissal.
+    $effect(() => {
+        if (!systemStore.updateAvailable) {
+            dismissed = false;
+            updating = false;
+            restarting = false;
+            errorMsg = "";
+        }
+    });
+
+    let visible = $derived(systemStore.updateAvailable && !dismissed);
+    let canSelfUpdate = $derived(systemStore.updateMethod === "self");
+
+    function upgradeCommand(method: string): string {
+        if (method === "docker") return "docker pull runwisp/runwisp";
+        if (method === "npm") return "npm update -g runwisp";
+        return "curl -fsSL https://get.runwisp.com | sh";
+    }
+
+    async function update() {
+        updating = true;
+        errorMsg = "";
+        try {
+            await systemApi.triggerUpdate();
+            // The daemon swapped its binary and is re-execing; it will drop the
+            // connection and come back on the new version. The connection layer
+            // reconnects and the banner clears itself on the next /api/daemon seed.
+            restarting = true;
+        } catch (err) {
+            errorMsg = err instanceof Error ? err.message : "Update failed";
+            logger.warn("Self-update failed", err);
+        } finally {
+            updating = false;
+        }
+    }
+</script>
+
+{#if visible}
+    <div
+        role="status"
+        class="flex items-center gap-3 border-b border-primary-soft-border bg-primary-soft px-6 py-2 text-sm text-primary-soft-text"
+    >
+        <CircleArrowUp size={16} class="shrink-0" />
+        <span class="flex-1">
+            {#if restarting}
+                RunWisp is updating to <code class="font-semibold">{systemStore.latestVersion}</code
+                >
+                — the daemon is restarting.
+            {:else if errorMsg}
+                Update to <code class="font-semibold">{systemStore.latestVersion}</code> failed: {errorMsg}
+            {:else}
+                RunWisp <code class="font-semibold">{systemStore.latestVersion}</code> is available.
+                {#if !canSelfUpdate}
+                    Upgrade with <code class="font-semibold"
+                        >{upgradeCommand(systemStore.updateMethod)}</code
+                    >.
+                {/if}
+            {/if}
+        </span>
+
+        {#if canSelfUpdate && !restarting}
+            <Button variant="primary" size="sm" loading={updating} onclick={update}>
+                {errorMsg ? "Retry" : "Update now"}
+            </Button>
+        {/if}
+
+        <button
+            type="button"
+            aria-label="Dismiss"
+            class="rounded-[3px] p-1 hover:bg-primary-soft-border/50"
+            onclick={() => (dismissed = true)}
+        >
+            <X size={16} />
+        </button>
+    </div>
+{/if}

--- a/apps/ui/src/lib/layouts/AppLayout.svelte
+++ b/apps/ui/src/lib/layouts/AppLayout.svelte
@@ -13,6 +13,7 @@
     import HeaderSearch from "$lib/components/HeaderSearch.svelte";
     import NotificationBell from "$lib/components/NotificationBell.svelte";
     import StaleConfigBanner from "$lib/components/StaleConfigBanner.svelte";
+    import UpdateAvailableBanner from "$lib/components/UpdateAvailableBanner.svelte";
     import ThemeToggle from "$lib/components/ThemeToggle.svelte";
 
     let {
@@ -267,6 +268,7 @@
         </header>
 
         <StaleConfigBanner />
+        <UpdateAvailableBanner />
 
         <div class="flex-1 overflow-y-auto scroll-smooth p-6">
             {@render children()}

--- a/apps/ui/src/lib/stores/system.svelte.ts
+++ b/apps/ui/src/lib/stores/system.svelte.ts
@@ -24,6 +24,12 @@ function createSystemStore() {
     let timezone = $state("");
     let timezoneSource = $state("");
     let configStale = $state(false);
+    // Update availability from the daemon's background check. Seeded from
+    // /api/daemon (refreshed on load/reconnect) — a new release is a slow-moving
+    // fact, so no live SSE push is needed.
+    let updateAvailable = $state(false);
+    let latestVersion = $state("");
+    let updateMethod = $state("");
     // Standalone assumptions until the first /api/daemon lands: a standalone
     // daemon must never flash a cloud chip or hide its scheduling UI during
     // hydration. Components read these getters reactively and self-correct.
@@ -69,6 +75,9 @@ function createSystemStore() {
             timezone = info.resolvedTimezone;
             timezoneSource = info.timezoneSource;
             configStale = info.configStale;
+            updateAvailable = info.updateAvailable;
+            latestVersion = info.latestVersion ?? "";
+            updateMethod = info.updateMethod;
             cloudEnabled = info.cloudEnabled;
             schedulingActive = info.schedulingActive;
         } catch (err) {
@@ -153,6 +162,15 @@ function createSystemStore() {
         },
         get configStale() {
             return configStale;
+        },
+        get updateAvailable() {
+            return updateAvailable;
+        },
+        get latestVersion() {
+            return latestVersion;
+        },
+        get updateMethod() {
+            return updateMethod;
         },
         get cloudEnabled() {
             return cloudEnabled;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,10 +47,14 @@ RUN chmod +x /usr/local/bin/runwisp /usr/local/bin/docker-entrypoint.sh
 # container is meant to sit behind a reverse proxy or be port-mapped
 # directly. Operators wanting the daemon to terminate TLS itself (self-signed
 # HTTPS) can set RUNWISP_TLS=auto.
+# RUNWISP_CONTAINER=1 marks this as a container install so the update checker
+# offers `docker pull` instead of trying to swap the binary inside an immutable
+# image.
 ENV RUNWISP_CONFIG=/etc/runwisp/runwisp.toml \
 	RUNWISP_DATA=/var/lib/runwisp \
 	RUNWISP_HOST=0.0.0.0 \
-	RUNWISP_LOG_FORMAT=text
+	RUNWISP_LOG_FORMAT=text \
+	RUNWISP_CONTAINER=1
 
 EXPOSE 9477
 VOLUME ["/var/lib/runwisp"]

--- a/packages/common/src/generated/api.ts
+++ b/packages/common/src/generated/api.ts
@@ -76,6 +76,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/daemon/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update the daemon to the latest release
+         * @description Downloads, checksum-verifies, and swaps in the newest GitHub release, then restarts the daemon into it. Standalone binary installs only; docker/npm installs are rejected with a 400 and should upgrade via their package manager.
+         */
+        post: operations["selfUpdate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/events/stream": {
         parameters: {
             query?: never;
@@ -655,6 +675,7 @@ export interface components {
             configWarnings?: string[] | null;
             externalUrl: string;
             fingerprint: string;
+            latestVersion?: string;
             /** Format: int64 */
             port: number;
             resolvedTimezone: string;
@@ -663,6 +684,9 @@ export interface components {
             tasks: components["schemas"]["TaskBrief"][] | null;
             /** @enum {string} */
             timezoneSource: "config" | "system";
+            updateAvailable: boolean;
+            /** @enum {string} */
+            updateMethod: "self" | "docker" | "npm" | "manual";
             version: string;
         };
         DaemonLogLineEvent: {
@@ -1513,6 +1537,16 @@ export interface components {
             runId: string;
             taskName: string;
         };
+        UpdateResult: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example http://localhost:9477/schemas/UpdateResult.json
+             */
+            readonly $schema?: string;
+            newVersion: string;
+            oldVersion: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -1636,6 +1670,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ReloadResult"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    selfUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateResult"];
                 };
             };
             /** @description Error */


### PR DESCRIPTION
## Summary
- Web UI and TUI surface when a newer RunWisp release is available and can trigger a self-update
- Standalone installs get a safety-first update pipeline: download → sha256 verify → smoke-test → atomic swap with `.bak` rollback → re-exec; Docker/npm installs are shown the correct upgrade command instead
- Background check polls GitHub every few hours, best-effort/offline-silent, opt-out via `[daemon] check_updates = false`; surfaced on `GET /api/daemon` and triggered via `POST /api/daemon/update`

## Test plan
- [x] `bun run ci`